### PR TITLE
Fix WATCH_NAMESPACE env in operator.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: local-dev
+local-dev:
+	GO111MODULE=on operator-sdk up local --namespace "" --operator-flags '--zap-encoder=console'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ The following steps will install [Tekton Pipeline](https://github.com/tektoncd/p
    interacting with your kube cluster
 1. operator-sdk: https://github.com/operator-framework/operator-sdk
 
+
+## Running Operator Locally
+
+To run the operator lcoally during development:
+
+    `make local-dev`
+
 ## Building the Operator Image
 1. Enable go mod  
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Changes

Set the value of environment variable to "" instead of metadata.namespace
as we wan't the operator to watch all namespaces

Add a Makefile with a target for running the operator locally
during local development

Update local development steps in Readme

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._


