### PR TITLE
Use the correct way to get config cluster 🧗‍♂️

### DIFF
--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -157,13 +157,8 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 
 	log.Info("reconciling config change")
 
-	if ignoreRequest(req) {
-		log.Info("ignoring event of resource watched that is not cluster-wide")
-		return reconcile.Result{}, nil
-	}
-
 	res := &op.Config{}
-	err := r.client.Get(context.TODO(), req.NamespacedName, res)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: req.Name}, res)
 
 	// ignore all resources except the `resourceWatched`
 	if req.Name != resourceWatched {
@@ -342,13 +337,4 @@ func requestLogger(req reconcile.Request, context string) logr.Logger {
 		"Request.Namespace", req.Namespace,
 		"Request.NamespaceName", req.NamespacedName,
 		"Request.Name", req.Name)
-}
-
-func ignoreRequest(req reconcile.Request) bool {
-	// NOTE: only interested in the clusterwide events of the resource watched
-	// Otherwise, when release.yaml is applied and onwer-ref is set to the
-	// clusterwide resource, events are generated for "targetNamespace/resourceWatched"
-	// and as the GET call for that resource fails, the pipeline resources get
-	// deleted. this filter prevents that from happening
-	return req.Name == resourceWatched && req.Namespace != ""
 }


### PR DESCRIPTION
# Changes

Closes: #31 
The CR config cluster is a cluster-scoped resource, not a namespaced
resource. We need to use the types.NamespacedName without namespace
to really get it.

The check of ignoreRequest is removed, because we need to do further
action, if a deployment of pipelines is deleted.



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
