### PR TITLE
add dashboard addon v0.2.0 with webhooks extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,28 @@ args:
 Then install `Tekton Pipeline` manually:  
 
 `kubectl apply -f deploy/crds/*_cr.yaml`
+
+## Addon components
+
+Supported addon components are installed by creating the 'addon' CR for the component.
+
+Sample CR
+
+```
+apiVersion: operator.tekton.dev/v1alpha1
+kind: Addon
+metadata:
+  name: dashboard
+spec:
+  version: v0.1.0
+```
+
+The current supported components and versions are:
+
+- dashboard
+  - v0.1.1
+  - v0.2.0
+  - openshift-v0.2.0
+- extensionwebhooks
+  - v0.2.0
+  - openshift-v0.2.0

--- a/deploy/resources/addons/dashboard/openshift-v0.2.0/release.yaml
+++ b/deploy/resources/addons/dashboard/openshift-v0.2.0/release.yaml
@@ -1,0 +1,283 @@
+# ------------------- Dashboard Service Account ------------------- #
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"tekton-dashboard"}}'
+---
+# ------------------- Extension Resource Definition ------------------- #
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: extensions.dashboard.tekton.dev
+spec:
+  group: dashboard.tekton.dev
+  names:
+    kind: Extension
+    plural: extensions
+    categories:
+      - all
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+# ------------------- Dashboard Role & Role Binding ------------------- #
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-minimal
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log", "namespaces", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "list", "create", "update", "watch", "delete"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["dashboard.tekton.dev"]
+    resources: ["extensions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+
+# ------------------- Dashboard Role & Role Binding ------------------- #
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-dashboard-minimal
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-minimal
+---
+# ------------------- Dashboard Deployment ------------------- #
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  labels:
+    app: tekton-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-dashboard
+  template:
+    metadata:
+      name: tekton-dashboard
+      labels:
+        app: tekton-dashboard
+    spec:
+      containers:
+      - name: oauth-proxy
+        image: openshift/oauth-proxy:latest@sha256:6bc1759a3202b4614739f12441461e344907f6b3f758c34314284debe36d4e15
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8443
+          name: public
+        args:
+        - --https-address=:8443
+        - --provider=openshift
+        - --openshift-service-account=tekton-dashboard
+        - --upstream=http://localhost:9097
+        - --tls-cert=/etc/tls/private/tls.crt
+        - --tls-key=/etc/tls/private/tls.key
+        - --cookie-secret=SECRET
+        - --skip-auth-regex=^/v1/extensions/.*\.js
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: proxy-tls
+      - name: tekton-dashboard
+        image: gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard@sha256:d6d1572aff2036707339fdcdf6a89e2850750a1ac643cd033ecdba4fbe4c3f20
+        ports:
+        - containerPort: 9097
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9097
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9097
+        resources:
+        env:
+        - name: PORT
+          value: "9097"
+        - name: WEB_RESOURCES_DIR
+          value: /var/run/ko/web
+        - name: PIPELINE_RUN_SERVICE_ACCOUNT
+          value: ""
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      serviceAccountName: tekton-dashboard
+      volumes:
+      - name: proxy-tls
+        secret:
+          secretName: proxy-tls
+---
+# ------------------- Dashboard Route ------------------- #
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  to:
+    kind: Service
+    name: tekton-dashboard
+  tls:
+    termination: Reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+---
+# ------------------- Dashboard Service ------------------- #
+kind: Service
+apiVersion: v1
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  labels:
+    app: tekton-dashboard
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: proxy-tls
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+  selector:
+    app: tekton-dashboard
+---
+# ------- Insecure Dashboard Service - Do Not Expose ------ #
+kind: Service
+apiVersion: v1
+metadata:
+  name: tekton-dashboard-internal
+  namespace: tekton-pipelines
+  labels:
+    app: tekton-dashboard-internal
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9097
+      targetPort: 9097
+  selector:
+    app: tekton-dashboard
+---
+# ------------------- Pipeline0 --------------------------- #
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline0
+  namespace: tekton-pipelines
+spec:
+  resources:
+  - name: git-source
+    type: git
+  params:
+  - name: pathToResourceFiles
+    description: The path to the resource files to apply
+    default: /workspace/git-source
+    type: string
+  - name: apply-directory
+    description: The directory from which resources are to be applied
+    default: "."
+    type: string
+  - name: target-namespace
+    description: The namespace in which to create the resources being imported
+    default: tekton-pipelines
+    type: string
+  tasks:
+  - name: pipeline0-task
+    taskRef:
+      name: pipeline0-task
+    params:
+    - name: pathToResourceFiles
+      value: $(params.pathToResourceFiles)
+    - name: apply-directory
+      value: $(params.apply-directory)
+    - name: target-namespace
+      value: $(params.target-namespace)
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+---
+# ------------------- Pipeline0 task ---------------------- #
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: pipeline0-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    resources:
+    - name: git-source
+      type: git
+    params:
+    - name: pathToResourceFiles
+      description: The path to the resource files to apply
+      default: /workspace/git-source
+      type: string
+    - name: apply-directory
+      description: The directory from which resources are to be applied
+      default: "."
+      type: string
+    - name: target-namespace
+      description: The namespace in which to create the resources being imported
+      default: tekton-pipelines
+      type: string
+  steps:
+  - name: kubectl-apply
+    image: lachlanevenson/k8s-kubectl@sha256:7f50d26d77ba7bd15ef9c0ebd29db88cf81d095287b63bd1e4054cdfb0d52417
+    command:
+    - kubectl
+    args:
+    - apply
+    - -f
+    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory) 
+    - -n
+    - $(inputs.params.target-namespace)

--- a/deploy/resources/addons/dashboard/v0.2.0/release.yaml
+++ b/deploy/resources/addons/dashboard/v0.2.0/release.yaml
@@ -30,19 +30,6 @@ metadata:
   namespace: tekton-pipelines
 rules:
 - apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
-- apiGroups:
   - extensions
   - apps
   resources:

--- a/deploy/resources/addons/dashboard/v0.2.0/release.yaml
+++ b/deploy/resources/addons/dashboard/v0.2.0/release.yaml
@@ -1,0 +1,319 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: extensions.dashboard.tekton.dev
+spec:
+  group: dashboard.tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: Extension
+    plural: extensions
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-dashboard-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+  - delete
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - dashboard.tekton.dev
+  resources:
+  - extensions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-dashboard-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-dashboard
+  template:
+    metadata:
+      labels:
+        app: tekton-dashboard
+      name: tekton-dashboard
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "9097"
+        - name: WEB_RESOURCES_DIR
+          value: /var/run/ko/web
+        - name: PIPELINE_RUN_SERVICE_ACCOUNT
+          value: ""
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard@sha256:d6d1572aff2036707339fdcdf6a89e2850750a1ac643cd033ecdba4fbe4c3f20
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9097
+        name: tekton-dashboard
+        ports:
+        - containerPort: 9097
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9097
+        resources: null
+      serviceAccountName: tekton-dashboard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: http
+    port: 9097
+    protocol: TCP
+    targetPort: 9097
+  selector:
+    app: tekton-dashboard
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: pipeline0-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    params:
+    - default: /workspace/git-source
+      description: The path to the resource files to apply
+      name: pathToResourceFiles
+      type: string
+    - default: .
+      description: The directory from which resources are to be applied
+      name: apply-directory
+      type: string
+    - default: tekton-pipelines
+      description: The namespace in which to create the resources being imported
+      name: target-namespace
+      type: string
+    resources:
+    - name: git-source
+      type: git
+  steps:
+  - args:
+    - apply
+    - -f
+    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+    - -n
+    - $(inputs.params.target-namespace)
+    command:
+    - kubectl
+    image: lachlanevenson/k8s-kubectl:latest@sha256:7f50d26d77ba7bd15ef9c0ebd29db88cf81d095287b63bd1e4054cdfb0d52417
+    name: kubectl-apply
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline0
+  namespace: tekton-pipelines
+spec:
+  params:
+  - default: /workspace/git-source
+    description: The path to the resource files to apply
+    name: pathToResourceFiles
+    type: string
+  - default: .
+    description: The directory from which resources are to be applied
+    name: apply-directory
+    type: string
+  - default: tekton-pipelines
+    description: The namespace in which to create the resources being imported
+    name: target-namespace
+    type: string
+  resources:
+  - name: git-source
+    type: git
+  tasks:
+  - name: pipeline0-task
+    params:
+    - name: pathToResourceFiles
+      value: $(params.pathToResourceFiles)
+    - name: apply-directory
+      value: $(params.apply-directory)
+    - name: target-namespace
+      value: $(params.target-namespace)
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+    taskRef:
+      name: pipeline0-task
+
+---

--- a/deploy/resources/addons/extensionwebhooks/openshift-v0.2.0/release.yaml
+++ b/deploy/resources/addons/extensionwebhooks/openshift-v0.2.0/release.yaml
@@ -1,0 +1,401 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-webhooks-extension
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-webhooks-extension-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-webhooks-extension-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: webhooks-extension
+  name: webhooks-extension
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhooks-extension
+  template:
+    metadata:
+      labels:
+        app: webhooks-extension
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "8080"
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DOCKER_REGISTRY_LOCATION
+          value: DOCKER_REPO
+        - name: WEB_RESOURCES_DIR
+          value: web
+        image: gcr.io/tekton-releases/github.com/tektoncd/experimental/webhooks-extension/cmd/extension@sha256:4b227d0cb2ff9f2bd5ac2746a51bec8eff55d29cfd4ae60afa8dd68d6c4fe2f0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 8080
+        name: webhooks-extension
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8080
+      serviceAccountName: tekton-webhooks-extension
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tekton-dashboard-bundle-location: web/extension.9b61e1e9.js
+    tekton-dashboard-display-name: Webhooks
+    tekton-dashboard-endpoints: webhooks.web
+  labels:
+    app: webhooks-extension
+    tekton-dashboard-extension: "true"
+  name: webhooks-extension
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: webhooks-extension
+  type: NodePort
+
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  labels:
+    app: webhooks-extension-sink
+  name: webhooks-extension-sink
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: INSTALLED_NAMESPACE
+          value: tekton-pipelines
+        - name: SERVICEACCOUNT
+          value: tekton-webhooks-extension
+        - name: PLATFORM
+          value: openshift
+        image: gcr.io/tekton-releases/github.com/tektoncd/experimental/webhooks-extension/cmd/sink@sha256:b7ef6c779aa02a395459a08facd6d581e350179ecdf447681b207515ddf521b9
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /liveness
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readiness
+      serviceAccountName: tekton-webhooks-extension
+
+---
+# Monitor the pipelinerun status and update the pull request
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: monitor-result-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    resources:
+      - name: pull-request
+        type: pullRequest
+    params:
+      - name: pipelineruns
+        description: The name of the pipelineruns (and their namespace) to be monitored in format pipelinerun1:namespace1, pipelinerun2:namespace2
+        default: default pipelinerun
+        type: string
+      - name: commentsuccess
+        description: The text of the success comment
+        default: "Success"
+        type: string
+      - name: commentfailure
+        description: The text of the failure comment
+        default: "Failed"
+        type: string
+      - name: dashboard-url
+        description: The URL to the pipelineruns page of the dashboard
+        default: "http://localhost:9097/"
+        type: string
+      # This can be deleted after pending status change issue is resolved, that being that AFAIK the pull request resource only modifies
+      # status once everything is complete, so we can only modify status via the pull request resource once.  To get around this we hit
+      # the github status URL to set the status into pending and use this secret to during that request.  
+      - name: secret
+        description: The secret containing the access token to access github
+        type: string
+      # Up to here
+  outputs:
+    resources:
+      - name: pull-request
+        type: pullRequest
+  steps:
+  - name: check
+    image: maiwj/kubernetes-python-client@sha256:74a868a0dff5c8ada64472db3efd09d205d4f877d14d2d3226511adbb25cfea3
+    env:
+      - name: PIPELINERUNS
+        value: $(inputs.params.pipelineruns)
+      - name: COMMENT_SUCCESS
+        value: $(inputs.params.commentsuccess)
+      - name: COMMENT_FAILURE
+        value: $(inputs.params.commentfailure)
+      - name: URL
+        value: $(inputs.params.dashboard-url)
+      # This can be deleted after any fix to the above mentioned pending status change
+      - name: GITHUBTOKEN
+        valueFrom:
+          secretKeyRef:
+            key: accessToken
+            name: $(inputs.params.secret)
+      # Up to here
+    command: ["/bin/bash"]
+    args:
+    - -ce
+    - |
+      set -e
+      cat <<EOF | python
+      import time, os, json, requests, pprint
+      from kubernetes import client, config
+      config.load_incluster_config()
+      api_instance = client.CustomObjectsApi(client.ApiClient(client.Configuration()))
+      gitPRcontext = "Tekton"
+      gitPRurl = ""
+      # This is the code thats puts the pullrequest into pending status, this is code to rip out later if there
+      # is a fix to the above mentioned update status to pending issue.
+      with open("/workspace/pull-request/github/pr.json") as fp:
+        rawdata = json.load(fp)
+        statusurl = rawdata['statuses_url']
+      pendingData = {
+        "state": "pending",
+        "description": "pipelines in progress",
+        "target_url": "",
+        "context": "Tekton"
+      }
+      print("Setting status to pending with URL : " + statusurl)
+      resp = requests.post(statusurl, json.dumps(pendingData), headers = {'Content-Type': 'application/json', 'Authorization': "Bearer $GITHUBTOKEN"})
+      print(resp)
+      # End of code to replace
+      if not "$URL".startswith("http"):
+        pipelineRunURLPrefix = "http://" + "$URL"
+      else:
+        pipelineRunURLPrefix = "$URL"
+      runsToCheck = "$PIPELINERUNS".split(",")
+      runsPassed = []
+      runsFailed = []
+      runsIncomplete = []
+      failed = 0
+      i = range(180)
+      for x in i:
+          time.sleep( 10 )
+          if len(runsToCheck) > 0:
+            for entry in runsToCheck:
+              pr, namespace, pipeline = entry.split(":")
+              pr = pr.strip()
+              namespace = namespace.strip()
+              pipeline = pipeline.strip()
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+              print("Checking pipelinerun " + pr + " in namespace " + namespace)
+              output = api_instance.get_namespaced_custom_object("tekton.dev", "v1alpha1", namespace, "pipelineruns", pr)
+              if output["status"]["conditions"][0]["status"] == u'True' and output["status"]["conditions"][0]["type"] == u'Succeeded':
+                print("Success - pipelinerun " + pr + " in namespace " + namespace)
+                runsToCheck.remove(entry)
+                runsPassed.append("[**$COMMENT_SUCCESS**](" + link + ") | " + pipeline + " | " +  pr + " | " + namespace)
+              if output["status"]["conditions"][0]["status"] == u'False' and output["status"]["conditions"][0]["type"] == u'Succeeded':
+                failed =+ 1
+                print("Failed - pipelinerun " + pr + " in namespace " + namespace)
+                runsToCheck.remove(entry)
+                runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+          else:
+            break
+      gitPRdescription = "All pipelines succeeded!"
+      gitPRcode = "success"
+      if failed > 0:
+        gitPRdescription = str(failed) + " pipeline(s) failed!"
+        gitPRcode = "failure"
+      if len(runsToCheck) > 0:
+        print("Some pipelineruns had not completed when the monitor reached its timeout")
+        gitPRdescription = "timed out monitoring pipeline runs"
+        gitPRcode = "error"
+        for entry in runsToCheck:
+          pr, namespace, pipeline = entry.split(":")
+          pr = pr.strip()
+          namespace = namespace.strip()
+          pipeline = pipeline.strip()
+          print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
+          link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+          runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+      results = runsPassed + runsFailed + runsIncomplete
+      comment = ("## Tekton Status Report \n\n"
+                 "Status | Pipeline | PipelineRun | Namespace\n"
+                 ":----- | :------- | :--------------- | :--------\n"
+                 ) + "\n".join(results)
+      handle = open("/workspace/pull-request/comments/newcomment.json", 'w')
+      handle.write(comment)
+      handle.close()
+      if not "$URL".startswith("http"):
+        detailsURL = "http://" + "$URL" + "/#/pipelineruns"
+      else:
+        detailsURL = "$URL" + "/#/pipelineruns"
+      print("Set details url to: " + detailsURL)
+      status = json.dumps(dict(code=gitPRcode, description=gitPRdescription, id=gitPRcontext, url=detailsURL))
+      handle = open("/workspace/pull-request/status/newstatus.json", 'w')
+      handle.write(status)
+      handle.close()
+      EOF
+---
+

--- a/deploy/resources/addons/extensionwebhooks/v0.2.0/release.yaml
+++ b/deploy/resources/addons/extensionwebhooks/v0.2.0/release.yaml
@@ -384,6 +384,5 @@ spec:
           name: $(inputs.params.secret)
     image: maiwj/kubernetes-python-client:latest@sha256:74a868a0dff5c8ada64472db3efd09d205d4f877d14d2d3226511adbb25cfea3
     name: check
---- null
 
 ---

--- a/deploy/resources/addons/extensionwebhooks/v0.2.0/release.yaml
+++ b/deploy/resources/addons/extensionwebhooks/v0.2.0/release.yaml
@@ -1,0 +1,389 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-webhooks-extension
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-webhooks-extension-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-webhooks-extension-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-webhooks-extension-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-webhooks-extension
+  namespace: tekton-pipelines
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: webhooks-extension
+  name: webhooks-extension
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhooks-extension
+  template:
+    metadata:
+      labels:
+        app: webhooks-extension
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "8080"
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DOCKER_REGISTRY_LOCATION
+          value: DOCKER_REPO
+        - name: WEB_RESOURCES_DIR
+          value: web
+        image: gcr.io/tekton-releases/github.com/tektoncd/experimental/webhooks-extension/cmd/extension@sha256:4b227d0cb2ff9f2bd5ac2746a51bec8eff55d29cfd4ae60afa8dd68d6c4fe2f0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 8080
+        name: webhooks-extension
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8080
+      serviceAccountName: tekton-webhooks-extension
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tekton-dashboard-bundle-location: web/extension.9b61e1e9.js
+    tekton-dashboard-display-name: Webhooks
+    tekton-dashboard-endpoints: webhooks.web
+  labels:
+    app: webhooks-extension
+    tekton-dashboard-extension: "true"
+  name: webhooks-extension
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: webhooks-extension
+  type: NodePort
+
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  labels:
+    app: webhooks-extension-sink
+  name: webhooks-extension-sink
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: INSTALLED_NAMESPACE
+          value: tekton-pipelines
+        - name: SERVICEACCOUNT
+          value: tekton-webhooks-extension
+        image: gcr.io/tekton-releases/github.com/tektoncd/experimental/webhooks-extension/cmd/sink@sha256:b7ef6c779aa02a395459a08facd6d581e350179ecdf447681b207515ddf521b9
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /liveness
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /readiness
+      serviceAccountName: tekton-webhooks-extension
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: monitor-result-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    params:
+    - default: default pipelinerun
+      description: The name of the pipelineruns (and their namespace) to be monitored
+        in format pipelinerun1:namespace1, pipelinerun2:namespace2
+      name: pipelineruns
+      type: string
+    - default: Success
+      description: The text of the success comment
+      name: commentsuccess
+      type: string
+    - default: Failed
+      description: The text of the failure comment
+      name: commentfailure
+      type: string
+    - default: http://localhost:9097/
+      description: The URL to the pipelineruns page of the dashboard
+      name: dashboard-url
+      type: string
+    - description: The secret containing the access token to access github
+      name: secret
+      type: string
+    resources:
+    - name: pull-request
+      type: pullRequest
+  outputs:
+    resources:
+    - name: pull-request
+      type: pullRequest
+  steps:
+  - args:
+    - -ce
+    - |
+      set -e
+      cat <<EOF | python
+      import time, os, json, requests, pprint
+      from kubernetes import client, config
+      config.load_incluster_config()
+      api_instance = client.CustomObjectsApi(client.ApiClient(client.Configuration()))
+      gitPRcontext = "Tekton"
+      gitPRurl = ""
+      # This is the code thats puts the pullrequest into pending status, this is code to rip out later if there
+      # is a fix to the above mentioned update status to pending issue.
+      with open("/workspace/pull-request/github/pr.json") as fp:
+        rawdata = json.load(fp)
+        statusurl = rawdata['statuses_url']
+      pendingData = {
+        "state": "pending",
+        "description": "pipelines in progress",
+        "target_url": "",
+        "context": "Tekton"
+      }
+      print("Setting status to pending with URL : " + statusurl)
+      resp = requests.post(statusurl, json.dumps(pendingData), headers = {'Content-Type': 'application/json', 'Authorization': "Bearer $GITHUBTOKEN"})
+      print(resp)
+      # End of code to replace
+      if not "$URL".startswith("http"):
+        pipelineRunURLPrefix = "http://" + "$URL"
+      else:
+        pipelineRunURLPrefix = "$URL"
+      runsToCheck = "$PIPELINERUNS".split(",")
+      runsPassed = []
+      runsFailed = []
+      runsIncomplete = []
+      failed = 0
+      i = range(180)
+      for x in i:
+          time.sleep( 10 )
+          if len(runsToCheck) > 0:
+            for entry in runsToCheck:
+              pr, namespace, pipeline = entry.split(":")
+              pr = pr.strip()
+              namespace = namespace.strip()
+              pipeline = pipeline.strip()
+              link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+              print("Checking pipelinerun " + pr + " in namespace " + namespace)
+              output = api_instance.get_namespaced_custom_object("tekton.dev", "v1alpha1", namespace, "pipelineruns", pr)
+              if output["status"]["conditions"][0]["status"] == u'True' and output["status"]["conditions"][0]["type"] == u'Succeeded':
+                print("Success - pipelinerun " + pr + " in namespace " + namespace)
+                runsToCheck.remove(entry)
+                runsPassed.append("[**$COMMENT_SUCCESS**](" + link + ") | " + pipeline + " | " +  pr + " | " + namespace)
+              if output["status"]["conditions"][0]["status"] == u'False' and output["status"]["conditions"][0]["type"] == u'Succeeded':
+                failed =+ 1
+                print("Failed - pipelinerun " + pr + " in namespace " + namespace)
+                runsToCheck.remove(entry)
+                runsFailed.append("[**$COMMENT_FAILURE**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+          else:
+            break
+      gitPRdescription = "All pipelines succeeded!"
+      gitPRcode = "success"
+      if failed > 0:
+        gitPRdescription = str(failed) + " pipeline(s) failed!"
+        gitPRcode = "failure"
+      if len(runsToCheck) > 0:
+        print("Some pipelineruns had not completed when the monitor reached its timeout")
+        gitPRdescription = "timed out monitoring pipeline runs"
+        gitPRcode = "error"
+        for entry in runsToCheck:
+          pr, namespace, pipeline = entry.split(":")
+          pr = pr.strip()
+          namespace = namespace.strip()
+          pipeline = pipeline.strip()
+          print("Still Running - pipelinerun " + pr + " in namespace " + namespace)
+          link = pipelineRunURLPrefix + "/#/namespaces/" + namespace + "/pipelines/" + pipeline + "/runs/" + pr
+          runsIncomplete.append("[**??????**](" + link + ") | " + pipeline + " | " + pr + " | " + namespace)
+      results = runsPassed + runsFailed + runsIncomplete
+      comment = ("## Tekton Status Report \n\n"
+                 "Status | Pipeline | PipelineRun | Namespace\n"
+                 ":----- | :------- | :--------------- | :--------\n"
+                 ) + "\n".join(results)
+      handle = open("/workspace/pull-request/comments/newcomment.json", 'w')
+      handle.write(comment)
+      handle.close()
+      if not "$URL".startswith("http"):
+        detailsURL = "http://" + "$URL" + "/#/pipelineruns"
+      else:
+        detailsURL = "$URL" + "/#/pipelineruns"
+      print("Set details url to: " + detailsURL)
+      status = json.dumps(dict(code=gitPRcode, description=gitPRdescription, id=gitPRcontext, url=detailsURL))
+      handle = open("/workspace/pull-request/status/newstatus.json", 'w')
+      handle.write(status)
+      handle.close()
+      EOF
+    command:
+    - /bin/bash
+    env:
+    - name: PIPELINERUNS
+      value: $(inputs.params.pipelineruns)
+    - name: COMMENT_SUCCESS
+      value: $(inputs.params.commentsuccess)
+    - name: COMMENT_FAILURE
+      value: $(inputs.params.commentfailure)
+    - name: URL
+      value: $(inputs.params.dashboard-url)
+    - name: GITHUBTOKEN
+      valueFrom:
+        secretKeyRef:
+          key: accessToken
+          name: $(inputs.params.secret)
+    image: maiwj/kubernetes-python-client:latest@sha256:74a868a0dff5c8ada64472db3efd09d205d4f877d14d2d3226511adbb25cfea3
+    name: check
+--- null
+
+---


### PR DESCRIPTION
# Changes

Add dashboard addon v0.2.0 with webhooks extension

The current supported components and versions are:

- dashboard
  - v0.1.1
  - v0.2.0
  - openshift-v0.2.0
- extensionwebhooks
  - v0.2.0
  - openshift-v0.2.0


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
