### PR TITLE
Add inject-Default-SA Transformer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	-kubectl delete namespace tekton-pipelines
 
 .PHONY: local-dev
-local-dev: dev-setup
+local-dev: clean dev-setup
 	GO111MODULE=on operator-sdk up local --namespace "" --operator-flags '--zap-encoder=console'
 
 .PHONY: update-deps dev-setup

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/tektoncd/operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/coreos/prometheus-operator v0.31.1 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/jcrossley3/manifestival v0.0.0-20190621184852-78b6b04ae6ff

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
-github.com/tektoncd/plumbing v0.0.0-20190731030558-283e91c83abb h1:4lv2Qqkh2tni7eso9NC76HBOLBKL0Ls2yKojtcN87G0=
-github.com/tektoncd/plumbing v0.0.0-20190731030558-283e91c83abb/go.mod h1:dvZoTaPGpr3ZDqOUR1sc8VOhh/7OzYncVnbQETJTqvQ=
 github.com/tektoncd/plumbing v0.0.0-20191008065817-933f0722e02c h1:MgZFJLajYLPYgT3upGYFFOWInxPfdmcA5/uc2+Cxy6o=
 github.com/tektoncd/plumbing v0.0.0-20191008065817-933f0722e02c/go.mod h1:dvZoTaPGpr3ZDqOUR1sc8VOhh/7OzYncVnbQETJTqvQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"flag"
+	"github.com/tektoncd/operator/pkg/controller/transform"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -197,6 +198,7 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, res *op.Config
 	tfs := []mf.Transformer{
 		mf.InjectOwner(res),
 		mf.InjectNamespace(res.Spec.TargetNamespace),
+		transform.InjectDefaultSA("pipeline"),
 	}
 
 	if err := r.manifest.Transform(tfs...); err != nil {

--- a/pkg/controller/transform/transform.go
+++ b/pkg/controller/transform/transform.go
@@ -1,0 +1,39 @@
+package transform
+
+import (
+	"strings"
+
+	mf "github.com/jcrossley3/manifestival"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// InjectDefaultSA adds default service account into config-defaults configMap
+func InjectDefaultSA(defaultSA string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if strings.ToLower(u.GetKind()) != "configmap" {
+			return nil
+		}
+		if u.GetName() != "config-defaults" {
+			return nil
+		}
+
+		cm := &corev1.ConfigMap{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cm)
+		if err != nil {
+			return err
+		}
+
+		cm.Data["default-service-account"] = defaultSA
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+		if err != nil {
+			return err
+		}
+
+		u.SetUnstructuredContent(unstrObj)
+
+		return nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -359,8 +359,8 @@ k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/types
-k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/api/meta


### PR DESCRIPTION
Add an `injectDefaultSA` transfor function (manifestival.Transformer)
to inject a specific service account as the `default-service-account`
in `config-defaults` configMap in payload (release.yaml) being processed

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- operator will set the `default-service-account: pipeline` in configMap `config-defaults` while installing tekton-pipelines

```
