### PR TITLE
Introduce new feature: image replacement

### DIFF
--- a/pkg/apis/operator/v1alpha1/addon_types.go
+++ b/pkg/apis/operator/v1alpha1/addon_types.go
@@ -8,6 +8,12 @@ import (
 // +k8s:openapi-gen=true
 type AddonSpec struct {
 	Version string `json:"version"`
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// ExtensionWapper containes attribute Extension used
+	// +optional
+	ExtensionWapper `json:",inline"`
 }
 
 // AddonStatus defines the observed state of Addon
@@ -58,4 +64,10 @@ type AddonList struct {
 
 func init() {
 	SchemeBuilder.Register(&Addon{}, &AddonList{})
+}
+
+func (addonSpec AddonSpec) ConvertExtensionwapper() *ExtensionWapper {
+	return &ExtensionWapper{
+		Registry: addonSpec.Registry,
+	}
 }

--- a/pkg/apis/operator/v1alpha1/config_types.go
+++ b/pkg/apis/operator/v1alpha1/config_types.go
@@ -9,6 +9,12 @@ import (
 type ConfigSpec struct {
 	// namespace where pipelines will be installed
 	TargetNamespace string `json:"targetNamespace"`
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// ExtensionWapper containes attribute Extension used
+	// +optional
+	ExtensionWapper `json:",inline"`
 }
 
 // ConfigStatus defines the observed state of Config
@@ -77,4 +83,10 @@ type ConfigList struct {
 
 func init() {
 	SchemeBuilder.Register(&Config{}, &ConfigList{})
+}
+
+func (configSpec ConfigSpec) ConvertExtensionwapper() *ExtensionWapper {
+	return &ExtensionWapper{
+		Registry: configSpec.Registry,
+	}
 }

--- a/pkg/apis/operator/v1alpha1/extension_type.go
+++ b/pkg/apis/operator/v1alpha1/extension_type.go
@@ -1,0 +1,20 @@
+package v1alpha1
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ExtensionWapper define the attributes used by Extension.
+// Extension is stuff like plugin, to make add/remove feature easier.
+// +k8s:openapi-gen=true
+type ExtensionWapper struct {
+	// Registry is used for image replacement
+	Registry *Registry `json:"registry,omitempty"`
+}
+
+// Registry defines image overrides of tekton images.
+// The override values are specific to each tekton deployment.
+// +k8s:openapi-gen=true
+type Registry struct {
+	// A map of a container name or arg key to the full image location of the individual tekton container.
+	// +optional
+	Override map[string]string `json:"override,omitempty"`
+}

--- a/pkg/controller/addon/add_imagereplacement.go
+++ b/pkg/controller/addon/add_imagereplacement.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package addon
+
+import (
+	ir "github.com/tektoncd/operator/pkg/controller/extensions/imagereplacement"
+)
+
+func init() {
+	imageReplacement, _ := ir.New()
+	activities = append(activities, imageReplacement)
+}

--- a/pkg/controller/addon/addon_controller.go
+++ b/pkg/controller/addon/addon_controller.go
@@ -10,6 +10,7 @@ import (
 	mf "github.com/jcrossley3/manifestival"
 	"github.com/prometheus/common/log"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/controller/common"
 	"github.com/tektoncd/operator/pkg/controller/setup"
 	"golang.org/x/xerrors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,7 @@ var (
 	ctrlLog                   = logf.Log.WithName("ctrl").WithName("addon")
 	errPipelineNotReady       = xerrors.Errorf("tekton-pipelines not ready")
 	errAddonVersionUnresolved = xerrors.Errorf("could not resolve to a valid addon version")
+	activities                common.Activities
 )
 
 // Add creates a new Addon Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -247,6 +249,14 @@ func (r *ReconcileAddon) processPayload(res *op.Addon, targetNS string) (*mf.Man
 		mf.InjectNamespace(targetNS),
 	}
 
+	var extensionWrapper *op.ExtensionWapper
+	extensionWrapper = res.Spec.ConvertExtensionwapper()
+	extensions, err := activities.Extend(r.client, r.scheme, extensionWrapper)
+	if err != nil {
+		return nil, err
+	}
+
+	tfs = append(tfs, extensions.Transform()...)
 	if err := manifest.Transform(tfs...); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/common/extensions.go
+++ b/pkg/controller/common/extensions.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	mf "github.com/jcrossley3/manifestival"
+	v1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("common")
+
+// Activity is a interface, func Configure will be implemented by each Extension as a register. It will decide if
+// the Extension will be add to process chain.
+type Activity interface {
+	Configure(client.Client, *runtime.Scheme, *v1alpha1.ExtensionWapper) (*Extension, error)
+}
+
+// Activities is array of Activity
+type Activities []Activity
+
+// Extensions is array of Extension
+type Extensions []Extension
+
+// Extension is a plugin, could be remove/add easily
+type Extension struct {
+	Transformers []mf.Transformer
+}
+
+// Extend produce Extensions by invoke Activities
+func (activities Activities) Extend(c client.Client, scheme *runtime.Scheme, extensionWapper *v1alpha1.ExtensionWapper) (result Extensions, err error) {
+	for _, activity := range activities {
+		ext, err := activity.Configure(c, scheme, extensionWapper)
+		if err != nil {
+			return result, err
+		}
+		if ext != nil {
+			result = append(result, *ext)
+		}
+	}
+	return
+}
+
+// Transform do real work
+func (exts Extensions) Transform() []mf.Transformer {
+	result := []mf.Transformer{}
+
+	for _, extension := range exts {
+		result = append(result, extension.Transformers...)
+	}
+
+	return result
+}

--- a/pkg/controller/config/add_imagereplacement.go
+++ b/pkg/controller/config/add_imagereplacement.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+import (
+	ir "github.com/tektoncd/operator/pkg/controller/extensions/imagereplacement"
+)
+
+func init() {
+	imageReplacement, _ := ir.New()
+	activities = append(activities, imageReplacement)
+}

--- a/pkg/controller/extensions/imagereplacement/helpers.go
+++ b/pkg/controller/extensions/imagereplacement/helpers.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package imagereplacement
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	v1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func UpdateDeployment(deploy *appsv1.Deployment, registry *v1alpha1.Registry, log logr.Logger) error {
+	containers := deploy.Spec.Template.Spec.Containers
+	for index := range containers {
+		container := &containers[index]
+		log.Info(container.Name)
+		newImage := getNewImage(registry, container.Name)
+		log.Info(newImage)
+		if newImage != "" {
+			updateContainerImage(container, newImage, log)
+		}
+
+		// replace image in args
+		args := container.Args
+		for i, v := range args {
+			newImage := getNewImage(registry, v)
+			if newImage != "" {
+				log.Info(fmt.Sprintf("Updating image in Args of container from: %v, to: %v", v, newImage))
+				args[i+1] = newImage
+			}
+		}
+	}
+
+	return nil
+}
+
+func getNewImage(registry *v1alpha1.Registry, key string) string {
+	overrideImage := registry.Override[key]
+	if overrideImage != "" {
+		return overrideImage
+	}
+	return ""
+}
+
+func updateContainerImage(container *corev1.Container, newImage string, log logr.Logger) {
+	log.Info(fmt.Sprintf("Updating container image from: %v, to: %v", container.Image, newImage))
+	container.Image = newImage
+}

--- a/pkg/controller/extensions/imagereplacement/helpers_test.go
+++ b/pkg/controller/extensions/imagereplacement/helpers_test.go
@@ -1,0 +1,153 @@
+package imagereplacement
+
+import (
+	"testing"
+
+	v1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+type imageReplacementTest struct {
+	name       string
+	containers []corev1.Container
+	registry   v1alpha1.Registry
+	argsIndex  []int8
+	expected   []string
+}
+
+var updateDeploymentImageTests = []imageReplacementTest{
+	{
+		name: "ImageinContainer",
+		containers: []corev1.Container{{
+			Name:  "tekton-pipelines-controller",
+			Image: "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0"},
+		},
+		registry: v1alpha1.Registry{
+			Override: map[string]string{
+				"tekton-pipelines-controller": "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:new-tag",
+			},
+		},
+		expected: []string{"quay.io/openshift-pipeline/tektoncd-pipeline-webhook:new-tag"},
+	},
+
+	{
+		name: "ImageinArgs",
+		containers: []corev1.Container{{
+			Name:  "tekton-pipelines-controller",
+			Image: "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			Args:  []string{"-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.4.0"},
+		}},
+		registry: v1alpha1.Registry{
+			Override: map[string]string{
+				"-kubeconfig-writer-image": "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag",
+			},
+		},
+		argsIndex: []int8{1},
+		expected: []string{"quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag"},
+	},
+
+	{
+		name: "ImageinArgsMultiple",
+		containers: []corev1.Container{{
+			Name:  "tekton-pipelines-controller",
+			Image: "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			Args: []string{"-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.4.0",
+				"-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.4.0"},
+		}},
+		registry: v1alpha1.Registry{
+			Override: map[string]string{
+				"-kubeconfig-writer-image": "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag",
+				"-creds-image":             "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:new-tag",
+			},
+		},
+		argsIndex: []int8{1, 3},
+		expected: []string{"quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:new-tag"},
+	},
+
+	{
+		name: "ImageinArgsandContainerMultiple",
+		containers: []corev1.Container{{
+			Name:  "tekton-pipelines-controller",
+			Image: "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			Args: []string{"-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.4.0",
+				"-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.4.0"},
+		}},
+		registry: v1alpha1.Registry{
+			Override: map[string]string{
+				"tekton-pipelines-controller": "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:new-tag",
+				"-kubeconfig-writer-image":    "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag",
+				"-creds-image":                "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:new-tag",
+			},
+		},
+		argsIndex: []int8{1, 3},
+		expected: []string{"quay.io/openshift-pipeline/tektoncd-pipeline-webhook:new-tag",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:new-tag",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:new-tag"},
+	},
+	{
+		name: "replaceNothing",
+		containers: []corev1.Container{{
+			Name:  "tekton-pipelines-controller",
+			Image: "quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			Args: []string{"-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.4.0",
+				"-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.4.0"},
+		}},
+		registry: v1alpha1.Registry{
+			Override: map[string]string{},
+		},
+		argsIndex: []int8{1, 3},
+		expected: []string{"quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.4.0",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.4.0",
+			"quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.4.0"},
+	},
+}
+
+func TestUpdateDeploymentImage(t *testing.T) {
+	for _, tt := range updateDeploymentImageTests {
+		t.Run(tt.name, func(t *testing.T) {
+			runUpdateDeploymentImageTest(t, tt)
+		})
+	}
+}
+
+func runUpdateDeploymentImageTest(t *testing.T, tt imageReplacementTest) {
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tt.name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: tt.containers,
+				},
+			},
+		},
+	}
+	log := logf.Log.WithName(tt.name)
+	logf.SetLogger(logf.ZapLogger(true))
+
+	UpdateDeployment(&deployment, &tt.registry, log)
+
+	expecteds := tt.expected
+	// Assert container[*].image
+	assertEqual(t, deployment.Spec.Template.Spec.Containers[0].Image, expecteds[0])
+	expecteds = expecteds[1:]
+	// Assert container[*].args
+	for i, argsIndex := range tt.argsIndex {
+		assertEqual(t, deployment.Spec.Template.Spec.Containers[0].Args[argsIndex], expecteds[i])
+	}
+
+}
+
+func assertEqual(t *testing.T, actual, expected string) {
+	if actual == expected {
+		return
+	}
+	t.Fatalf("expected does not equal actual. \nExpected: %v\nActual: %v", expected, actual)
+}

--- a/pkg/controller/extensions/imagereplacement/imagereplacement.go
+++ b/pkg/controller/extensions/imagereplacement/imagereplacement.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package imagereplacement
+
+import (
+	mf "github.com/jcrossley3/manifestival"
+	v1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/controller/common"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	log = logf.Log.WithName("image-replacement")
+)
+
+// New creates a new Imagereplacement
+func New() (*Imagereplacement, error) {
+	return &Imagereplacement{}, nil
+}
+
+// Imagereplacement define Activity to replace image url in the yaml
+type Imagereplacement struct {
+	Extension        common.Extension
+	extensionWrapper *v1alpha1.ExtensionWapper
+	scheme           *runtime.Scheme
+}
+
+// Configure decide if the imageReplacement need to be added to process chain
+func (ir Imagereplacement) Configure(c client.Client, s *runtime.Scheme, extensionWapper *v1alpha1.ExtensionWapper) (*common.Extension, error) {
+	if extensionWapper.Registry != nil && extensionWapper.Registry.Override != nil {
+		ir.scheme = s
+		ir.extensionWrapper = extensionWapper
+		ir.Extension = common.Extension{
+			Transformers: []mf.Transformer{ir.egress},
+		}
+		return &ir.Extension, nil
+	}
+
+	return nil, nil
+}
+
+func (ir Imagereplacement) egress(u *unstructured.Unstructured) error {
+	if u.GetKind() == "Deployment" {
+		var deploy = &appsv1.Deployment{}
+		if err := ir.scheme.Convert(u, deploy, nil); err != nil {
+			return err
+		}
+		registry := ir.extensionWrapper.Registry
+		err := UpdateDeployment(deploy, registry, log)
+		if err != nil {
+			return err
+		}
+		if err := ir.scheme.Convert(deploy, u, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Changes
Fix issue mentioned in #66 
Introduce new feature: `image replacement`

Enable `image replacement` for both `Config` and `Addon`.
A sample for `Config`:
```
apiVersion: operator.tekton.dev/v1alpha1
kind: Config
metadata:
  name: cluster
spec:
  targetNamespace: tekton-pipeliness
  registry:
    override:
      tekton-pipelines-controller: index.docker.io/vincentpli/haha:v0.0.1
      -kubeconfig-writer-image: index.docker.io/vincentpli/kubeconfigwriter:v0.10.0
```
Almost same in `Addon`.

In code lever, not hard code in `Reconcile`, introduce concept ` Extension` and implements the first build in `Extension`: `imagereplacement`.
The design is easy for extending new features, maybe we will have more `Extension` in future.

Still not consider `pullsecret`, will add later.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
