### PR TITLE
Correct version in cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ The current supported components and versions are:
   - openshift-v0.2.0
 - trigger
   - v0.1.0
-  - v0.2.0
+  - v0.2.1

--- a/deploy/crds/operator_v1alpha1_addon_dashboard_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_addon_dashboard_cr.yaml
@@ -4,4 +4,4 @@ metadata:
   name: dashboard
 spec:
   # Add fields here
-  version: v0.1.1
+  version: v0.2.0

--- a/deploy/crds/operator_v1alpha1_addon_extensionwebhooks_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_addon_extensionwebhooks_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.tekton.dev/v1alpha1
 kind: Addon
 metadata:
-  name: trigger
+  name: extensionwebhooks
 spec:
   # Add fields here
-  version: v0.2.1
+  version: v0.2.0


### PR DESCRIPTION
# Changes
The version v0.2.0 of `trigger` is removed so change the relevant `cr`.
Add `cr` sample for `extensionwebhook`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
