### PR TITLE
cmd/manager: do not set operatorNs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -158,13 +158,8 @@ func serveCRMetrics(cfg *rest.Config) error {
 	if err != nil {
 		return err
 	}
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return err
-	}
 	// To generate metrics in other namespaces, add the values below.
-	ns := []string{operatorNs}
+	ns := []string{""}
 	// Generate and serve custom resource specific metrics.
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {


### PR DESCRIPTION
It causes

```
E0326 23:33:51.863594       1 reflector.go:134] github.com/operator-framework/operator-sdk/pkg/kube-metrics/collector.go:67: Failed to list *unstructured.Unstructured: the server could not find the requested resource
```