### PR TITLE
Change `operator-sdk up local` into `operator-sdk run local`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ local-test-e2e:
 	GO111MODULE=on \
 	operator-sdk test local ./test/e2e  \
 	--up-local \
+	--watch-namespace "" \
 	--operator-namespace operators \
 	--debug  \
 	--verbose

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ all: local-dev
 
 .PHONY: clean
 clean:
-	-kubectl delete -f deploy/crds/
 	-kubectl delete -f deploy/
+	-kubectl delete -f deploy/crds/
 	-kubectl delete namespace tekton-pipelines
 
 .PHONY: local-dev
 local-dev: dev-setup
-	GO111MODULE=on operator-sdk up local --namespace "" --operator-flags '--zap-encoder=console'
+	GO111MODULE=on operator-sdk run local --watch-namespace "" --operator-flags '--zap-encoder=console'
 
 .PHONY: update-deps dev-setup
 dev-setup:
@@ -29,6 +29,6 @@ local-test-e2e:
 	GO111MODULE=on \
 	operator-sdk test local ./test/e2e  \
 	--up-local \
-	--namespace operators \
+	--operator-namespace operators \
 	--debug  \
 	--verbose

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -26,7 +26,7 @@ header "Running operator-sdk test"
  operator-sdk test local ./test/e2e  \
   --up-local \
   --operator-namespace operators \
-  --watch-namespace tekton-pipelines \
+  --watch-namespace "" \
   --debug  \
   --verbose || fail_test
 success


### PR DESCRIPTION
# Changes
* As of operator-sdk 0.16,  `operator-sdk up local` is deprecated.
* Remove the CRDs in the end of clean-up.
* Fix some issues about the params for the command `operator-sdk`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._


