### PR TITLE
Fix flag in make local-dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 .PHONY: local-dev
 local-dev: dev-setup
-	GO111MODULE=on operator-sdk run local --watch-namespace "" --operator-flags '--zap-encoder=console'
+	GO111MODULE=on operator-sdk run --local --watch-namespace "" --operator-flags '--zap-encoder=console'
 
 .PHONY: update-deps dev-setup
 dev-setup:


### PR DESCRIPTION
Add correct `--local` flag to `operator-sdk run` command

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

    ```release-note
    NONE
    ```

