### PR TITLE
Fix kubectl command in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ tkn pipelinerun logs -f pipelinerun-with-params
 At present the operator need to add `cluster-admin` clusterrole to install Tektoncd Dashboard.
 
 ```shell script
-kc create clusterrolebinding tekton-operator-cluster-admin --clusterrole cluster-admin --serviceaccount tekton-operator:tekton-operator
+kubectl create clusterrolebinding tekton-operator-cluster-admin --clusterrole cluster-admin --serviceaccount tekton-operator:tekton-operator
 ---
 clusterrolebinding.rbac.authorization.k8s.io/tekton-operator-cluster-admin created
 ```


### PR DESCRIPTION
# Changes

In README.md we have `kc` instead on `kubectl` while creating the ClusterRoleBinding for Dashboard.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

 ```release-note
NONE
 ```

