### PR TITLE
Fix local-test-e2e target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ local-test-e2e: clean dev-setup
 	--operator-namespace tekton-operators \
 	--no-setup \
 	--verbose \
-	--go-test-flags "-v -timeout 20m -tags=e2e"
+	--go-test-flags "-v -timeout 20m -tags=e2e" \
 	--debug


### PR DESCRIPTION
# Changes

Add missing backslash symbol to fix execution of local-test-e2e target in Makefile.
Otherwise `make local-test-e2e` fails with:
```
debug
make: debug: Command not found
Makefile:39: recipe for target 'local-test-e2e' failed]
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
    NONE
```

