### PR TITLE
fix condition duplicated issue for addon

### DIFF
--- a/pkg/controller/addon/addon_controller.go
+++ b/pkg/controller/addon/addon_controller.go
@@ -326,6 +326,12 @@ func requestLogger(req reconcile.Request, context string) logr.Logger {
 
 // updateStatus set the status of res to s and refreshes res to the lastest version
 func (r *ReconcileAddon) updateStatus(res *op.TektonAddon, c op.TektonAddonCondition) error {
+	for _, condition := range res.Status.Conditions {
+		if condition.Code == c.Code && condition.Version == c.Version {
+			return nil
+		}
+	}
+
 	res.Status.Conditions = append([]op.TektonAddonCondition{c}, res.Status.Conditions...)
 
 	res.GetObjectMeta()


### PR DESCRIPTION
# Changes
The issue mentioned in slack channel: caused by `condition` increase unlimited.
```
{"level":"info","ts":1599719446.982504,"logger":"ctrl.tektonaddon.reconcile","msg":"Reconciling TektonAddon","Request.Namespace":"","Request.NamespaceName":"/dashboard","Request.Name":"dashboard"}
time="2020-09-10T06:30:47Z" level=error msg="etcdserver: request is too largestatus update failed" source="addon_controller.go:333"
{"level":"error","ts":1599719447.9850516,"logger":"ctrl.tektonaddon.addon install","msg":"failed to set status","Request.Namespace":"","Request.NamespaceName":"/dashboard","Request.Name":"dashboard","error":"etcdserver: request is too large","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tgithub.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/tektoncd/operator/pkg/controller/addon.(*ReconcileAddon).reconcileAddon\n\tgithub.com/tektoncd/operator@/pkg/controller/addon/addon_controller.go:171\ngithub.com/tektoncd/operator/pkg/controller/addon.(*ReconcileAddon).Reconcile\n\tgithub.com/tektoncd/operator@/pkg/controller/addon/addon_controller.go:134\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\tsigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/w ait.JitterUntil.func1\n\tk8s.io/apimachinery@v0.17.6/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\tk8s.io/apimachinery@v0.17.6/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\tk8s.io/apimachinery@v0.17.6/pkg/util/wait/wait.go:88"}
```
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
