### PR TITLE
Fixes tektonpipline status conditions update

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -29,9 +29,6 @@ const (
 	// DeploymentsAvailable is a Condition indicating whether or not the Deployments of
 	// the respective component have come up successfully.
 	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
-	// VersionMigrationEligible is a Condition indicating whether or not the current version of
-	// Tekton component is eligible to upgrade or downgrade to the specified version.
-	VersionMigrationEligible apis.ConditionType = "VersionMigrationEligible"
 )
 
 // TektonComponent is a common interface for accessing meta, spec and status of all known types.
@@ -64,12 +61,6 @@ type TektonComponentStatus interface {
 	// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 	// it's waiting for deployments.
 	MarkDeploymentsNotReady()
-
-	// MarkVersionMigrationEligible marks the VersionMigrationEligible status as true.
-	MarkVersionMigrationEligible()
-	// MarkVersionMigrationNotEligible marks the VersionMigrationEligible status as false with
-	// the given message.
-	MarkVersionMigrationNotEligible(msg string)
 
 	// MarkDependenciesInstalled marks the DependenciesInstalled status as true.
 	MarkDependenciesInstalled()

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_lifecycle.go
@@ -25,7 +25,6 @@ var (
 		DependenciesInstalled,
 		DeploymentsAvailable,
 		InstallSucceeded,
-		VersionMigrationEligible,
 	)
 )
 
@@ -65,19 +64,6 @@ func (tps *TektonPipelineStatus) MarkInstallFailed(msg string) {
 		InstallSucceeded,
 		"Error",
 		"Install failed with message: %s", msg)
-}
-
-// MarkVersionMigrationEligible marks the VersionMigrationEligible status as false with given message.
-func (tps *TektonPipelineStatus) MarkVersionMigrationEligible() {
-	pipelineCondSet.Manage(tps).MarkTrue(VersionMigrationEligible)
-}
-
-// MarkVersionMigrationNotEligible marks the DeploymentsAvailable status as true.
-func (tps *TektonPipelineStatus) MarkVersionMigrationNotEligible(msg string) {
-	pipelineCondSet.Manage(tps).MarkFalse(
-		VersionMigrationEligible,
-		"Error",
-		"Version migration is not eligible with message: %s", msg)
 }
 
 // MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_lifecycle_test.go
@@ -43,8 +43,6 @@ func TestTektonPipelineHappyPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tp, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(tp, InstallSucceeded, t)
 
-	tp.MarkVersionMigrationEligible()
-
 	// Install succeeds.
 	tp.MarkInstallSucceeded()
 	// Dependencies are assumed successful too.
@@ -78,8 +76,6 @@ func TestTektonPipelineErrorPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tp, DependenciesInstalled, t)
 	apistest.CheckConditionOngoing(tp, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(tp, InstallSucceeded, t)
-
-	tp.MarkVersionMigrationEligible()
 
 	// Install fails.
 	tp.MarkInstallFailed("test")
@@ -139,12 +135,4 @@ func TestTektonPipelineExternalDependency(t *testing.T) {
 	apistest.CheckConditionSucceeded(tp, DependenciesInstalled, t)
 	apistest.CheckConditionOngoing(tp, DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(tp, InstallSucceeded, t)
-}
-
-func TestTektonPipelineVersionMigrationNotEligible(t *testing.T) {
-	tp := &TektonPipelineStatus{}
-	tp.InitializeConditions()
-
-	tp.MarkVersionMigrationNotEligible("Version migration not eligible.")
-	apistest.CheckConditionFailed(tp, VersionMigrationEligible, t)
 }


### PR DESCRIPTION
Fixes tektonpipline status conditions update

Fixes https://github.com/tektoncd/operator/issues/155

Removes upgrade eligible status conditions as it is not a part of the operator implementation in master branch.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```