### PR TITLE
use tektontriggers from openshift

### DIFF
--- a/pkg/reconciler/openshift/tektontrigger/controller.go
+++ b/pkg/reconciler/openshift/tektontrigger/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Tekton Authors
+Copyright 2020 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package tektontrigger
 
 import (
-	"github.com/tektoncd/operator/pkg/reconciler/openshift/tektonpipeline"
-	"github.com/tektoncd/operator/pkg/reconciler/openshift/tektontrigger"
-	"knative.dev/pkg/injection/sharedmain"
+	"context"
+
+	k8s_ctrl "github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
 )
 
-func main() {
-	sharedmain.Main("tekton-operator",
-		tektonpipeline.NewController,
-		tektontrigger.NewController,
-	)
+// NewController initializes the controller and is called by the generated code
+// Registers eventhandlers to enqueue events
+func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return k8s_ctrl.NewExtendedController(OpenShiftExtension)(ctx, cmw)
 }

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektontrigger
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+)
+
+// NoPlatform "generates" a NilExtension
+func OpenShiftExtension(context.Context) common.Extension {
+	return openshiftExtension{}
+}
+
+type openshiftExtension struct{}
+
+func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	return []mf.Transformer{}
+	//return nil
+}
+func (oe openshiftExtension) Reconcile(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}
+func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}


### PR DESCRIPTION
this make openshift entry point to use its own tektontriggers controller
which enable it to use openshift specific extension

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
