### PR TITLE
Fix openshift specific RBAC reconciler

### DIFF
--- a/config/openshift/kustomization.yaml
+++ b/config/openshift/kustomization.yaml
@@ -20,3 +20,7 @@ patches:
   target:
     kind: Deployment
     name: tekton-operator
+- path: role.yaml
+  target:
+    kind: ClusterRole
+    name: tekton-operator

--- a/config/openshift/role.yaml
+++ b/config/openshift/role.yaml
@@ -1,0 +1,234 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - pods/log
+  - limitranges
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - delete
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  - deployments/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - build.knative.dev
+  resources:
+  - builds
+  - buildtemplates
+  - clusterbuildtemplates
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - use
+- apiGroups:
+  - operator.tekton.dev
+  resources:
+  - '*'
+  - tektonaddons
+  verbs:
+  - '*'
+- apiGroups:
+  - tekton.dev
+  - triggers.tekton.dev
+  - operator.tekton.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - dashboard.tekton.dev
+  resources:
+  - '*'
+  - tektonaddons
+  verbs:
+  - '*'
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleyamlsamples
+  - consoleclidownloads
+  verbs:
+  - '*'

--- a/test/e2e/openshift/rbac_test.go
+++ b/test/e2e/openshift/rbac_test.go
@@ -1,0 +1,58 @@
+// +build e2e
+
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/test/utils"
+
+	"github.com/tektoncd/operator/test/resources"
+
+	"github.com/tektoncd/operator/test/client"
+)
+
+// TestTektonAddonsDeployment verifies the TektonAddons creation, deployment recreation, and TektonAddons deletion.
+func TestRBACReconciler(t *testing.T) {
+	clients := client.Setup(t)
+
+	crNames := utils.ResourceNames{
+		Namespace: "operator-test-rbac",
+	}
+	expectedSAName := "pipeline"
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.Namespace) })
+	defer utils.TearDownNamespace(clients, crNames.Namespace)
+
+	//// Create a Test Namespace
+	if _, err := resources.EnsureTestNamespaceExists(clients.KubeClient.Kube, crNames.Namespace); err != nil {
+		t.Fatalf("failed to create test namespace: %s, %q", crNames.Namespace, err)
+	}
+
+	// Test whether the `pipelineSa` is created in a "default" namespace
+	t.Run("verify-service-account", func(t *testing.T) {
+		resources.AssertServiceAccount(t, clients, crNames.Namespace, expectedSAName)
+	})
+
+	// Test whether the roleBindings are created in a "default" namespace
+	t.Run("verify-rolebindings", func(t *testing.T) {
+		resources.AssertRoleBinding(t, clients, crNames.Namespace, "edit")
+		resources.AssertRoleBinding(t, clients, crNames.Namespace, "pipeline-anyuid")
+	})
+}

--- a/test/resources/rbac.go
+++ b/test/resources/rbac.go
@@ -1,0 +1,66 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/tektoncd/operator/test/utils"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureTestNamespaceExists creates a Test Namespace
+func EnsureTestNamespaceExists(clientSet *kubernetes.Clientset, name string) (*corev1.Namespace, error) {
+	// If this function is called by the upgrade tests, we only create the custom resource, if it does not exist.
+	ns, err := clientSet.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		return clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	}
+	return ns, err
+}
+
+func AssertServiceAccount(t *testing.T, clients *utils.Clients, ns, targetSA string) {
+	t.Helper()
+
+	err := wait.Poll(Interval, Timeout, func() (bool, error) {
+		saList, err := clients.KubeClient.Kube.CoreV1().ServiceAccounts(ns).List(context.TODO(), metav1.ListOptions{})
+		for _, item := range saList.Items {
+			if item.Name == targetSA {
+				return true, nil
+			}
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("could not find serviceaccount %s/%s: %q", ns, targetSA, err)
+	}
+}
+func AssertRoleBinding(t *testing.T, clients *utils.Clients, ns, roleBindingName string) {
+	t.Helper()
+
+	err := wait.Poll(Interval, Timeout, func() (bool, error) {
+		rbList, err := clients.KubeClient.Kube.RbacV1().RoleBindings(ns).List(context.TODO(), metav1.ListOptions{})
+		for _, item := range rbList.Items {
+			if item.Name == roleBindingName {
+				return true, nil
+			}
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("could not find serviceaccount %s/%s: %q", ns, roleBindingName, err)
+	}
+}

--- a/test/utils/cleanup.go
+++ b/test/utils/cleanup.go
@@ -63,3 +63,10 @@ func TearDownAddon(clients *Clients, name string) {
 		_ = clients.TektonAddon().Delete(context.TODO(), name, metav1.DeleteOptions{})
 	}
 }
+
+// TearDownNamespace will delete created test Namespace
+func TearDownNamespace(clients *Clients, name string) {
+	if clients != nil && clients.KubeClient != nil {
+		_ = clients.KubeClient.Kube.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+}


### PR DESCRIPTION
Add all verbs for `tekton-operator` clusterRole in OpenShift overlay.
This is required as the `rbac` reconciler for openshift need that to
bind `pipeline` serviceAccount each namespace to `edit` clusterRole.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->

    ```release-note
    NONE
    ```
