### PR TITLE
De-indent pull request template release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,19 +29,19 @@ Examples of user facing changes:
 
 For pull requests with a release note:
 
-    ```release-note
-    Your release note here
-    ```
+```release-note
+Your release note here
+```
 
 For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
 
-    ```release-note
-    action required: your release note here
-    ```
+```release-note
+action required: your release note here
+```
 
 For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
 
-    ```release-note
-    NONE
-    ```
+```release-note
+NONE
+```
 -->


### PR DESCRIPTION

# Changes

The main reason for it is that it makes it *easier* to set those
without having to manually remove some lines, …

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

This is a port of that change in other `tektoncd` projects (pipeline, …)

/cc @nikhil-thomas @savitaashture 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
