### PR TITLE
Fix small nits in e2e testcases

### DIFF
--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	pipelinev1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	configv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EnsureTektonConfigExists creates a TektonConfig with the name names.TektonConfig, if it does not exist.
-func EnsureTektonConfigExists(clients pipelinev1alpha1.TektonConfigInterface, names utils.ResourceNames) (*v1alpha1.TektonConfig, error) {
+func EnsureTektonConfigExists(clients configv1alpha1.TektonConfigInterface, names utils.ResourceNames) (*v1alpha1.TektonConfig, error) {
 	// If this function is called by the upgrade tests, we only create the custom resource, if it does not exist.
 	tcCR, err := clients.Get(context.TODO(), names.TektonConfig, metav1.GetOptions{})
 	if err == nil {
@@ -64,7 +64,7 @@ func EnsureTektonConfigExists(clients pipelinev1alpha1.TektonConfigInterface, na
 // WaitForTektonConfigState polls the status of the TektonConfig called name
 // from client every `interval` until `inState` returns `true` indicating it
 // is done, returns an error or timeout.
-func WaitForTektonConfigState(clients pipelinev1alpha1.TektonConfigInterface, name string,
+func WaitForTektonConfigState(clients configv1alpha1.TektonConfigInterface, name string,
 	inState func(s *v1alpha1.TektonConfig, err error) (bool, error)) (*v1alpha1.TektonConfig, error) {
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForTektonConfigState/%s/%s", name, "TektonConfigIsReady"))
 	defer span.End()

--- a/test/resources/tektondashboards.go
+++ b/test/resources/tektondashboards.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	pipelinev1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	dashboardv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EnsureTektonDashboardExists creates a TektonDashboard with the name names.TektonDashboard, if it does not exist.
-func EnsureTektonDashboardExists(clients pipelinev1alpha1.TektonDashboardInterface, names utils.ResourceNames) (*v1alpha1.TektonDashboard, error) {
+func EnsureTektonDashboardExists(clients dashboardv1alpha1.TektonDashboardInterface, names utils.ResourceNames) (*v1alpha1.TektonDashboard, error) {
 	// If this function is called by the upgrade tests, we only create the custom resource, if it does not exist.
 	ks, err := clients.Get(context.TODO(), names.TektonDashboard, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
@@ -61,7 +61,7 @@ func EnsureTektonDashboardExists(clients pipelinev1alpha1.TektonDashboardInterfa
 // WaitForTektonDashboardState polls the status of the TektonDashboard called name
 // from client every `interval` until `inState` returns `true` indicating it
 // is done, returns an error or timeout.
-func WaitForTektonDashboardState(clients pipelinev1alpha1.TektonDashboardInterface, name string,
+func WaitForTektonDashboardState(clients dashboardv1alpha1.TektonDashboardInterface, name string,
 	inState func(s *v1alpha1.TektonDashboard, err error) (bool, error)) (*v1alpha1.TektonDashboard, error) {
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForTektonDashboardState/%s/%s", name, "TektonDashboardIsReady"))
 	defer span.End()
@@ -73,7 +73,7 @@ func WaitForTektonDashboardState(clients pipelinev1alpha1.TektonDashboardInterfa
 	})
 
 	if waitErr != nil {
-		return lastState, fmt.Errorf("tektonpipeline %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
+		return lastState, fmt.Errorf("tektondashboard %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
 	}
 	return lastState, nil
 }
@@ -130,11 +130,11 @@ func TektonDashboardCRDelete(t *testing.T, clients *utils.Clients, crNames utils
 }
 
 func verifyNoTektonDashboardCR(clients *utils.Clients) error {
-	pipelines, err := clients.TektonDashboardAll().List(context.TODO(), metav1.ListOptions{})
+	dashboards, err := clients.TektonDashboardAll().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	if len(pipelines.Items) > 0 {
+	if len(dashboards.Items) > 0 {
 		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonDashboard exists")
 	}
 	return nil

--- a/test/resources/tektontriggers.go
+++ b/test/resources/tektontriggers.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	pipelinev1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	triggerv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EnsureTektonTriggerExists creates a TektonTrigger with the name names.TektonTrigger, if it does not exist.
-func EnsureTektonTriggerExists(clients pipelinev1alpha1.TektonTriggerInterface, names utils.ResourceNames) (*v1alpha1.TektonTrigger, error) {
+func EnsureTektonTriggerExists(clients triggerv1alpha1.TektonTriggerInterface, names utils.ResourceNames) (*v1alpha1.TektonTrigger, error) {
 	// If this function is called by the upgrade tests, we only create the custom resource, if it does not exist.
 	ks, err := clients.Get(context.TODO(), names.TektonTrigger, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
@@ -61,7 +61,7 @@ func EnsureTektonTriggerExists(clients pipelinev1alpha1.TektonTriggerInterface, 
 // WaitForTektonTriggerState polls the status of the TektonTrigger called name
 // from client every `interval` until `inState` returns `true` indicating it
 // is done, returns an error or timeout.
-func WaitForTektonTriggerState(clients pipelinev1alpha1.TektonTriggerInterface, name string,
+func WaitForTektonTriggerState(clients triggerv1alpha1.TektonTriggerInterface, name string,
 	inState func(s *v1alpha1.TektonTrigger, err error) (bool, error)) (*v1alpha1.TektonTrigger, error) {
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForTektonTriggerState/%s/%s", name, "TektonTriggerIsReady"))
 	defer span.End()
@@ -130,11 +130,11 @@ func TektonTriggerCRDelete(t *testing.T, clients *utils.Clients, crNames utils.R
 }
 
 func verifyNoTektonTriggerCR(clients *utils.Clients) error {
-	pipelines, err := clients.TektonTriggerAll().List(context.TODO(), metav1.ListOptions{})
+	triggers, err := clients.TektonTriggerAll().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	if len(pipelines.Items) > 0 {
+	if len(triggers.Items) > 0 {
 		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonTrigger exists")
 	}
 	return nil


### PR DESCRIPTION
# Changes

The failure in e2e testcase giving wrong messages for few components like below
```
Running tests with 'go test -race -v  -count=1 -tags=e2e -timeout=20m ./test/e2e/kubernetes '
=== RUN   TestTektonDashboardsDeployment
=== RUN   TestTektonDashboardsDeployment/create-pipeline
    tektonpipelines.go:93: TektonPipelineCR "pipeline" failed to get to the READY status: tektonpipeline pipeline is not in desired state, got: <nil>: timed out waiting for the condition
=== RUN   TestTektonDashboardsDeployment/create-dashboard
    tektondashboards.go:90: TektonDashboardCR "dashboard" failed to get to the READY status: tektonpipeline dashboard is not in desired state, got: <nil>: timed out waiting for the condition
=== RUN   TestTektonDashboardsDeployment/restore-dashboard-deployments
    tektondashboards.go:90: TektonDashboardCR "dashboard" failed to get to the READY status: tektonpipeline dashboard is not in desired state, got: <nil>: timed out waiting for the condition
=== RUN   TestTektonDashboardsDeployment/delete-dashboard
```
Modified error messages.

/cc @nikhil-thomas 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```