### PR TITLE
Makefile: add a way to install/delete CRs

### DIFF
--- a/config/crs/kubernetes/addon/operator_v1alpha1_addon_cr.yaml
+++ b/config/crs/kubernetes/addon/operator_v1alpha1_addon_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonAddon
+metadata:
+  name: addon
+spec:
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/kubernetes/config/all/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: all
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/config/basic/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/kubernetes/config/basic/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: basic
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/config/default/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/kubernetes/config/default/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: default
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/dashboard/operator_v1alpha1_dashboard_cr.yaml
+++ b/config/crs/kubernetes/dashboard/operator_v1alpha1_dashboard_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonDashboard
+metadata:
+  name: dashboard
+spec:
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/operator_v1alpha1_dashboard_cr.yaml
+++ b/config/crs/kubernetes/operator_v1alpha1_dashboard_cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonDashboard
-metadata:
-  name: dashboard
-spec:
-  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/pipeline/operator_v1alpha1_pipeline_cr.yaml
+++ b/config/crs/kubernetes/pipeline/operator_v1alpha1_pipeline_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonPipeline
+metadata:
+  name: pipeline
+spec:
+  targetNamespace: tekton-pipelines

--- a/config/crs/kubernetes/trigger/operator_v1alpha1_trigger_cr.yaml
+++ b/config/crs/kubernetes/trigger/operator_v1alpha1_trigger_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonTrigger
+metadata:
+  name: trigger
+spec:
+  targetNamespace: tekton-pipelines

--- a/config/crs/openshift/addon/operator_v1alpha1_addon_cr.yaml
+++ b/config/crs/openshift/addon/operator_v1alpha1_addon_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonAddon
+metadata:
+  name: addon
+spec:
+  targetNamespace: openshift-pipelines

--- a/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: all
+  targetNamespace: openshift-pipelines

--- a/config/crs/openshift/config/basic/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/basic/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: basic
+  targetNamespace: openshift-pipelines

--- a/config/crs/openshift/config/default/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/default/operator_v1alpha1_config_cr.yaml
@@ -11,16 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  profile: default
+  targetNamespace: openshift-pipelines

--- a/config/crs/openshift/operator_v1alpha1_addon_cr.yaml
+++ b/config/crs/openshift/operator_v1alpha1_addon_cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonAddon
-metadata:
-  name: addon
-spec:
-  targetNamespace: tekton-pipelines

--- a/config/crs/openshift/pipeline/operator_v1alpha1_pipeline_cr.yaml
+++ b/config/crs/openshift/pipeline/operator_v1alpha1_pipeline_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonPipeline
+metadata:
+  name: pipeline
+spec:
+  targetNamespace: openshift-pipelines

--- a/config/crs/openshift/trigger/operator_v1alpha1_trigger_cr.yaml
+++ b/config/crs/openshift/trigger/operator_v1alpha1_trigger_cr.yaml
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: openshift-operators
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: openshift-operators
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonTrigger
+metadata:
+  name: trigger
+spec:
+  targetNamespace: openshift-pipelines

--- a/config/crs/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/operator_v1alpha1_config_cr.yaml
@@ -1,7 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
-  name: config
-spec:
-  profile: default
-  targetNamespace: tekton-pipelines

--- a/config/crs/operator_v1alpha1_pipeline_cr.yaml
+++ b/config/crs/operator_v1alpha1_pipeline_cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonPipeline
-metadata:
-  name: pipeline
-spec:
-  targetNamespace: tekton-pipelines

--- a/config/crs/operator_v1alpha1_trigger_cr.yaml
+++ b/config/crs/operator_v1alpha1_trigger_cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonTrigger
-metadata:
-  name: trigger
-spec:
-  targetNamespace: tekton-pipelines

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ If the files in `pkg/apis` are updated we need to run `codegen` scripts
 Operator provides an option to choose which components needs to be installed by specifying `profile`.
 
 `profile` is an optional field and supported `profile` are
-* **basic** 
+* **basic**
 * **default**
 * **all**
 
@@ -58,11 +58,13 @@ Operator provides an option to choose which components needs to be installed by 
 
 To create Tekton Components run
 ```shell script
-kubectl apply -f config/crs/operator_v1alpha1_config_cr.yaml
+make apply-cr
+make CR=config/basic apply-cr
 ```
 To delete installed Tekton Components run
 ```shell script
-kubectl delete -f config/crs/operator_v1alpha1_config_cr.yaml
+make clean-cr
+make CR=config/basic clean-cr
 ```
 
 ## Running Tests


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This allow the developer to deploy a given CR to the current
cluster. `TARGET` is used in a similar fashion than for `apply` and
`resolve` (aka kubernetes vs openshift vs …). `CR` is what CR to
deploy, it follows the fs hierarchy under `config/crs/$(TARGET)`.

```shell
$ make apply-cr
$ make TARGET=openshift apply-cr
$ make TARGET=openshift CR=config/minimal apply-cr
$ make CR=pipeline apply-cr
```

This also changes the namespaces for the OpenShift platform:
- tekton-pipelines -> openshift-pipelines
- tekton-operator -> openshift-operators

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Makefile: add a way to install/delete CRs
```

