### PR TITLE
[wip] Add openShift specific way of getting internal CA bundle

### DIFF
--- a/cmd/openshift/kodata/config-trusted-cabundle.yaml
+++ b/cmd/openshift/kodata/config-trusted-cabundle.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-trusted-cabundle
+  labels:
+    operator.tekton.dev/release: devel
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -25,6 +25,7 @@ import (
 
 // Extension enables platform-specific features
 type Extension interface {
+	Append(context.Context, *mf.Manifest) error
 	Transformers(v1alpha1.TektonComponent) []mf.Transformer
 	PreReconcile(context.Context, v1alpha1.TektonComponent) error
 	PostReconcile(context.Context, v1alpha1.TektonComponent) error
@@ -41,6 +42,9 @@ func NoExtension(context.Context) Extension {
 
 type nilExtension struct{}
 
+func (nilExtension) Append(context.Context, *mf.Manifest) error {
+	return nil
+}
 func (nilExtension) Transformers(v1alpha1.TektonComponent) []mf.Transformer {
 	return nil
 }

--- a/pkg/reconciler/common/extensions_test.go
+++ b/pkg/reconciler/common/extensions_test.go
@@ -26,6 +26,10 @@ import (
 
 type TestExtension string
 
+func (t TestExtension) Append(context.Context, *mf.Manifest) error {
+	return nil
+}
+
 func (t TestExtension) Transformers(v1alpha1.TektonComponent) []mf.Transformer {
 	if t == "fail" {
 		return nil

--- a/pkg/reconciler/kubernetes/tektonconfig/extension.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension.go
@@ -37,6 +37,9 @@ type kubernetesExtension struct {
 	operatorClientSet versioned.Interface
 }
 
+func (oe kubernetesExtension) Append(ctx context.Context, m *mf.Manifest) error {
+	return nil
+}
 func (oe kubernetesExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{}
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -105,13 +105,21 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 		return err
 	}
 	stages := common.Stages{
-		common.AppendTarget,
+		r.append,
 		r.transform,
 		common.Install,
 		common.CheckDeployments,
 	}
 	manifest := r.manifest.Append()
 	return stages.Execute(ctx, &manifest, tp)
+}
+
+// append appends content to the passed manifest
+func (r *Reconciler) append(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
+	if err := common.AppendTarget(ctx, manifest, comp); err != nil {
+		return err
+	}
+	return r.extension.Append(ctx, manifest)
 }
 
 // transform mutates the passed manifest to one with common, component

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -122,13 +122,21 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		return err
 	}
 	stages := common.Stages{
-		common.AppendTarget,
+		r.append,
 		r.transform,
 		common.Install,
 		common.CheckDeployments,
 	}
 	manifest := r.manifest.Append()
 	return stages.Execute(ctx, &manifest, tt)
+}
+
+// append appends content to the passed manifest
+func (r *Reconciler) append(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
+	if err := common.AppendTarget(ctx, manifest, comp); err != nil {
+		return err
+	}
+	return r.extension.Append(ctx, manifest)
 }
 
 // transform mutates the passed manifest to one with common, component

--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	volumeName     = "config-registry-cert" // override default one
+	cfgMapName     = "config-trusted-cabundle"
+	cfgMapItemKey  = "ca-bundle.crt"
+	cfgMapItemPath = "tls-ca-bundle.pem"
+)
+
+// ApplyTrustedCABundle is a transformer that add the trustedCA volume, mount and
+// environment variables so that the deployment uses it.
+func ApplyTrustedCABundle(u *unstructured.Unstructured) error {
+	if u.GetKind() != "Deployment" {
+		// Don't do anything on something else than Deployment
+		return nil
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err := scheme.Scheme.Convert(u, deployment, nil); err != nil {
+		return err
+	}
+
+	volumes := deployment.Spec.Template.Spec.Volumes
+	for i, v := range volumes {
+		if v.Name == volumeName {
+			volumes = append(volumes[:i], volumes[i+1:]...)
+			break
+		}
+	}
+	volumes = append(volumes, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: cfgMapName},
+				Items: []corev1.KeyToPath{{
+					Key:  cfgMapItemKey,
+					Path: cfgMapItemPath,
+				}},
+			},
+		},
+	})
+	deployment.Spec.Template.Spec.Volumes = volumes
+
+	for i, c := range deployment.Spec.Template.Spec.Containers {
+		volumeMounts := c.VolumeMounts
+		for i, vm := range volumeMounts {
+			if vm.Name == volumeName {
+				volumeMounts = append(volumeMounts[:i], volumeMounts[i+1:]...)
+				break
+			}
+		}
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: "/etc/config-registry-cert/",
+			ReadOnly:  true,
+		})
+		c.VolumeMounts = volumeMounts
+		deployment.Spec.Template.Spec.Containers[i] = c
+	}
+
+	deployment.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   appsv1.SchemeGroupVersion.Group,
+		Version: appsv1.SchemeGroupVersion.Version,
+		Kind:    "Deployment",
+	})
+	m, err := toUnstructured(deployment)
+	if err != nil {
+		return err
+	}
+	u.SetUnstructuredContent(m.Object)
+	return nil
+}
+
+func toUnstructured(v interface{}) (*unstructured.Unstructured, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	ud := &unstructured.Unstructured{}
+	if err := json.Unmarshal(b, ud); err != nil {
+		return nil, err
+	}
+	return ud, nil
+}

--- a/pkg/reconciler/openshift/common/cabundle_test.go
+++ b/pkg/reconciler/openshift/common/cabundle_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestApplyTrustedCABundle(t *testing.T) {
+	actual := unstructuredDeployment(t)
+	expected := unstructuredDeployment(t,
+		withVolumes(corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: cfgMapName},
+					Items: []corev1.KeyToPath{{
+						Key:  cfgMapItemKey,
+						Path: cfgMapItemPath,
+					}},
+				},
+			},
+		}),
+		withVolumeMounts(corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: "/etc/config-registry-cert/",
+			ReadOnly:  true,
+		}),
+	)
+
+	if err := ApplyTrustedCABundle(actual); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.DeepEqual(t, actual, expected)
+}
+
+type deploymentModifier func(*appsv1.Deployment)
+
+func unstructuredDeployment(t *testing.T, modifiers ...deploymentModifier) *unstructured.Unstructured {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "registry",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "registry",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "registry",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "registry",
+						Image: "registry",
+					}},
+				},
+			},
+		},
+	}
+
+	for _, modifier := range modifiers {
+		modifier(deploy)
+	}
+
+	deploy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   appsv1.SchemeGroupVersion.Group,
+		Version: appsv1.SchemeGroupVersion.Version,
+		Kind:    "Deployment",
+	})
+	b, err := json.Marshal(deploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ud := &unstructured.Unstructured{}
+	if err := json.Unmarshal(b, ud); err != nil {
+		t.Fatal(err)
+	}
+	return ud
+}
+
+func withVolumes(volumes ...corev1.Volume) func(*appsv1.Deployment) {
+	return func(d *appsv1.Deployment) {
+		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, volumes...)
+	}
+}
+
+func withVolumeMounts(volumeMounts ...corev1.VolumeMount) func(*appsv1.Deployment) {
+	return func(d *appsv1.Deployment) {
+		for i, c := range d.Spec.Template.Spec.Containers {
+			c.VolumeMounts = append(c.VolumeMounts, volumeMounts...)
+			d.Spec.Template.Spec.Containers[i] = c
+		}
+	}
+}
+
+func withEnv(envs ...[]corev1.EnvVar) func(*appsv1.Deployment) {
+	return func(d *appsv1.Deployment) {
+		for i, c := range d.Spec.Template.Spec.Containers {
+			for _, env := range envs {
+				c.Env = append(c.Env, env...)
+			}
+			sort.Slice(c.Env, func(i, j int) bool {
+				return c.Env[i].Name < c.Env[j].Name
+			})
+			d.Spec.Template.Spec.Containers[i] = c
+		}
+	}
+}

--- a/pkg/reconciler/openshift/tektonaddon/extension.go
+++ b/pkg/reconciler/openshift/tektonaddon/extension.go
@@ -31,6 +31,9 @@ func OpenShiftExtension(context.Context) common.Extension {
 
 type openshiftExtension struct{}
 
+func (oe openshiftExtension) Append(ctx context.Context, m *mf.Manifest) error {
+	return nil
+}
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{}
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -38,6 +38,9 @@ type openshiftExtension struct {
 	operatorClientSet versioned.Interface
 }
 
+func (oe openshiftExtension) Append(ctx context.Context, m *mf.Manifest) error {
+	return nil
+}
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{}
 }

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -18,10 +18,13 @@ package tektonpipeline
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 )
 
 // NoPlatform "generates" a NilExtension
@@ -31,8 +34,19 @@ func OpenShiftExtension(context.Context) common.Extension {
 
 type openshiftExtension struct{}
 
+func (oe openshiftExtension) Append(ctx context.Context, m *mf.Manifest) error {
+	koDataDir := os.Getenv(common.KoEnvKey)
+	cm, err := common.Fetch(filepath.Join(koDataDir, "config-trusted-cabundle.yaml"))
+	if err != nil {
+		return err
+	}
+	*m = m.Append(cm)
+	return nil
+}
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{}
+	return []mf.Transformer{
+		occommon.ApplyTrustedCABundle,
+	}
 }
 func (oe openshiftExtension) PreReconcile(context.Context, v1alpha1.TektonComponent) error {
 	return nil

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -18,10 +18,13 @@ package tektontrigger
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 )
 
 // NoPlatform "generates" a NilExtension
@@ -31,8 +34,19 @@ func OpenShiftExtension(context.Context) common.Extension {
 
 type openshiftExtension struct{}
 
+func (oe openshiftExtension) Append(ctx context.Context, m *mf.Manifest) error {
+	koDataDir := os.Getenv(common.KoEnvKey)
+	cm, err := common.Fetch(filepath.Join(koDataDir, "config-trusted-cabundle.yaml"))
+	if err != nil {
+		return err
+	}
+	*m = m.Append(cm)
+	return nil
+}
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{}
+	return []mf.Transformer{
+		occommon.ApplyTrustedCABundle,
+	}
 }
 func (oe openshiftExtension) PreReconcile(context.Context, v1alpha1.TektonComponent) error {
 	return nil


### PR DESCRIPTION
# Changes

OpenShift, through OLM, allow us to *easily* get the custom trusted CA
bundle (a merge of user custom CA and internal CAs) in any namespace
through setting a label on a configmap (See
https://docs.openshift.com/container-platform/4.5/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki)

This changes does the following:

- Create the configmap and inject the ca-bundle into the controller(s) deployment.
- Create a `config-trusted-cabundle` on each new namespace (similar to
  what we do for the `pipeline` SA) so that it can be used in tasks.

- [x] Depends on #189 
- [x] Fix Unstructured errors
- [x] Need more tests
- [ ] *Maybe* handle rotation (or maybe do it in a follow-up)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Inject custom and internal CA for the OpenShift target
```
