### PR TITLE
[Openshift] Add TektonConfig CR autocreation

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/controller.go
+++ b/pkg/reconciler/openshift/tektonconfig/controller.go
@@ -18,8 +18,13 @@ package tektonconfig
 
 import (
 	"context"
+	"log"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 	k8s_ctrl "github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 )
@@ -27,5 +32,25 @@ import (
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	return k8s_ctrl.NewExtendedController(OpenShiftExtension)(ctx, cmw)
+	ctrl := k8s_ctrl.NewExtendedController(OpenShiftExtension)(ctx, cmw)
+	createCR(ctx)
+	return ctrl
+}
+
+func createCR(ctx context.Context) {
+	c := operatorclient.Get(ctx).OperatorV1alpha1()
+	tcCR := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: common.ConfigResourceName,
+		},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile: common.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: "openshift-pipelines",
+			},
+		},
+	}
+	if _, err := c.TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{}); err != nil {
+		log.Panic("Failed to autocreate TektonConfig with error: ", err)
+	}
 }


### PR DESCRIPTION
# Changes

For Openshift added `TektonConfig` with `profile: all` custom resource autocreation functionality so that when operator installed all the required components installed on Openshift without manual CR creation.

/cc @vdemeester @nikhil-thomas 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Add TektonConfig CR autocreation for Openshift
```