### PR TITLE
use --storage-driver as param as Env STORAGE_DRIVER

### DIFF
--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah-pr/buildah-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah-pr/buildah-pr-task.yaml
@@ -27,7 +27,7 @@ spec:
   params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah-pr/buildah-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah-pr/buildah-pr-v0-19-0-task.yaml
@@ -27,7 +27,7 @@ spec:
   params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-task.yaml
@@ -29,7 +29,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+    default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: overlay

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-v0-19-0-task.yaml
@@ -29,7 +29,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+    default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: overlay

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/openshift-client/openshift-client-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/openshift-client/openshift-client-task.yaml
@@ -40,7 +40,7 @@ spec:
         optional: true
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.4
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/openshift-client/openshift-client-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/openshift-client/openshift-client-v0-19-0-task.yaml
@@ -40,7 +40,7 @@ spec:
         optional: true
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.4
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3-pr/s2i-dotnet-3-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-dotnet-3/s2i-dotnet-3-v0-19-0-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-task.yaml
@@ -45,24 +45,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-task.yaml
@@ -43,7 +43,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -52,7 +52,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-v0-19-0-task.yaml
@@ -45,24 +45,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go-pr/s2i-go-pr-v0-19-0-task.yaml
@@ -43,7 +43,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -52,7 +52,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-task.yaml
@@ -44,24 +44,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-task.yaml
@@ -42,7 +42,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -51,7 +51,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-v0-19-0-task.yaml
@@ -44,24 +44,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-go/s2i-go-v0-19-0-task.yaml
@@ -42,7 +42,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -51,7 +51,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-task.yaml
@@ -90,7 +90,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -99,7 +99,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-task.yaml
@@ -92,24 +92,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-v0-19-0-task.yaml
@@ -90,7 +90,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -99,7 +99,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11-pr/s2i-java-11-pr-v0-19-0-task.yaml
@@ -92,24 +92,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
@@ -91,24 +91,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
@@ -89,7 +89,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -98,7 +98,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-v0-19-0-task.yaml
@@ -91,24 +91,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-11/s2i-java-11-v0-19-0-task.yaml
@@ -89,7 +89,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -98,7 +98,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-task.yaml
@@ -90,7 +90,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -99,7 +99,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-task.yaml
@@ -92,24 +92,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-v0-19-0-task.yaml
@@ -90,7 +90,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -99,7 +99,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8-pr/s2i-java-8-pr-v0-19-0-task.yaml
@@ -92,24 +92,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
@@ -91,24 +91,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
@@ -89,7 +89,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -98,7 +98,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-v0-19-0-task.yaml
@@ -91,24 +91,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-java-8/s2i-java-8-v0-19-0-task.yaml
@@ -89,7 +89,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -98,7 +98,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs-pr/s2i-nodejs-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-19-0-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl-pr/s2i-perl-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-perl/s2i-perl-v0-19-0-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php-pr/s2i-php-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-php/s2i-php-v0-19-0-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3-pr/s2i-python-3-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-python-3/s2i-python-3-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -58,7 +58,7 @@ spec:
       - name: STORAGE_DRIVER
         value: vfs
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-v0-19-0-task.yaml
@@ -49,24 +49,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby-pr/s2i-ruby-pr-v0-19-0-task.yaml
@@ -47,7 +47,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
@@ -56,7 +56,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-v0-19-0-task.yaml
@@ -46,7 +46,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       workingDir: /gen-source
       command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
@@ -55,7 +55,7 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: push
-      image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
+      image: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/s2i-ruby/s2i-ruby-v0-19-0-task.yaml
@@ -48,24 +48,18 @@ spec:
     - name: build
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: registry.redhat.io/rhel8/buildah@sha256:3e0377c19d3ad2bb4f6753120aac5d4fa228c2d3bade9f246220e0dd18d40fa1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}


### PR DESCRIPTION
with ENV
       - SROTAGE_DRIVER
       - vfs
build task fails with error
       error opening "/var/lib/shared/vfs-images/images.lock": no such file or directory
       level=error msg="exit status 125"
after passing as paramerter '--storage-driver=vfs' build task succed

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
