### PR TITLE
Add condition to verify existence of TektonConfig CR

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/controller.go
+++ b/pkg/reconciler/openshift/tektonconfig/controller.go
@@ -24,6 +24,7 @@ import (
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	k8s_ctrl "github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonconfig"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -51,6 +52,8 @@ func createCR(ctx context.Context) {
 		},
 	}
 	if _, err := c.TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{}); err != nil {
-		log.Panic("Failed to autocreate TektonConfig with error: ", err)
+		if !errors.IsAlreadyExists(err) {
+			log.Panic("Failed to autocreate TektonConfig with error: ", err)
+		}
 	}
 }


### PR DESCRIPTION
# Changes

Add condition to check existence of `TektonConfig` CR

/cc @vdemeester @nikhil-thomas 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```