### PR TITLE
Remove CRDs during uninstallation of owner component

### DIFF
--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -73,7 +73,7 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.Tekto
 
 // Uninstall removes all resources except CRDs, which are never deleted automatically.
 func Uninstall(ctx context.Context, manifest *mf.Manifest) error {
-	if err := manifest.Filter(mf.NoCRDs, mf.Not(mf.Any(role, rolebinding))).Delete(); err != nil {
+	if err := manifest.Filter(mf.Not(mf.Any(role, rolebinding))).Delete(); err != nil {
 		return fmt.Errorf("failed to remove non-crd/non-rbac resources: %w", err)
 	}
 	// Delete Roles last, as they may be useful for human operators to clean up.

--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -140,10 +140,9 @@ func TestUninstall(t *testing.T) {
 	crd := clusterScopedResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "test-crd")
 
 	// Deliberately mixing the order in the manifest.
-	in := []unstructured.Unstructured{deployment, role, roleBinding, clusterRole, clusterRoleBinding, crd}
+	in := []unstructured.Unstructured{crd, deployment, role, roleBinding, clusterRole, clusterRoleBinding}
 	// Expect things to be deleted, non-rbac resources first and then in reversed order.
-	// CRDs are not removed.
-	want := []unstructured.Unstructured{deployment, clusterRoleBinding, clusterRole, roleBinding, role}
+	want := []unstructured.Unstructured{deployment, crd, clusterRoleBinding, clusterRole, roleBinding, role}
 
 	client := &fakeClient{resourcesExist: true}
 	manifest, err := mf.ManifestFrom(mf.Slice(in), mf.UseClient(client))


### PR DESCRIPTION
Remove CRD fliter from uninstall mechanism

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```
