### PR TITLE
Improve seamless upgrade on openshift

### DIFF
--- a/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
+++ b/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
@@ -41,5 +41,49 @@ spec:
           args:
             - "-c"
             - |
+              #!/usr/bin/env bash
+
+              OWNER_KIND="TektonAddon"
+              OWNER_APIVERSION="operator.tekton.dev/v1alpha1"
+              OWNER_NAME="addon"
+              OWNER_UID=""
+
+              function findNewOwnerUID {
+                  OWNER_UID=$(kubectl get ${OWNER_KIND} ${OWNER_NAME} -o=jsonpath='{.metadata.uid}')
+                  echo OWNER_APIVERSION=$OWNER_APIVERSION
+                  echo OWNER_KIND=$OWNER_KIND
+                  echo OWNER_NAME=$OWNER_NAME
+                  echo OWNER_UID=$OWNER_UID
+              }
+
+              function checkOwner() {
+                  CT=${1}
+                  CONFIGOWNER=$(kubectl get clustertasks ${CT} -o=jsonpath='{.metadata.ownerReferences[?(@.kind=="Config")].name}')
+                  if [[ -n $CONFIGOWNER ]]; then
+                    return 0
+                  fi
+                  return 1
+              }
+
+              function updateOwnerReference() {
+                  CT=${1}
+                  kubectl patch clustertask ${CT} --type='json' -p='[{"op": "remove", "path": "/metadata/ownerReferences"}]'
+
+                  kubectl patch clustertask ${CT} --type='json' -p=\[\{\"op\":\ \"add\",\ \"path\":\ \"/metadata/ownerReferences\",\ \"value\":\ \[\{\"name\":\"${OWNER_NAME}\",\ \"kind\":\"${OWNER_KIND}\",\ \"apiVersion\":\ \"${OWNER_APIVERSION}\",\ \"blockOwnerDeletion\":\ \true,\ \"uid\":\ \ \"${OWNER_UID}\"\}\]\ \}\]
+              }
+
+              findNewOwnerUID
+
+              CLUSTERTASKS=$(kubectl get clustertasks -o=jsonpath='{.items[*].metadata.name}')
+
+              for CTASK in ${CLUSTERTASKS}; do
+                  if checkOwner ${CTASK}; then
+                    echo changing owner of ${CTASK}
+                    updateOwnerReference ${CTASK}
+                  fi
+              done
+
+              echo 'ownerReference reset'
               oc delete config.operator.tekton.dev cluster --ignore-not-found
+              echo 'old config cr deleted'
 ---

--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -71,7 +71,7 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.Tekto
 	return nil
 }
 
-// Uninstall removes all resources except CRDs, which are never deleted automatically.
+// Uninstall removes all resources
 func Uninstall(ctx context.Context, manifest *mf.Manifest) error {
 	if err := manifest.Filter(mf.Not(mf.Any(role, rolebinding))).Delete(); err != nil {
 		return fmt.Errorf("failed to remove non-crd/non-rbac resources: %w", err)


### PR DESCRIPTION
Add mechanism to retain old versioned clustertasks.
The `metadata.ownerReferences` of the version-named tasks
are set to the instance of TektonAddon.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
