### PR TITLE
Change image url in cleanup job on OpenShift

### DIFF
--- a/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
+++ b/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: delete-config-crd
-          image: quay.io/openshift/origin-cli:4.6.0
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           command:
             - "bash"
           args:
@@ -85,5 +85,6 @@ spec:
 
               echo 'ownerReference reset'
               oc delete config.operator.tekton.dev cluster --ignore-not-found
+              oc delete crd config.operator.tekton.dev
               echo 'old config cr deleted'
 ---


### PR DESCRIPTION
Set the openshfit-cli image from OpenShift internal registry
as the image for clean up job.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```
