### PR TITLE
Improve autoinstall mechanism for OpenShift

### DIFF
--- a/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
+++ b/cmd/openshift/kodata/tekton-config/99-clean-up/01-tekton-config-post-install-jobs.yaml
@@ -84,7 +84,11 @@ spec:
               done
 
               echo 'ownerReference reset'
-              oc delete config.operator.tekton.dev cluster --ignore-not-found
-              oc delete crd config.operator.tekton.dev
-              echo 'old config cr deleted'
+
+              # remove the config.operator.tekton.dev crd as the operator reconcilers will not remove it.
+              # this crd was added to the cluster by OLM with the past operator release(s)
+              # however, OLM will not remove this crd, so this job will handle it
+              # this should remove its instance as well (name: cluster, kind: Config, apiVersion: config.operator.tekton.dev/v1alpha1)
+              oc delete crd config.operator.tekton.dev --ignore-not-found
+              echo 'obsolete config.operator.tekton.dev instance deleted'
 ---

--- a/pkg/reconciler/openshift/tektonconfig/controller.go
+++ b/pkg/reconciler/openshift/tektonconfig/controller.go
@@ -18,14 +18,8 @@ package tektonconfig
 
 import (
 	"context"
-	"log"
 
-	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	k8s_ctrl "github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonconfig"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 )
@@ -34,26 +28,5 @@ import (
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	ctrl := k8s_ctrl.NewExtendedController(OpenShiftExtension)(ctx, cmw)
-	createCR(ctx)
 	return ctrl
-}
-
-func createCR(ctx context.Context) {
-	c := operatorclient.Get(ctx).OperatorV1alpha1()
-	tcCR := &v1alpha1.TektonConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ConfigResourceName,
-		},
-		Spec: v1alpha1.TektonConfigSpec{
-			Profile: common.ProfileAll,
-			CommonSpec: v1alpha1.CommonSpec{
-				TargetNamespace: "openshift-pipelines",
-			},
-		},
-	}
-	if _, err := c.TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{}); err != nil {
-		if !errors.IsAlreadyExists(err) {
-			log.Panic("Failed to autocreate TektonConfig with error: ", err)
-		}
-	}
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -18,6 +18,11 @@ package tektonconfig
 
 import (
 	"context"
+	"time"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
@@ -33,22 +38,43 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+const (
+	// RetryInterval specifies the time between two polls.
+	RetryInterval = 10 * time.Second
+
+	// RetryTimeout specifies the timeout for the function PollImmediate to
+	// reach a certain status.
+	RetryTimeout = 5 * time.Minute
+
+	// DefaultCRName specifies the default targetnamespaceto be used
+	// in autocreated TektonConfig instance
+	DefaultCRName = "config"
+
+	// DefaultTargetNamespace specifies the default targetnamespaceto be used
+	// in autocreated TektonConfig instance
+	DefaultTargetNamespace = "openshift-pipelines"
+)
+
 // NoPlatform "generates" a NilExtension
 func OpenShiftExtension(ctx context.Context) common.Extension {
+
 	logger := logging.FromContext(ctx)
 	mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
 	if err != nil {
-		logger.Fatalw("Error creating client from injected config", zap.Error(err))
+		logger.Fatalw("error creating client from injected config", zap.Error(err))
 	}
 	mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
 	manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
 	if err != nil {
-		logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		logger.Fatalw("error creating initial manifest", zap.Error(err))
 	}
-	return openshiftExtension{
+	ext := openshiftExtension{
 		operatorClientSet: operatorclient.Get(ctx),
 		manifest:          manifest,
 	}
+	// try to ensure that there is an instance of tektonConfig
+	ext.ensureTektonConfigInstance(ctx)
+	return ext
 }
 
 type openshiftExtension struct {
@@ -97,4 +123,66 @@ func RemoveDeprecatedConfigCRD(ctx context.Context, manifest *mf.Manifest, confi
 		return err
 	}
 	return nil
+}
+
+// try to ensure an instance of TektonConfig exists
+// if there is an error log error,and continue (an instance of TektonConfig will
+// then need to be created by the user to get OpenShift-Pipelines components installed
+func (oe openshiftExtension) ensureTektonConfigInstance(ctx context.Context) {
+	logger := logging.FromContext(ctx)
+	logger.Debug("ensuring tektonconfig instance")
+
+	waitErr := wait.PollImmediate(RetryInterval, RetryTimeout, func() (bool, error) {
+		//note: the code in this block will be retired until
+		// an error is returned, or
+		// 'true' is returned, or
+		// timeout
+		instance, err := oe.operatorClientSet.
+			OperatorV1alpha1().
+			TektonConfigs().Get(context.TODO(), DefaultCRName, metav1.GetOptions{})
+		if err == nil {
+			if !instance.GetDeletionTimestamp().IsZero() {
+				// log deleting timestamp error and retry
+				logger.Errorf("deletionTimestamp is set on existing Tektonconfig instance, Name: %w", instance.GetName())
+				return false, nil
+			}
+			return true, nil
+		}
+		if !apierrs.IsNotFound(err) {
+			//log error and retry
+			logger.Errorf("error getting Tektonconfig, Name: ", instance.GetName())
+			return false, nil
+		}
+		err = oe.createTektonConfigInstance()
+		if err != nil {
+			//log error and retry
+			logger.Errorf("error creating Tektonconfig instance, Name: ", instance.GetName())
+			return false, nil
+		}
+		// even if there is no error after create,
+		// loop again to ensure the create is successful with a 'get; api call
+		return false, nil
+	})
+	if waitErr != nil {
+		// log error and continue
+		logger.Error("error ensuring instance of tektonconfig, check retry logs above for more details, %w", waitErr)
+		logger.Info("an instance of TektonConfig need to be created by the user to get OpenShift-Pipelines components installed")
+	}
+}
+
+func (oe openshiftExtension) createTektonConfigInstance() error {
+	tcCR := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: common.ConfigResourceName,
+		},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile: common.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: DefaultTargetNamespace,
+			},
+		},
+	}
+	_, err := oe.operatorClientSet.OperatorV1alpha1().
+		TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{})
+	return err
 }


### PR DESCRIPTION
Add a waitRetry mechansim in the  `auto-create instance` part of
OpenShift extension in TektonConfig reconciler

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
