### PR TITLE
fix buildah test failure

### DIFF
--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-task.yaml
@@ -32,7 +32,7 @@ spec:
     default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
-    default: overlay
+    default: vfs
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
@@ -71,8 +71,6 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
 
   - name: push
     image: $(params.BUILDER_IMAGE)
@@ -85,8 +83,6 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)

--- a/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-v0-19-0-task.yaml
+++ b/cmd/openshift/kodata/tekton-addon/0.0.1/02-clustertasks/buildah/buildah-v0-19-0-task.yaml
@@ -32,7 +32,7 @@ spec:
     default: registry.redhat.io/rhel8/buildah@sha256:785f0d039113ba978c4ee467f0554de7b72411b5c555a16abe60062759799497
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
-    default: overlay
+    default: vfs
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
@@ -71,8 +71,6 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
 
   - name: push
     image: $(params.BUILDER_IMAGE)
@@ -85,8 +83,6 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)


### PR DESCRIPTION
this removed securityContext.privileged
set default STROAGE_DRIVER value to vfs

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
