### PR TITLE
Handle `manifestival.ManifestFrom` errors

### DIFF
--- a/pkg/reconciler/kubernetes/tektonconfig/controller.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/controller.go
@@ -56,7 +56,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
 
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -59,7 +59,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
 
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -57,8 +57,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		// FIXME(vdemeester) why ignoring error ?
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
 
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -59,7 +59,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
 
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,

--- a/pkg/reconciler/openshift/rbac/controller.go
+++ b/pkg/reconciler/openshift/rbac/controller.go
@@ -37,7 +37,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
+
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),

--- a/pkg/reconciler/openshift/tektonaddon/controller.go
+++ b/pkg/reconciler/openshift/tektonaddon/controller.go
@@ -57,7 +57,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
 		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+		if err != nil {
+			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		}
 
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,


### PR DESCRIPTION
# Changes

This commit handles errors from `manifestival.ManifestFrom` method which
were being ignored till now.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```