### PR TITLE
Fix e2e tests script failure on OpenShift

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -30,9 +30,12 @@ function install_operator_resources() {
 
   make TARGET=${TARGET:-kubernetes} apply || fail_test "Tekton Operator installation failed"
 
+  OPERATOR_NAMESPACE="tekton-operator"
+  [[ "${TARGET}" == "openshift" ]] && OPERATOR_NAMESPACE="openshift-operators"
+
   # Wait for pods to be running in the namespaces we are deploying to
   # TODO: parameterize namespace, operator can run in a namespace different from the namespace where tektonpipelines is installed
-  wait_until_pods_running tekton-operator || fail_test "Tekton Operator controller did not come up"
+  wait_until_pods_running ${OPERATOR_NAMESPACE} || fail_test "Tekton Operator controller did not come up"
 
   # Make sure that everything is cleaned up in the current namespace.
   for res in tektonpipelines tektontriggers tektondashboards; do


### PR DESCRIPTION
Set operator namespace in deployment validation as `openshift-operators`
when tests are run on openshift.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```