### PR TITLE
Modify 0.19.0 pipeline release.yaml

### DIFF
--- a/cmd/openshift/kodata/tekton-pipeline/0.19.0/tektoncd-pipeline-v0.19.0.yaml
+++ b/cmd/openshift/kodata/tekton-pipeline/0.19.0/tektoncd-pipeline-v0.19.0.yaml
@@ -1823,7 +1823,7 @@ metadata:
     # labels below are related to istio and should not be used for resource lookup
     version: v0.19.0
 spec:
-  minAvailable: 80%
+  minAvailable: 0%
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook


### PR DESCRIPTION
Set `spec.minimuxAvailable: 0%` in the podDisruptionPolicy of tekton-webhook.

It was initially 80%. This will make draining nodes impossible as the replica count of
pipeline webhook deployment is `1`.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
- set 0% in spec.minimumAvailable in the podDisruptionPolicy of tekton-webhook (pipeline release v0.19.0).
```