### PR TITLE
Add label on tekton namespace to avoid proxy webhook

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -140,6 +140,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	extra := []mf.Transformer{
 		common.ApplyProxySettings,
 		common.DeploymentImages(images),
+		common.InjectLabelOnNamespace(),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)

--- a/pkg/reconciler/proxy/proxy.go
+++ b/pkg/reconciler/proxy/proxy.go
@@ -149,7 +149,7 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 		webhook.Webhooks[i].Rules = rules
 		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{{
-				Key:      "webhooks.knative.dev/exclude",
+				Key:      "operator.tekton.dev/disable-proxy",
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			}, {
 				// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.


### PR DESCRIPTION
This will add a label on tekton namespace which will
disable proxy webhook on these namespace and
as a good practice it will not cause issue during installation
and restart

Adds a transformer to inject label on namespace

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

For pull requests with a release note:

```release-note
Fix node restart and restart failures
```