### PR TITLE
Add Image Replacement mechanism for Cleanup Job

### DIFF
--- a/config/openshift/operator.yaml
+++ b/config/openshift/operator.yaml
@@ -22,3 +22,6 @@ spec:
       containers:
         - name: tekton-operator
           image: ko://github.com/tektoncd/operator/cmd/openshift
+          env:
+          - name: IMAGE_TP12_SEAMLESS_DELETE_CONFIG_CRD
+            value: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/pkg/reconciler/openshift/tektonconfig/extension/openshift_cleanup.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/openshift_cleanup.go
@@ -12,6 +12,10 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+const (
+	TP12SeamlessPrefix = "IMAGE_TP12_SEAMLESS_"
+)
+
 func AppendCleanupTarget(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.TektonComponent) error {
 	manifestPath := filepath.Join(common.ComponentDir(instance), "99-clean-up")
 	m, err := common.Fetch(manifestPath)
@@ -23,7 +27,9 @@ func AppendCleanupTarget(ctx context.Context, manifest *mf.Manifest, instance v1
 }
 
 func CleanupTransforms(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.TektonComponent) error {
-	return common.Transform(ctx, manifest, instance)
+	images := common.ToLowerCaseKeys(common.ImagesFromEnv(TP12SeamlessPrefix))
+	tf := common.JobImages(images)
+	return common.Transform(ctx, manifest, instance, tf)
 }
 
 func RunCleanup(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.TektonComponent) error {


### PR DESCRIPTION
Add Image Replacement mechanism for cleanup job for
OpenShift TP12 to TP13 seamless install

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```
