### PR TITLE
Enable usage of tektoncd catalog tasks for s390x and ppc6le in Openshift operator

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
@@ -76,11 +75,11 @@ var _ tektonaddonreconciler.Interface = (*Reconciler)(nil)
 var _ tektonaddonreconciler.Finalizer = (*Reconciler)(nil)
 
 var communityResourceURLs = []string{
-	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.1/jib-maven.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.2/jib-maven.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/maven/0.1/maven.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/tkn/0.1/tkn.yaml",
-	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml",
-	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.2/helm-upgrade-from-source.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-cli/0.1/git-cli.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/pull-request/0.1/pull-request.yaml",
@@ -254,9 +253,6 @@ func ignoreNotFound(err error) error {
 // appendCommunityTarget mutates the passed manifest by appending one
 // appropriate for the passed TektonComponent
 func (r *Reconciler) appendCommunityTarget(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
-	if runtime.GOARCH == "ppc64le" || runtime.GOARCH == "s390x" {
-		return nil
-	}
 	urls := strings.Join(communityResourceURLs, ",")
 	m, err := mf.ManifestFrom(mf.Path(urls))
 	if err != nil {


### PR DESCRIPTION

# Changes

The catalog tasks addition was disabled for s390x and ppc6le because tasks themselves failed for non Intel architectures.
Now all tasks from the list can be executed on s390x and ppc64le (in some case container images are multi-arched, for other cases there is special parameter to specify custom image specific to architecture).

For several tasks version has to be bumped from 0.1 to 0.2, because custom image parameter is supported only in version 0.2

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Enable usage of tektoncd catalog tasks for s390x and ppc6le in Openshift operator
```
