### PR TITLE
Add option to run tests on non-Intel architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DATE         ?= $(shell date +%FT%T%z)
 KO_DATA_PATH  = $(shell pwd)/cmd/$(TARGET)/kodata
 TARGET        = kubernetes
 CR            = config/default
+PLATFORM := $(if $(PLATFORM),--platform $(PLATFORM))
 
 GOLANGCI_VERSION  = v1.30.0
 
@@ -67,7 +68,7 @@ bin/%: cmd/% FORCE
 
 .PHONY: apply
 apply: | $(KO) $(KUSTOMIZE) ; $(info $(M) ko apply on $(TARGET)) @ ## Apply config to the current cluster
-	$Q $(KUSTOMIZE) build config/$(TARGET) | $(KO) apply -f -
+	$Q $(KUSTOMIZE) build config/$(TARGET) | $(KO) apply $(PLATFORM) -f -
 
 .PHONY: apply-cr
 apply-cr: | ; $(info $(M) apply CRs on $(TARGET)) @ ## Apply the CRs to the current cluster

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,6 +21,9 @@ source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
 TARGET=${TARGET:-kubernetes}
+# In case if KUBECONFIG variable is specified, it will be used for `go test`
+KUBECONFIG_PARAM=${KUBECONFIG:+"--kubeconfig $KUBECONFIG"}
+
 echo "Running tests on ${TARGET}"
 
 [[ -z ${E2E_DEBUG} ]] && initialize $@
@@ -30,8 +33,8 @@ header "Setting up environment"
 install_operator_resources
 
 header "Running Go e2e tests"
-go_test_e2e -timeout=20m ./test/e2e/common || failed=1
-go_test_e2e -timeout=20m ./test/e2e/${TARGET} || failed=1
+go_test_e2e -timeout=20m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
+go_test_e2e -timeout=20m ./test/e2e/${TARGET} ${KUBECONFIG_PARAM} || failed=1
 
 (( failed )) && fail_test
 success


### PR DESCRIPTION
# Changes
At this moment tests for operator can be executed with default `e2e-tests.sh` script only for amd64 architecture, because operator image during setup process is built for amd64 by default. Addition of the PLATFORM env variable to Makefile allows to build operator image for needed architecture via `--platform` parameter in ko tool.
In case if PLATFORM variable is not specified, there will be current behaviour.

Also `--kubeconfig` parameter support is added to the test script, this parameter is used when tests are executed not on default k8s cluster.
If KUBECONFIG env variable is not specified, `--kubeconfig` parameter is not used.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
