### PR TITLE
openshift: move pipeline sa to restricted instead of anyuid

### DIFF
--- a/pkg/reconciler/openshift/rbac/rbac.go
+++ b/pkg/reconciler/openshift/rbac/rbac.go
@@ -40,7 +40,7 @@ type Reconciler struct {
 var _ nsreconciler.Interface = (*Reconciler)(nil)
 
 const (
-	pipelineAnyuid           = "pipeline-anyuid"
+	pipelineRestricted       = "pipeline-restricted"
 	pipelineSA               = "pipeline"
 	serviceCABundleCofigMap  = "config-service-cabundle"
 	trustedCABundleConfigMap = "config-trusted-cabundle"
@@ -191,17 +191,17 @@ func (r *Reconciler) createRoleBinding(ctx context.Context, sa *corev1.ServiceAc
 func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("finding cluster role pipeline-anyuid")
+	logger.Info("finding cluster role pipeline-restricted")
 
 	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: pipelineAnyuid},
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRestricted},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
 					"security.openshift.io",
 				},
 				ResourceNames: []string{
-					"anyuid",
+					"restricted",
 				},
 				Resources: []string{
 					"securitycontextconstraints",
@@ -214,7 +214,7 @@ func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 	}
 
 	rbacClient := r.kubeClientSet.RbacV1()
-	_, err := rbacClient.ClusterRoles().Get(ctx, pipelineAnyuid, metav1.GetOptions{})
+	_, err := rbacClient.ClusterRoles().Get(ctx, pipelineRestricted, metav1.GetOptions{})
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -229,17 +229,17 @@ func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 func (r *Reconciler) ensureSCCRoleBinding(ctx context.Context, sa *corev1.ServiceAccount) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("finding role-binding pipeline-anyuid")
+	logger.Info("finding role-binding pipeline-restricted")
 	rbacClient := r.kubeClientSet.RbacV1()
-	pipelineRB, rbErr := rbacClient.RoleBindings(sa.Namespace).Get(ctx, pipelineAnyuid, metav1.GetOptions{})
+	pipelineRB, rbErr := rbacClient.RoleBindings(sa.Namespace).Get(ctx, pipelineRestricted, metav1.GetOptions{})
 	if rbErr != nil && !errors.IsNotFound(rbErr) {
-		logger.Error(rbErr, "rbac pipeline-anyuid get error")
+		logger.Error(rbErr, "rbac pipeline-restricted get error")
 		return rbErr
 	}
 
-	logger.Info("finding cluster role pipeline-anyuid")
-	if _, err := rbacClient.ClusterRoles().Get(ctx, pipelineAnyuid, metav1.GetOptions{}); err != nil {
-		logger.Error(err, "finding pipeline-anyuid cluster role failed")
+	logger.Info("finding cluster role pipeline-restricted")
+	if _, err := rbacClient.ClusterRoles().Get(ctx, pipelineRestricted, metav1.GetOptions{}); err != nil {
+		logger.Error(err, "finding pipeline-restricted cluster role failed")
 		return err
 	}
 
@@ -254,17 +254,17 @@ func (r *Reconciler) ensureSCCRoleBinding(ctx context.Context, sa *corev1.Servic
 func (r *Reconciler) createSCCRoleBinding(ctx context.Context, sa *corev1.ServiceAccount) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("create new rolebinding pipeline-anyuid")
+	logger.Info("create new rolebinding pipeline-restricted")
 	rbacClient := r.kubeClientSet.RbacV1()
 	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: pipelineAnyuid, Namespace: sa.Namespace},
-		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: pipelineAnyuid},
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRestricted, Namespace: sa.Namespace},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: pipelineRestricted},
 		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: sa.Name, Namespace: sa.Namespace}},
 	}
 
 	_, err := rbacClient.RoleBindings(sa.Namespace).Create(ctx, rb, metav1.CreateOptions{})
 	if err != nil {
-		logger.Error(err, "creation of pipeline-anyuid rb failed")
+		logger.Error(err, "creation of pipeline-restricted rb failed")
 	}
 	return err
 }


### PR DESCRIPTION

# Changes

By default, the pipeline sa should be as limited as possible. As it is
possible to use buildah task with any uid, it should be possible to
run those with restricted.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/hold
/cc @pradeepitm12 @nikhil-thomas @savitaashture


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
openshift: move pipeline sa to restricted (less privileges)
```
