### PR TITLE
Add clustertriggerbinding for GitLab

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/01-clustertriggerbindings/gitlab.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/01-clustertriggerbindings/gitlab.yaml
@@ -1,0 +1,107 @@
+# pull/merge_request event https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-mergereq
+spec:
+  params:
+  - name: git-repo-url
+    value: $(body.project.git_http_url)
+  - name: mergereq-sha
+    value: $(body.object_attributes.last_commit.id)
+  - name: mergereq-action
+    value: $(body.object_attributes.action)
+  - name: mergereq-number
+    value: $(body.object_attributes.iid)
+  - name: mergereq-repo-name
+    value: $(body.repository.name)
+  - name: mergereq-url
+    value: $(body.object_attributes.url)
+  - name: mergereq-title
+    value: $(body.object_attributes.title)
+
+# push events https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-push
+spec:
+  params:
+  - name: git-revision
+    value: $(body.checkout_sha)
+  - name: git-commit-message
+    value: $(body.commits[0].message)
+  - name: git-repo-url
+    value: $(body.repository.git_http_url)
+  - name: git-repo-name
+    value: $(body.repository.name)
+  - name: pusher-name
+    value: $(body.user_name)
+
+# comment events are done at commit, merge_request, issue and code snippet for more info https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#comment-events
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-review-comment-on-issues
+spec:
+  params:
+  - name: issue-url
+    value: $(body.issue.url)
+  - name: issue-title
+    value: $(body.issue.title)
+  - name: issue-comment-link
+    value: $(body.object_attributes.url)
+  - name: issue-owner
+    value: $(body.user.name)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-review-comment-on-mergerequest
+spec:
+  params:
+    - name: mergereq-url
+      value: $(body.merge_request.url)
+    - name: comment-description
+      value: $(body.object_attributes.description)
+    - name: comment-url
+      value: $(body.object_attributes.url)
+    - name: mr-owner
+      value: $(body.user.name)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-review-comment-on-commit
+spec:
+  params:
+    - name: commit-url
+      value: $(body.commit.url)
+    - name: comment-description
+      value: $(body.object_attributes.description)
+    - name: comment-url
+      value: $(body.object_attributes.url)
+    - name: commit-owner
+      value: $(body.user.name)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: gitlab-review-comment-on-snippet
+spec:
+  params:
+    - name: snippet-comment-description
+      value: $(body.object_attributes.description)
+    - name: snippet-comment-url
+      value: $(body.object_attributes.url)
+    - name: snippet-title
+      value: $(body.snippet.title)
+    - name: snippet-type
+      value: $(body.snippet.type)
+    - name: snippet-owner
+      value: $(body.user.name)


### PR DESCRIPTION
# Changes

Added ClusterTriggerBinding for GitLab

/cc @vdemeester @nikhil-thomas @khrm 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Installing Operator by default creates Gitlab ClusterTriggerBinding on Openshift 
```