### PR TITLE
Fix operator nightly payload version naming

### DIFF
--- a/tekton/overlays/nightly-releases/fetch-nightly-components.yaml
+++ b/tekton/overlays/nightly-releases/fetch-nightly-components.yaml
@@ -19,7 +19,7 @@ spec:
       for component in ${components}; do
         componentPath=cmd/kubernetes/operator/kodata/tekton-${component}
         rm -rf ${componentPath}/*
-        mkdir -p ${componentPath}/nightly
+        mkdir -p ${componentPath}/0.0.0-nightly
         if [[ ${component} == "dashboard" ]]; then
           curl -L -o ${componentPath}/nightly/release.notags.yaml https://storage.googleapis.com/tekton-releases-nightly/${component}/latest/tekton-dashboard-release.yaml
           sed -i '/aggregationRule/,+3d' ${componentPath}/nightly/release.notags.yaml


### PR DESCRIPTION
Use a valid semver version `0.0.0-nightly` for now. We can
find a better alternative later.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```