### PR TITLE
Add kn-apply ct and install kn related ct only on amd64

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/02-clustertasks/kn-apply/kn-apply-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/02-clustertasks/kn-apply/kn-apply-task.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: kn-apply
+  labels:
+    app.kubernetes.io/version: "1.4.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: cli
+spec:
+  description: >-
+    This task deploys a given image to a Knative Service.
+
+    It uses `kn service apply` to create or update given knative service.
+  params:
+    - name: KN_IMAGE
+      description: kn CLI container image to run this task
+      default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:e912d6731df784ad030f8e26f012036acadd6aad0f2f25834575dd0c8573cad1
+    - name: SERVICE
+      description: Knative service name
+    - name: IMAGE
+      description: Image to deploy
+  steps:
+    - name: kn
+      image: "$(params.KN_IMAGE)"
+      command: ["/ko-app/kn"]
+      args: ["service", "apply", "$(params.SERVICE)", "--image", "$(params.IMAGE)"]

--- a/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/02-clustertasks/kn-apply/kn-apply-v0-19-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/0.0.1/addons/02-clustertasks/kn-apply/kn-apply-v0-19-0-task.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: kn-apply-v0-19-0
+  labels:
+    app.kubernetes.io/version: "1.4.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: cli
+spec:
+  description: >-
+    This task deploys a given image to a Knative Service.
+
+    It uses `kn service apply` to create or update given knative service.
+  params:
+    - name: KN_IMAGE
+      description: kn CLI container image to run this task
+      default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:e912d6731df784ad030f8e26f012036acadd6aad0f2f25834575dd0c8573cad1
+    - name: SERVICE
+      description: Knative service name
+    - name: IMAGE
+      description: Image to deploy
+  steps:
+    - name: kn
+      image: "$(params.KN_IMAGE)"
+      command: ["/ko-app/kn"]
+      args: ["service", "apply", "$(params.SERVICE)", "--image", "$(params.IMAGE)"]

--- a/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates.go
@@ -18,6 +18,7 @@ package tektonaddon
 
 import (
 	"path"
+	"runtime"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -73,8 +74,14 @@ func GeneratePipelineTemplates(templatePath string, manifest *mf.Manifest) error
 	workspacedTaskGenerators := []taskGenerator{
 		&pipeline{environment: "openshift", nameSuffix: "", generateDeployTask: openshiftDeployTask},
 		&pipeline{environment: "kubernetes", nameSuffix: "-deployment", generateDeployTask: kubernetesDeployTask},
-		&pipeline{environment: "knative", nameSuffix: "-knative", generateDeployTask: knativeDeployTask},
 	}
+
+	if runtime.GOARCH == "amd64" {
+		workspacedTaskGenerators = append(workspacedTaskGenerators,
+			&pipeline{environment: "knative", nameSuffix: "-knative", generateDeployTask: knativeDeployTask},
+		)
+	}
+
 	wps, err := generateBasePipeline(workspacedTemplate, workspacedTaskGenerators, !usingPipelineResource)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will install kn-apply clustertask as part of addons
and as kn images in not available for ppc64le and s390x arch
so kn related clustertasks will not be installed on these arch
and also knative pipelines will be skipped on these arch

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add kn-apply ct and install kn related ct only on amd64
```