### PR TITLE
Add ca cert volume mounts to taskrun pods

### DIFF
--- a/pkg/reconciler/proxy/proxy_test.go
+++ b/pkg/reconciler/proxy/proxy_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestUpdateVolume(t *testing.T) {
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{},
+			Containers: []v1.Container{
+				{
+					Name:  "testc",
+					Image: "testi",
+				},
+			},
+		},
+	}
+	podUpdated := updateVolume(pod, "testv", "testcm", "testkey")
+	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 1)
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "testv")
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "testcm")
+	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 1)
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].Name, "testv")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].SubPath, "testkey")
+}


### PR DESCRIPTION
This will add the volume mounts for internal registry cert
and https proxy cert to the pods created by taskrun.
Configmap of these certs was created already during installation
This will mount them in pod if the configmap exist in namespace

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add ca cert volume mounts to taskrun pods
```
