### PR TITLE
Fix e2e compilation issue for Openshift

### DIFF
--- a/test/e2e/openshift/rbac_test.go
+++ b/test/e2e/openshift/rbac_test.go
@@ -41,7 +41,7 @@ func TestRBACReconciler(t *testing.T) {
 	defer utils.TearDownNamespace(clients, crNames.Namespace)
 
 	//// Create a Test Namespace
-	if _, err := resources.EnsureTestNamespaceExists(clients.KubeClient, crNames.Namespace); err != nil {
+	if _, err := resources.EnsureTestNamespaceExists(clients, crNames.Namespace); err != nil {
 		t.Fatalf("failed to create test namespace: %s, %q", crNames.Namespace, err)
 	}
 

--- a/test/resources/rbac.go
+++ b/test/resources/rbac.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/client-go/kubernetes"
-
 	corev1 "k8s.io/api/core/v1"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -18,16 +16,16 @@ import (
 )
 
 // EnsureTestNamespaceExists creates a Test Namespace
-func EnsureTestNamespaceExists(clientSet *kubernetes.Clientset, name string) (*corev1.Namespace, error) {
+func EnsureTestNamespaceExists(clients *utils.Clients, name string) (*corev1.Namespace, error) {
 	// If this function is called by the upgrade tests, we only create the custom resource, if it does not exist.
-	ns, err := clientSet.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	ns, err := clients.KubeClient.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		}
-		return clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		return clients.KubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	}
 	return ns, err
 }


### PR DESCRIPTION
# Changes

/cc @nikhil-thomas @pradeepitm12 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```