### PR TITLE
Change base image for openshift platform

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,4 @@
 defaultBaseImage: gcr.io/distroless/static:nonroot
+baseImageOverrides:
+  github.com/tektoncd/operator/cmd/openshift/operator: registry.access.redhat.com/ubi8/ubi-minimal
+  github.com/tektoncd/operator/cmd/openshift/webhook: registry.access.redhat.com/ubi8/ubi-minimal


### PR DESCRIPTION
This will change the base image used for image builds
issue of webhook image failing on openshift because of non root
and require 65532 user is also fixed

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Change base image for openshift platform
```