### PR TITLE
Add docs link for v0.22.0-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ on any Kubernetes Cluster.
 | Version | Docs |
 | ------- | ---- |
 | [HEAD](/README.md) | [Docs @ HEAD](/docs/README.md) |
+| [v0.22.0-1](https://github.com/tektoncd/operator/releases/tag/v0.22.0-1) | [Docs @ v0.22.0-1](https://github.com/tektoncd/operator/tree/v0.22.0-1/docs) | [Examples @ v0.22.0](https://github.com/tektoncd/pipeline/tree/v0.22.0/examples#examples) |
 | [v0.21.0-1](https://github.com/tektoncd/operator/releases/tag/v0.21.0-1) | [Docs @ v0.21.0-1](https://github.com/tektoncd/operator/tree/v0.21.0-1/docs) | [Examples @ v0.21.0](https://github.com/tektoncd/pipeline/tree/v0.21.0/examples#examples) |


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

The link to v0.22 docs is missing from the table in the main README,
so adding it there. Following the same convention as other projects
to keep the most recent links on the top of the table.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

/kind documentation