### PR TITLE
[openshift] Add mechamism to cleanup RBAC from TP1.2 builds

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension/cleanup-clusterrole-rolebinding.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/cleanup-clusterrole-rolebinding.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	cleanupClusterRoleName = "pipeline-anyuid"
-	cleanupRoleBindingName = "pipeline-anyuid"
+	cleanupClusterRoleName       = "pipeline-anyuid"
+	cleanupRoleBindingName       = "pipeline-anyuid"
+	cleanupClusterRoleTP12       = "privileged-scc-role"
+	clenupClusterRoleBindingTP12 = "openshift-pipelines-privileged"
 )
 
 func RbacCleanup(ctx context.Context, client kubernetes.Interface) error {
@@ -55,6 +57,11 @@ func RbacCleanup(ctx context.Context, client kubernetes.Interface) error {
 		return err
 	}
 
+	err = cleanUpTP12Rbac(ctx, rbacClient)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -75,5 +82,22 @@ func cleanUpClusterRole(ctx context.Context, rbacClient v1.RbacV1Interface) erro
 			return err
 		}
 	}
+	return nil
+}
+
+func cleanUpTP12Rbac(ctx context.Context, rbacClient v1.RbacV1Interface) error {
+	err := rbacClient.ClusterRoles().Delete(ctx, cleanupClusterRoleTP12, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	err = rbacClient.ClusterRoleBindings().Delete(ctx, clenupClusterRoleBindingTP12, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Add delete k8s api call to delete:

- `ClusterRolebinding: openshift-pipelines-privileged`
- `ClusterRole: privileged-scc-role`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```