### PR TITLE
Autocreates TektonConfig Instance for all platforms with `all` profile

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - 300-operator_v1alpha1_addon_crd.yaml
 - 300-operator_v1alpha1_config_crd.yaml
 - config-logging.yaml
+- tekton-config-defaults.yaml
 - role.yaml
 - role_binding.yaml
 - service_account.yaml

--- a/config/base/operator.yaml
+++ b/config/base/operator.yaml
@@ -46,3 +46,13 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "tekton-operator"
+            - name: AUTOINSTALL_COMPONENTS
+              valueFrom:
+                configMapKeyRef:
+                  name: tekton-config-defaults
+                  key: AUTOINSTALL_COMPONENTS
+            - name: DEFAULT_TARGET_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: tekton-config-defaults
+                  key: DEFAULT_TARGET_NAMESPACE

--- a/config/base/tekton-config-defaults.yaml
+++ b/config/base/tekton-config-defaults.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2021 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,26 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-namespace: openshift-operators
 
-bases:
-- ../base/
-patches:
-- path: operator.yaml
-  target:
-    kind: Deployment
-    name: tekton-operator
-- path: role.yaml
-  target:
-    kind: ClusterRole
-    name: tekton-operator
-- path: role_binding.yaml
-  target:
-    kind: ClusterRoleBinding
-    name: tekton-operator
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-config-defaults
+  labels:
+    operator.tekton.dev/release: devel
 
-configMapGenerator:
-- name: tekton-config-defaults
-  literals:
-  - DEFAULT_TARGET_NAMESPACE=openshift-pipelines
-  behavior: merge
+data:
+  AUTOINSTALL_COMPONENTS: "true"
+  DEFAULT_TARGET_NAMESPACE: ""

--- a/config/kubernetes/kustomization.yaml
+++ b/config/kubernetes/kustomization.yaml
@@ -20,3 +20,9 @@ patches:
   target:
     kind: Deployment
     name: tekton-operator
+
+configMapGenerator:
+- name: tekton-config-defaults
+  literals:
+  - DEFAULT_TARGET_NAMESPACE=tekton-pipelines
+  behavior: merge

--- a/go.sum
+++ b/go.sum
@@ -789,7 +789,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/tektoncd/pipeline v0.20.1-0.20210203144343-1b7a37f0d21d/go.mod h1:GwdfGGt/5VhZL8JvJu8kFz8friKufcJ/TJkJmK6uc0U=
 github.com/tektoncd/pipeline v0.23.0 h1:nOyk1KqXTZBlqRx20YrITUh7F/uDI2bXMfHedIxIzEY=
 github.com/tektoncd/pipeline v0.23.0/go.mod h1:QcD1kMaXVIHA/V7RCi4NQUCR6z3plBVjmglRbpS71FQ=
-github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5 h1:Y2Gd3X79zqvCd6AdiWyi/pnSewSkLxKygpvXNFXwscg=
 github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9 h1:ZLPo8/vilaxvpdvvdd9ZgIhhQJPkHyS5GeKK8UH4/Yo=
 github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=

--- a/pkg/reconciler/kubernetes/tektonconfig/controller.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/controller.go
@@ -18,6 +18,7 @@ package tektonconfig
 
 import (
 	"context"
+	"os"
 
 	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
@@ -78,6 +79,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("TektonConfig")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
+
+		if os.Getenv("AUTOINSTALL_COMPONENTS") == "true" {
+			// try to ensure that there is an instance of tektonConfig
+			newTektonConfig(operatorclient.Get(ctx), kubeclient.Get(ctx), manifest).ensureInstance(ctx)
+		}
 
 		return impl
 	}

--- a/pkg/reconciler/kubernetes/tektonconfig/instance.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/instance.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"os"
+	"time"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// RetryInterval specifies the time between two polls.
+	RetryInterval = 10 * time.Second
+
+	// RetryTimeout specifies the timeout for the function PollImmediate to
+	// reach a certain status.
+	RetryTimeout = 5 * time.Minute
+
+	// DefaultCRName specifies the default targetnamespaceto be used
+	// in autocreated TektonConfig instance
+	DefaultCRName = "config"
+)
+
+type tektonConfig struct {
+	operatorClientSet versioned.Interface
+	kubeClientSet     kubernetes.Interface
+	manifest          mf.Manifest
+	namespace         string
+}
+
+func newTektonConfig(operatorClientSet versioned.Interface, kubeClientSet kubernetes.Interface,
+	manifest mf.Manifest) tektonConfig {
+
+	return tektonConfig{
+		operatorClientSet: operatorClientSet,
+		kubeClientSet:     kubeClientSet,
+		manifest:          manifest,
+		namespace:         os.Getenv("DEFAULT_TARGET_NAMESPACE"),
+	}
+}
+
+// try to ensure an instance of TektonConfig exists
+// if there is an error log error,and continue (an instance of TektonConfig will
+// then need to be created by the user to get Tekton Pipelines components installed
+func (tc tektonConfig) ensureInstance(ctx context.Context) {
+	logger := logging.FromContext(ctx)
+	logger.Debug("ensuring tektonconfig instance")
+
+	waitErr := wait.PollImmediate(RetryInterval, RetryTimeout, func() (bool, error) {
+		//note: the code in this block will be retired until
+		// an error is returned, or
+		// 'true' is returned, or
+		// timeout
+		instance, err := tc.operatorClientSet.
+			OperatorV1alpha1().
+			TektonConfigs().Get(context.TODO(), DefaultCRName, metav1.GetOptions{})
+		if err == nil {
+			if !instance.GetDeletionTimestamp().IsZero() {
+				// log deleting timestamp error and retry
+				logger.Errorf("deletionTimestamp is set on existing Tektonconfig instance, Name: %w", instance.GetName())
+				return false, nil
+			}
+			return true, nil
+		}
+		if !apierrs.IsNotFound(err) {
+			//log error and retry
+			logger.Errorf("error getting Tektonconfig, Name: ", instance.GetName())
+			return false, nil
+		}
+		err = tc.createInstance()
+		if err != nil {
+			//log error and retry
+			logger.Errorf("error creating Tektonconfig instance, Name: ", instance.GetName())
+			return false, nil
+		}
+		// even if there is no error after create,
+		// loop again to ensure the create is successful with a 'get; api call
+		return false, nil
+	})
+	if waitErr != nil {
+		// log error and continue
+		logger.Error("error ensuring instance of tektonconfig, check retry logs above for more details, %w", waitErr)
+		logger.Infof("an instance of TektonConfig need to be created by the user to get Pipelines components installed")
+	}
+}
+
+func (tc tektonConfig) createInstance() error {
+	tcCR := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: common.ConfigResourceName,
+		},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile: common.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: tc.namespace,
+			},
+		},
+	}
+	_, err := tc.operatorClientSet.OperatorV1alpha1().
+		TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{})
+	return err
+}

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -18,11 +18,6 @@ package tektonconfig
 
 import (
 	"context"
-	"time"
-
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
@@ -38,23 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
-)
-
-const (
-	// RetryInterval specifies the time between two polls.
-	RetryInterval = 10 * time.Second
-
-	// RetryTimeout specifies the timeout for the function PollImmediate to
-	// reach a certain status.
-	RetryTimeout = 5 * time.Minute
-
-	// DefaultCRName specifies the default targetnamespaceto be used
-	// in autocreated TektonConfig instance
-	DefaultCRName = "config"
-
-	// DefaultTargetNamespace specifies the default targetnamespaceto be used
-	// in autocreated TektonConfig instance
-	DefaultTargetNamespace = "openshift-pipelines"
 )
 
 // NoPlatform "generates" a NilExtension
@@ -75,8 +53,7 @@ func OpenShiftExtension(ctx context.Context) common.Extension {
 		kubeClientSet:     kubeclient.Get(ctx),
 		manifest:          manifest,
 	}
-	// try to ensure that there is an instance of tektonConfig
-	ext.ensureTektonConfigInstance(ctx)
+
 	return ext
 }
 
@@ -113,66 +90,4 @@ func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonC
 		return extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
 	}
 	return nil
-}
-
-// try to ensure an instance of TektonConfig exists
-// if there is an error log error,and continue (an instance of TektonConfig will
-// then need to be created by the user to get OpenShift-Pipelines components installed
-func (oe openshiftExtension) ensureTektonConfigInstance(ctx context.Context) {
-	logger := logging.FromContext(ctx)
-	logger.Debug("ensuring tektonconfig instance")
-
-	waitErr := wait.PollImmediate(RetryInterval, RetryTimeout, func() (bool, error) {
-		//note: the code in this block will be retired until
-		// an error is returned, or
-		// 'true' is returned, or
-		// timeout
-		instance, err := oe.operatorClientSet.
-			OperatorV1alpha1().
-			TektonConfigs().Get(context.TODO(), DefaultCRName, metav1.GetOptions{})
-		if err == nil {
-			if !instance.GetDeletionTimestamp().IsZero() {
-				// log deleting timestamp error and retry
-				logger.Errorf("deletionTimestamp is set on existing Tektonconfig instance, Name: %w", instance.GetName())
-				return false, nil
-			}
-			return true, nil
-		}
-		if !apierrs.IsNotFound(err) {
-			//log error and retry
-			logger.Errorf("error getting Tektonconfig, Name: ", instance.GetName())
-			return false, nil
-		}
-		err = oe.createTektonConfigInstance()
-		if err != nil {
-			//log error and retry
-			logger.Errorf("error creating Tektonconfig instance, Name: ", instance.GetName())
-			return false, nil
-		}
-		// even if there is no error after create,
-		// loop again to ensure the create is successful with a 'get; api call
-		return false, nil
-	})
-	if waitErr != nil {
-		// log error and continue
-		logger.Error("error ensuring instance of tektonconfig, check retry logs above for more details, %w", waitErr)
-		logger.Info("an instance of TektonConfig need to be created by the user to get OpenShift-Pipelines components installed")
-	}
-}
-
-func (oe openshiftExtension) createTektonConfigInstance() error {
-	tcCR := &v1alpha1.TektonConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ConfigResourceName,
-		},
-		Spec: v1alpha1.TektonConfigSpec{
-			Profile: common.ProfileAll,
-			CommonSpec: v1alpha1.CommonSpec{
-				TargetNamespace: DefaultTargetNamespace,
-			},
-		},
-	}
-	_, err := oe.operatorClientSet.OperatorV1alpha1().
-		TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{})
-	return err
 }

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -33,6 +33,7 @@ func TestTektonConfigDeployment(t *testing.T) {
 
 	crNames := utils.ResourceNames{
 		TektonConfig:    common.ConfigResourceName,
+		Namespace:       "tekton-operator",
 		TargetNamespace: "tekton-pipelines",
 	}
 
@@ -41,7 +42,7 @@ func TestTektonConfigDeployment(t *testing.T) {
 
 	// Create a TektonConfig
 	t.Run("create-config", func(t *testing.T) {
-		if _, err := resources.EnsureTektonConfigExists(clients.TektonConfig(), crNames); err != nil {
+		if _, err := resources.EnsureTektonConfigExists(clients.KubeClientSet, clients.TektonConfig(), crNames); err != nil {
 			t.Fatalf("TektonConfig %q failed to create: %v", crNames.TektonConfig, err)
 		}
 	})

--- a/test/utils/clients.go
+++ b/test/utils/clients.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -30,10 +31,11 @@ import (
 
 // Clients holds instances of interfaces for making requests to Tekton Pipelines.
 type Clients struct {
-	KubeClient *test.KubeClient
-	Dynamic    dynamic.Interface
-	Operator   operatorv1alpha1.OperatorV1alpha1Interface
-	Config     *rest.Config
+	KubeClient    *test.KubeClient
+	Dynamic       dynamic.Interface
+	Operator      operatorv1alpha1.OperatorV1alpha1Interface
+	Config        *rest.Config
+	KubeClientSet *kubernetes.Clientset
 }
 
 // NewClients instantiates and returns several clientsets required for making request to the
@@ -60,6 +62,11 @@ func NewClients(configPath string, clusterName string) (*Clients, error) {
 	}
 
 	clients.Operator, err = newTektonOperatorAlphaClients(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	clients.KubeClientSet, err = kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, only for openshift a tektonconfig was autocreated. Now, this
will create a instance on all platforms.
This will check for AUTOINSTALL_COMPONENTS in env, which is passed through a
config map. If it is true it will create an instance.

Closes #267

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
