### PR TITLE
Fixes E2E test for TektonConfig 

### DIFF
--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package common
 
 import (
+	"os"
 	"testing"
 
 	"github.com/tektoncd/operator/pkg/reconciler/common"
@@ -32,9 +33,12 @@ func TestTektonConfigDeployment(t *testing.T) {
 	clients := client.Setup(t)
 
 	crNames := utils.ResourceNames{
-		TektonConfig:    common.ConfigResourceName,
-		Namespace:       "tekton-operator",
-		TargetNamespace: "tekton-pipelines",
+		TektonConfig: common.ConfigResourceName,
+		Namespace:    "tekton-operator",
+	}
+
+	if os.Getenv("TARGET") == "openshift" {
+		crNames.Namespace = "openshift-operators"
 	}
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownConfig(clients, crNames.TektonConfig) })

--- a/test/e2e/openshift/rbac_test.go
+++ b/test/e2e/openshift/rbac_test.go
@@ -53,6 +53,5 @@ func TestRBACReconciler(t *testing.T) {
 	// Test whether the roleBindings are created in a "default" namespace
 	t.Run("verify-rolebindings", func(t *testing.T) {
 		resources.AssertRoleBinding(t, clients, crNames.Namespace, "edit")
-		resources.AssertRoleBinding(t, clients, crNames.Namespace, "pipeline-anyuid")
 	})
 }

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -64,7 +64,7 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 			},
 			Spec: v1alpha1.TektonConfigSpec{
 				CommonSpec: v1alpha1.CommonSpec{
-					TargetNamespace: names.TargetNamespace,
+					TargetNamespace: cm.Data["DEFAULT_TARGET_NAMESPACE"],
 				},
 			},
 		}


### PR DESCRIPTION
The test use to fail on OpenShift as it use to look for the configmap
tekton-config-defaults in tekton-operator ns instead of openshift-operators ns.
This patch fixes it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
