### PR TITLE
Mount certs at different path than default

### DIFF
--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -114,10 +114,8 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 			}
 		}
 
-		// /etc/ssl/certs is the default place where CA certs reside in *nix
-		// however this can be overridden using SSL_CERT_DIR, let's check for
-		// that here.
-		sslCertDir := "/etc/ssl/certs"
+		// we wiil mount the certs at this location so we don't override the existing certs
+		sslCertDir := "/tekton-custom-certs"
 		for _, env := range c.Env {
 			if env.Name == "SSL_CERT_DIR" {
 				sslCertDir = env.Value

--- a/pkg/reconciler/openshift/common/cabundle_test.go
+++ b/pkg/reconciler/openshift/common/cabundle_test.go
@@ -60,18 +60,20 @@ func TestApplyCABundles(t *testing.T) {
 					},
 				},
 			}),
-		withVolumeMounts(corev1.VolumeMount{
-			Name:      trustedCAConfigMapVolume,
-			MountPath: filepath.Join("/etc/ssl/certs", trustedCAKey),
-			SubPath:   trustedCAKey,
-			ReadOnly:  true,
-		},
+		withVolumeMounts(
+			corev1.VolumeMount{
+				Name:      trustedCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", trustedCAKey),
+				SubPath:   trustedCAKey,
+				ReadOnly:  true,
+			},
 			corev1.VolumeMount{
 				Name:      serviceCAConfigMapVolume,
-				MountPath: filepath.Join("/etc/ssl/certs", serviceCAKey),
+				MountPath: filepath.Join("/tekton-custom-certs", serviceCAKey),
 				SubPath:   serviceCAKey,
 				ReadOnly:  true,
-			}),
+			},
+		),
 	)
 
 	if err := ApplyCABundles(actual); err != nil {

--- a/pkg/reconciler/proxy/proxy_test.go
+++ b/pkg/reconciler/proxy/proxy_test.go
@@ -37,6 +37,9 @@ func TestUpdateVolume(t *testing.T) {
 	}
 	podUpdated := updateVolume(pod, "testv", "testcm", "testkey")
 	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 1)
+	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].Env), 1)
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Name, "SSL_CERT_DIR")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Value, "/tekton-custom-certs")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "testv")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "testcm")
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 1)


### PR DESCRIPTION
This will change the certs mounting path to /custom-certs
instead of /etc/ssl/certs so that we dont override the default certs
Also add the ENV to point to these certs in all containers

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Mount certs at /custom-certs than /etc/ssl/certs
```
