### PR TITLE
Fix EventListener instance deletion

### DIFF
--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -32,6 +32,7 @@ var (
 	consoleCLIDownload    mf.Predicate = mf.Any(mf.ByKind("ConsoleCLIDownload"))
 	clusterTriggerBinding mf.Predicate = mf.Any(mf.ByKind("ClusterTriggerBinding"))
 	persistentVolumeClaim mf.Predicate = mf.Any(mf.ByKind("PersistentVolumeClaim"))
+	deployment            mf.Predicate = mf.Any(mf.ByKind("Deployment"))
 )
 
 // Install applies the manifest resources for the given version and updates the given
@@ -78,8 +79,14 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.Tekto
 
 // Uninstall removes all resources
 func Uninstall(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.TektonComponent) error {
-	if err := manifest.Filter(mf.Not(mf.Any(role, rolebinding))).Delete(); err != nil {
+	if err := manifest.Filter(mf.Not(mf.Any(role, rolebinding, deployment))).Delete(); err != nil {
 		return fmt.Errorf("failed to remove non-crd/non-rbac resources: %w", err)
+	}
+	// delete deployment separately (after delete call to CRDs)
+	// to improve the chance of the finalizers to be handled before the controllers are deleted
+	// ref: https://github.com/tektoncd/triggers/issues/775#issuecomment-700271144
+	if err := manifest.Filter(mf.Any(deployment)).Delete(); err != nil {
+		return fmt.Errorf("failed to remove deployments: %w", err)
 	}
 	// Delete Roles last, as they may be useful for human operators to clean up.
 	if err := manifest.Filter(mf.Any(role, rolebinding)).Delete(); err != nil {

--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -148,7 +148,7 @@ func TestUninstall(t *testing.T) {
 	// Deliberately mixing the order in the manifest.
 	in := []unstructured.Unstructured{crd, deployment, role, roleBinding, clusterRole, clusterRoleBinding}
 	// Expect things to be deleted, non-rbac resources first and then in reversed order.
-	want := []unstructured.Unstructured{deployment, crd, clusterRoleBinding, clusterRole, roleBinding, role}
+	want := []unstructured.Unstructured{crd, deployment, clusterRoleBinding, clusterRole, roleBinding, role}
 
 	client := &fakeClient{resourcesExist: true}
 	manifest, err := mf.ManifestFrom(mf.Slice(in), mf.UseClient(client))


### PR DESCRIPTION
Separate deletion of deployments from the deletion of all other resources.
So that delete call to CRDs are executed first before calling delete on controllers.
This will help to create a window before controller deletion, where controller can
handle finalizers on CRDs and CRD instances.

This is not the perfect fix, but this is good enough.

Ideal fix will be to add finalizer on controllers and remove them after making sure
all other resources have been removed. But this could create other issues such as the
CRDs watched by controllers being deleted can cause the controllers t

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit 962c5bfc371b19d5b7fe8e401e287890b16710e2)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
