### PR TITLE
Add namespace transformer for ClusterInterceptor

### DIFF
--- a/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-interceptor.yaml
+++ b/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-interceptor.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterInterceptor
+metadata:
+  name: cel
+spec:
+  clientConfig:
+    service:
+      name: tekton-triggers-core-interceptors
+      path: "cel"
+      namespace: tekton-pipelines

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -53,6 +53,7 @@ func transformers(ctx context.Context, obj v1alpha1.TektonComponent) []mf.Transf
 		mf.InjectOwner(obj),
 		injectNamespaceConditional(AnnotationPreserveNS, obj.GetSpec().GetTargetNamespace()),
 		injectNamespaceCRDWebhookClientConfig(obj.GetSpec().GetTargetNamespace()),
+		injectNamespaceCRClusterInterceptorClientConfig(obj.GetSpec().GetTargetNamespace()),
 	}
 }
 
@@ -112,6 +113,24 @@ func injectNamespaceCRDWebhookClientConfig(targetNamespace string) mf.Transforme
 			return nil
 		}
 		service, found, err := unstructured.NestedFieldNoCopy(u.Object, "spec", "conversion", "webhookClientConfig", "service")
+		if !found || err != nil {
+			return err
+		}
+		m := service.(map[string]interface{})
+		if _, ok := m["namespace"]; ok {
+			m["namespace"] = targetNamespace
+		}
+		return nil
+	}
+}
+
+func injectNamespaceCRClusterInterceptorClientConfig(targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		kind := strings.ToLower(u.GetKind())
+		if kind != "clusterinterceptor" {
+			return nil
+		}
+		service, found, err := unstructured.NestedFieldNoCopy(u.Object, "spec", "clientConfig", "service")
 		if !found || err != nil {
 			return err
 		}

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"gotest.tools/assert"
 	"os"
 	"path"
 	"reflect"
@@ -27,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -365,4 +365,19 @@ func TestReplaceNamespaceInDeploymentArgs(t *testing.T) {
 	args := d.Spec.Template.Spec.Containers[0].Args
 	assert.Equal(t, args[0], "-api_addr")
 	assert.Equal(t, args[1], "tekton-results-api-service.openshift-pipelines.svc.cluster.local:50051")
+}
+
+func TestReplaceNamespaceInClusterInterceptor(t *testing.T) {
+	testData := path.Join("testdata", "test-replace-namespace-in-cluster-interceptor.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assertNoEror(t, err)
+
+	manifest, err = manifest.Transform(injectNamespaceCRClusterInterceptorClientConfig("foobar"))
+	assertNoEror(t, err)
+
+	clusterInterceptor := manifest.Resources()[0].Object
+	service, _, err := unstructured.NestedFieldNoCopy(clusterInterceptor, "spec", "clientConfig", "service")
+	m := service.(map[string]interface{})
+	assertNoEror(t, err)
+	assert.Equal(t, "foobar", m["namespace"])
 }


### PR DESCRIPTION
# Changes

As of now operator is ignoring namespace transformation
on new Resource [clusterInterceptor] and thus it was giving an error.

Add a `injectNamespaceCRDClusterInterceptorClientConfig` function which
will add transformation for ClusterInterceptor CRD.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```