### PR TITLE
 [OpenShift] Optimize rbac creation in TektonConfig extention 

### DIFF
--- a/pkg/reconciler/common/name_test.go
+++ b/pkg/reconciler/common/name_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package common
 
 import (
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"strings"
 	"testing"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestRestrictLengthWithRandomSuffix(t *testing.T) {

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -88,9 +88,15 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 	if configInstance.Spec.Profile == common.ProfileAll {
-		return extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
+		if err := extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	r := rbac{
+		kubeClientSet: oe.kubeClientSet,
+	}
+	return r.cleanUp(ctx)
 }
 
 // configOwnerRef returns owner reference pointing to passed instance

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,6 +32,9 @@ failed=0
 header "Setting up environment"
 install_operator_resources
 
+echo "Wait for TektonConfig creation"
+sleep 30
+
 header "Running Go e2e tests"
 go_test_e2e -timeout=20m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
 go_test_e2e -timeout=20m ./test/e2e/${TARGET} ${KUBECONFIG_PARAM} || failed=1

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -26,6 +26,7 @@ import (
 
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 
 	"knative.dev/pkg/test/logging"
 
@@ -63,8 +64,21 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 				Name: names.TektonConfig,
 			},
 			Spec: v1alpha1.TektonConfigSpec{
+				Profile: common.ProfileAll,
 				CommonSpec: v1alpha1.CommonSpec{
 					TargetNamespace: cm.Data["DEFAULT_TARGET_NAMESPACE"],
+				},
+				Addon: v1alpha1.Addon{
+					Params: []v1alpha1.Param{
+						{
+							Name:  "pipelineTemplates",
+							Value: "true",
+						},
+						{
+							Name:  "clusterTasks",
+							Value: "true",
+						},
+					},
 				},
 			},
 		}


### PR DESCRIPTION


This adds a label to namespace after creating rbac resources so
that on further reconcilation, reconciler won't loop on it and ignore
them. Only new namespaces would be looped for rbac resource creation.

Also adds a filter to namespace events to queue in TektonConfig only
if namespace doesn't match the regex.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
