### PR TITLE
Install kn tasks on all arch

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/buildah/buildah-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/buildah/buildah-1-5-0-task.yaml
@@ -29,7 +29,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+    default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: vfs

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/buildah/buildah-task.yaml
@@ -29,7 +29,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+    default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: vfs

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn-apply/kn-apply-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn-apply/kn-apply-1-5-0-task.yaml
@@ -20,7 +20,7 @@ spec:
   params:
   - name: KN_IMAGE
     description: kn CLI container image to run this task
-    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358
+    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb
   - name: SERVICE
     description: Knative service name
   - name: IMAGE

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn-apply/kn-apply-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn-apply/kn-apply-task.yaml
@@ -20,7 +20,7 @@ spec:
   params:
   - name: KN_IMAGE
     description: kn CLI container image to run this task
-    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358
+    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb
   - name: SERVICE
     description: Knative service name
   - name: IMAGE

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn/kn-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn/kn-1-5-0-task.yaml
@@ -20,7 +20,7 @@ spec:
   params:
   - name: kn-image
     description: kn CLI container image to run this task
-    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358
+    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb
   - name: ARGS
     type: array
     description: kn CLI arguments to run

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn/kn-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/kn/kn-task.yaml
@@ -20,7 +20,7 @@ spec:
   params:
   - name: kn-image
     description: kn CLI container image to run this task
-    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358
+    default: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb
   - name: ARGS
     type: array
     description: kn CLI arguments to run

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-dotnet/s2i-dotnet-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-dotnet/s2i-dotnet-1-5-0-task.yaml
@@ -24,7 +24,7 @@ spec:
   params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
     - name: VERSION
       description: The tag of .NET imagestream for .NET version
       default: '3.1-ubi8'
@@ -45,7 +45,7 @@ spec:
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/dotnet:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-dotnet/s2i-dotnet-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-dotnet/s2i-dotnet-task.yaml
@@ -24,7 +24,7 @@ spec:
   params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
     - name: VERSION
       description: The tag of .NET imagestream for .NET version
       default: '3.1-ubi8'
@@ -45,7 +45,7 @@ spec:
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/dotnet:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-go/s2i-go-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-go/s2i-go-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/golang:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-go/s2i-go-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/golang:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-java/s2i-java-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-java/s2i-java-1-5-0-task.yaml
@@ -51,13 +51,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: gen-env-file
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: /env-params
       command:
         - '/bin/sh'
@@ -80,7 +80,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command:
         - 's2i'

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-java/s2i-java-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-java/s2i-java-task.yaml
@@ -51,13 +51,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: gen-env-file
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: /env-params
       command:
         - '/bin/sh'
@@ -80,7 +80,7 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command:
         - 's2i'

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-nodejs/s2i-nodejs-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-nodejs/s2i-nodejs-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-perl/s2i-perl-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-perl/s2i-perl-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/perl:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-perl/s2i-perl-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/perl:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-php/s2i-php-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-php/s2i-php-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/php:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-php/s2i-php-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/php:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-python/s2i-python-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-python/s2i-python-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/python:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-python/s2i-python-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-python/s2i-python-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/python:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-ruby/s2i-ruby-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-ruby/s2i-ruby-1-5-0-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/ruby:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/s2i-ruby/s2i-ruby-task.yaml
@@ -39,13 +39,13 @@ spec:
       type: string
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
   workspaces:
     - name: source
       mountPath: /workspace/source
   steps:
     - name: generate
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308
+      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
       workingDir: $(workspaces.source.path)
       command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/ruby:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/skopeo-copy/skopeo-copy-1-5-0-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/skopeo-copy/skopeo-copy-1-5-0-task.yaml
@@ -44,7 +44,7 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
-      image: registry.redhat.io/rhel8/skopeo@sha256:34e2d9e273bf610509984193a19aeea44e6061e86baca62a969661d122298bbf
+      image: registry.redhat.io/rhel8/skopeo@sha256:7297e3b42ef1d56a5bc1d64a979d05c157bf31b476cc526386c873a89459610a
       script: |
         # Function to copy multiple images.
         #

--- a/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/skopeo-copy/skopeo-copy-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/1.5.0/addons/02-clustertasks/skopeo-copy/skopeo-copy-task.yaml
@@ -44,7 +44,7 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
-      image: registry.redhat.io/rhel8/skopeo@sha256:34e2d9e273bf610509984193a19aeea44e6061e86baca62a969661d122298bbf
+      image: registry.redhat.io/rhel8/skopeo@sha256:7297e3b42ef1d56a5bc1d64a979d05c157bf31b476cc526386c873a89459610a
       script: |
         # Function to copy multiple images.
         #

--- a/hack/openshift/update-tasks.sh
+++ b/hack/openshift/update-tasks.sh
@@ -183,36 +183,35 @@ main() {
   # ./manifest-tool inspect registry.redhat.io/rhel8/buildah:latest
   change_task_image "$dest_dir" "$version"  \
     "buildah"  "quay.io/buildah"  \
-    "registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13"
+    "registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee"
 
   change_task_image "$dest_dir" "$version"  \
     "openshift-client"  'quay.io/openshift/origin-cli:$(params.VERSION)'  \
     "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
 
-  # ./manifest-tool inspect registry.redhat.io/openshift-serverless-1/client-kn-rhel8:0.19
+  # ./manifest-tool inspect registry.redhat.io/openshift-serverless-1/client-kn-rhel8:0.22
   change_task_image "$dest_dir" "$version"  \
     "kn"  "gcr.io/knative-releases/knative.dev/client/cmd/kn:latest"  \
-    "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358"
+    "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb"
 
   change_task_image "$dest_dir" "$version"  \
     "kn-apply"  "gcr.io/knative-releases/knative.dev/client/cmd/kn:latest"  \
-    "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:efb51d4a337566ca8532073cd598cc2cfbbec260f037ce4de19d4c67ee411358"
+    "registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:286f6b4c008307df1bc369891ef9e806050d3a5f5e77ee0c9313ffdb350abbcb"
 
   # ./manifest-tool inspect registry.redhat.io/rhel8/skopeo:latest
   change_task_image "$dest_dir" "$version"  \
     "skopeo-copy"  "quay.io/skopeo/stable"  \
-    "registry.redhat.io/rhel8/skopeo@sha256:34e2d9e273bf610509984193a19aeea44e6061e86baca62a969661d122298bbf"
+    "registry.redhat.io/rhel8/skopeo@sha256:7297e3b42ef1d56a5bc1d64a979d05c157bf31b476cc526386c873a89459610a"
 
-  # this will do the change for all pipelines catalog tasks except buildah-pr
   for t in ${!OPENSHIFT_CATALOG_TASKS[@]} ; do
     # ./manifest-tool inspect registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8:v1.3.1
     change_task_image "$dest_dir" "$version"  \
       "$t"  "quay.io/openshift-pipeline/s2i"  \
-      "registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:ba51e5e74ff5a29fd429b0bb77bc2130e5284826a60d042fc4e4374381a7a308"
+      "registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631"
 
     change_task_image "$dest_dir" "$version"  \
       "$t"  "quay.io/buildah"  \
-      "registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13"
+      "registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee"
 
   done
 

--- a/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates.go
@@ -18,7 +18,6 @@ package tektonaddon
 
 import (
 	"path"
-	"runtime"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -74,12 +73,7 @@ func GeneratePipelineTemplates(templatePath string, manifest *mf.Manifest) error
 	workspacedTaskGenerators := []taskGenerator{
 		&pipeline{environment: "openshift", nameSuffix: "", generateDeployTask: openshiftDeployTask},
 		&pipeline{environment: "kubernetes", nameSuffix: "-deployment", generateDeployTask: kubernetesDeployTask},
-	}
-
-	if runtime.GOARCH == "amd64" {
-		workspacedTaskGenerators = append(workspacedTaskGenerators,
-			&pipeline{environment: "knative", nameSuffix: "-knative", generateDeployTask: knativeDeployTask},
-		)
+		&pipeline{environment: "knative", nameSuffix: "-knative", generateDeployTask: knativeDeployTask},
 	}
 
 	wps, err := generateBasePipeline(workspacedTemplate, workspacedTaskGenerators, !usingPipelineResource)

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
@@ -260,23 +259,7 @@ func addPipelineTemplates(manifest *mf.Manifest) error {
 func applyAddons(manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
 	koDataDir := os.Getenv(common.KoEnvKey)
 	addonLocation := filepath.Join(koDataDir, "tekton-addon/"+common.TargetVersion(comp)+"/addons")
-	addons, err := mf.ManifestFrom(mf.Recursive(addonLocation))
-	if err != nil {
-		return err
-	}
-	if runtime.GOARCH == "ppc64le" || runtime.GOARCH == "s390x" {
-		version := common.TargetVersion((*v1alpha1.TektonPipeline)(nil))
-		version_formated := strings.Replace(version, ".", "-", -1)
-		addons = addons.Filter(
-			mf.Not(mf.Any(
-				mf.ByName("kn"),
-				mf.ByName("kn-v"+version_formated),
-				mf.ByName("kn-apply"),
-				mf.ByName("kn-apply-v"+version_formated),
-			)))
-	}
-	*manifest = manifest.Append(addons)
-	return nil
+	return common.AppendManifest(manifest, addonLocation)
 }
 
 func applyOptionalAddons(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent, cfg *rest.Config) error {


### PR DESCRIPTION
As knative client image is multi arch now, this will make
operator install the task on all archs

Update the image sha to latest available images

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Install kn tasks on all arch and bump image sha
```