### PR TITLE
fix autoprune not exectuing for second resource #38

### DIFF
--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -142,7 +142,7 @@ func getPruningContainers(resources, namespaces []string, keep uint, tknImage st
 			Name:                     jobName,
 			Image:                    tknImage,
 			Command:                  []string{"/bin/sh", "-c"},
-			Args:                     cmdArgs,
+			Args:                     []string{cmdArgs},
 			TerminationMessagePolicy: "FallbackToLogsOnError",
 		}
 		containers = append(containers, container)
@@ -151,11 +151,11 @@ func getPruningContainers(resources, namespaces []string, keep uint, tknImage st
 	return containers
 }
 
-func deleteCommand(resources []string, keep uint, ns string) []string {
-	cmdArgs := []string{}
+func deleteCommand(resources []string, keep uint, ns string) string {
+	var cmdArgs string
 	for _, res := range resources {
-		cmd := "tkn " + strings.ToLower(res) + " delete --keep " + fmt.Sprint(keep) + " -f -n " + ns
-		cmdArgs = append(cmdArgs, cmd)
+		cmd := "tkn " + strings.ToLower(res) + " delete --keep=" + fmt.Sprint(keep) + " -n " + ns + " -f ; "
+		cmdArgs = cmdArgs + cmd
 	}
 	return cmdArgs
 }


### PR DESCRIPTION
earlier resources["pipelinerun", "taskrun"] executes fine
but somehow resources ["taskrun", "pipelinrun"] do not execute
for the second resource.

problem: command created and passed was an array where each
item was treated as an arugement.

Now the commands are single string and seperated by ';'

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
