### PR TITLE
Skip Tekton Result tests for Z and Power platforms

### DIFF
--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -21,6 +21,7 @@ package kubernetes
 import (
 	"context"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +36,10 @@ import (
 
 // TestTektonResultDeployment verifies the TektonResult creation, deployment recreation, and TektonResult deletion.
 func TestTektonResultDeployment(t *testing.T) {
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("Tekton Result is not available for %q", platform)
+	}
 	clients := client.Setup(t)
 
 	crNames := utils.ResourceNames{


### PR DESCRIPTION
# Changes

At this moment Tekton Result is available only for Intel platform, so the tests on Z and Power platforms should be skipped.

The issue to discuss multi-arch options for Tekton Result is open https://github.com/tektoncd/results/issues/116

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

