### PR TITLE
[OpenShift] Removes external reference in openshift payload

### DIFF
--- a/pkg/reconciler/openshift/common/testdata/test-prefix-images-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-prefix-images-expected.yaml
@@ -63,7 +63,7 @@ spec:
             "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v0.24.3",
 
             # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
-            "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
+            "-gsutil-image", "no-image-available",
             # The shell image must be root in order to create directories and copy files to PVCs.
             # gcr.io/distroless/base:debug as of Apirl 17, 2021
             # image shall not contains tag, so it will be supported on a runtime like cri-o

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -39,7 +39,7 @@ import (
 
 // UpdateDeployments will also remove runAsUser from container
 
-func UpdateDeployments(prefix string, replaceImg map[string]string, skipImages []string) mf.Transformer {
+func UpdateDeployments(prefix string, replaceImg map[string]string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() != "Deployment" {
 			return nil
@@ -59,10 +59,6 @@ func UpdateDeployments(prefix string, replaceImg map[string]string, skipImages [
 
 			// Prefix Images in Args if there
 			for i := 0; i < len(c.Args); i++ {
-				if valueInArr(skipImages, c.Args[i]) {
-					i++
-					continue
-				}
 				val, ok := replaceImg[c.Args[i]]
 				if ok {
 					c.Args[i+1] = val
@@ -92,15 +88,6 @@ func prefixImage(prefix, img string) string {
 	}
 	arr := strings.Split(strings.Split(img, "@")[0], "/")
 	return prefix + arr[len(arr)-1]
-}
-
-func valueInArr(arr []string, val string) bool {
-	for _, v := range arr {
-		if v == val {
-			return true
-		}
-	}
-	return false
 }
 
 // RemoveRunAsGroup will remove runAsGroup from all container in a deployment

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -39,12 +39,11 @@ func TestUpdateDeployments(t *testing.T) {
 	pipelinesPrefix := "quay.io/openshift-pipeline/tektoncd-pipeline-"
 
 	replaceImages := map[string]string{
-		"-shell-image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+		"-shell-image":  "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+		"-gsutil-image": "no-image-available",
 	}
-	skip := []string{
-		"-gsutil-image",
-	}
-	newManifest, err := manifest.Transform(UpdateDeployments(pipelinesPrefix, replaceImages, skip))
+
+	newManifest, err := manifest.Transform(UpdateDeployments(pipelinesPrefix, replaceImages))
 	assert.NilError(t, err)
 
 	got := &appsv1.Deployment{}
@@ -75,7 +74,7 @@ func TestUpdateDeploymentsTriggers(t *testing.T) {
 
 	triggersPrefix := "quay.io/openshift-pipeline/tektoncd-triggers-"
 
-	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}, []string{}))
+	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}))
 	assert.NilError(t, err)
 	newManifest, err = newManifest.Transform(RemoveRunAsGroup())
 	assert.NilError(t, err)
@@ -108,7 +107,7 @@ func TestUpdateDeploymentsInterceptor(t *testing.T) {
 
 	triggersPrefix := "quay.io/openshift-pipeline/tektoncd-triggers-"
 
-	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}, []string{}))
+	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}))
 	assert.NilError(t, err)
 	newManifest, err = newManifest.Transform(RemoveRunAsGroup())
 	assert.NilError(t, err)

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -49,9 +49,9 @@ const (
 
 var (
 	replaceImgs = map[string]string{
-		"-shell-image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+		"-shell-image":  "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+		"-gsutil-image": "no-image-available",
 	}
-	skipImgs = []string{"-gsutil-image"}
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -81,7 +81,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		common.InjectLabelOnNamespace(monitoringLabel),
 		occommon.ApplyCABundles,
-		occommon.UpdateDeployments(pipelinesPrefix, replaceImgs, skipImgs),
+		occommon.UpdateDeployments(pipelinesPrefix, replaceImgs),
 	}
 }
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -35,7 +35,7 @@ type openshiftExtension struct{}
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{
-		occommon.UpdateDeployments(triggersPrefix, map[string]string{}, []string{}),
+		occommon.UpdateDeployments(triggersPrefix, map[string]string{}),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundles,
 	}


### PR DESCRIPTION
This removes external reference for one of pipelines images in
the payload. this removes it and add no image available instead
of a gcr image.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
