### PR TITLE
[OpenShift] fixes the disable affinity assistant configuration

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -27,9 +27,6 @@ func (tp *TektonPipeline) SetDefaults(ctx context.Context) {
 }
 
 func (p *PipelineProperties) setDefaults() {
-	if p.DisableAffinityAssistant == nil {
-		p.DisableAffinityAssistant = ptr.Bool(false)
-	}
 	if p.DisableHomeEnvOverwrite == nil {
 		p.DisableHomeEnvOverwrite = ptr.Bool(true)
 	}

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
@@ -40,7 +40,6 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 	}
 
 	properties := PipelineProperties{
-		DisableAffinityAssistant:                 ptr.Bool(false),
 		DisableHomeEnvOverwrite:                  ptr.Bool(true),
 		DisableWorkingDirectoryOverwrite:         ptr.Bool(true),
 		DisableCredsInit:                         ptr.Bool(false),

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -33,6 +33,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -135,10 +136,10 @@ func SetDefault(properties *v1alpha1.PipelineProperties) bool {
 		updated = true
 	}
 
-	// Set `disable-affinity-assistant` to true
-	// webhook will set `false` as default value
-	if properties.DisableAffinityAssistant == nil || !*properties.DisableAffinityAssistant {
-		*properties.DisableAffinityAssistant = DefaultDisableAffinityAssistant
+	// Set `disable-affinity-assistant` to true if not set in CR
+	// webhook will not set any value but by default in pipelines configmap it will be false
+	if properties.DisableAffinityAssistant == nil {
+		properties.DisableAffinityAssistant = ptr.Bool(DefaultDisableAffinityAssistant)
 		updated = true
 	}
 


### PR DESCRIPTION
This is always true in case of openshift due to which user would
not able to enable it. so this fixes by removing the defaulting in
Operator CR and adding the field only when user adds it.
By default, the value in configmap is false for kubernetes and will
be changed to true for openshift which user can change if requires.

fixes #372 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
