### PR TITLE
Add METRICS_DOMAIN env in Deployments

### DIFF
--- a/config/base/operator.yaml
+++ b/config/base/operator.yaml
@@ -45,6 +45,8 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "tekton-operator"
+            - name: METRICS_DOMAIN
+              value: tekton.dev/operator
             - name: AUTOINSTALL_COMPONENTS
               valueFrom:
                 configMapKeyRef:

--- a/config/base/webhook.yaml
+++ b/config/base/webhook.yaml
@@ -45,6 +45,8 @@ spec:
           value: tekton-operator-webhook
         - name: WEBHOOK_SECRET_NAME
           value: tekton-operator-webhook-certs
+        - name: METRICS_DOMAIN
+          value: tekton.dev/operator
         ports:
         - name: https-webhook
           containerPort: 8443


### PR DESCRIPTION
If other operators using knative/pkg with `config-observability`
configmap are installed in same namespace as Tekton Operator then
it assumes the configmap is of its own and looks for `METRICS_DOMAIN`
due to which operator fails. this fixes that for now.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
