### PR TITLE
Use release version for `operator.tekton.dev/release` label value

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -115,7 +115,7 @@ spec:
       done
 
       # Rewrite "devel" to params.versionTag
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/base/*.yaml
+      sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/base/*.yaml
 
       # Publish images and create release.yaml
       mkdir -p $OUTPUT_RELEASE_DIR


### PR DESCRIPTION
# Changes

I was looking at the latest (`v0.49.0`) release and noticed that the `operator.tekton.dev/release` label still had the `devel` value instead of the release tag:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    operator.tekton.dev/release: devel
    version: v0.49.0
  name: tekton-operator-webhook
  namespace: tekton-operator
```

I wasn't able to test the pipeline after the changes, but I did run sed in the repo and saw the expected diff. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
The `operator.tekton.dev/release` label value is now populated with the release version
```

