### PR TITLE
config: replace any wildcard verbs by a list

### DIFF
--- a/config/base/role.yaml
+++ b/config/base/role.yaml
@@ -30,7 +30,14 @@ rules:
   - pods/log
   - limitranges
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - extensions
   - apps
@@ -66,7 +73,14 @@ rules:
   - statefulsets
   - deployments/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -187,22 +201,74 @@ rules:
   - '*'
   - tektonaddons
   verbs:
-  - '*'
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
 - apiGroups:
   - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  - pipelineresources/status
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  - runs
+  - runs/status
+  - runs/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
   - triggers.tekton.dev
   - operator.tekton.dev
   resources:
   - '*'
   verbs:
-  - '*'
+  - add
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
 - apiGroups:
   - dashboard.tekton.dev
   resources:
   - '*'
   - tektonaddons
+  - extensions
   verbs:
-  - '*'
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
 - apiGroups:
     - security.openshift.io
   resources:
@@ -226,13 +292,27 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - serving.knative.dev
   resources:
@@ -290,4 +370,11 @@ rules:
   resources:
     - '*'
   verbs:
-    - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch

--- a/config/openshift/role.yaml
+++ b/config/openshift/role.yaml
@@ -30,7 +30,14 @@ rules:
   - pods/log
   - limitranges
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - extensions
   - apps
@@ -66,7 +73,14 @@ rules:
   - statefulsets
   - deployments/finalizers
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -81,7 +95,14 @@ rules:
   - clusterroles
   - roles
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -184,7 +205,14 @@ rules:
   - '*'
   - tektonaddons
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - tekton.dev
   - triggers.tekton.dev
@@ -192,14 +220,29 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - add
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - dashboard.tekton.dev
   resources:
   - '*'
   - tektonaddons
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - security.openshift.io
   resources:
@@ -235,29 +278,63 @@ rules:
   - consoleclidownloads
   - consolequickstarts
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - delete
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - batch
   resources:
   - jobs
   - cronjobs
   verbs:
-  - '*'
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch


### PR DESCRIPTION

# Changes

Better be explicit on the verbs we allow than the wildcard (`*`). Next
step would be to see if we need all these or not.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @tektoncd/operator-collaborators @tektoncd/operator-maintainers 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Replace any wildecard vebr by an explicit list in the roles
```
