### PR TITLE
[OpenShift] Fixes failures on OpenShift

### DIFF
--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -45,7 +45,7 @@ release_yaml() {
 
     # before adding releases, remove existing version directories
     # ignore while adding for interceptors
-    if [[ ${releaseFileName} != "interceptors.notags" ]] ; then
+    if [[ ${releaseFileName} != "interceptors" ]] ; then
       rm -rf ${comp_dir}/*
     fi
 
@@ -89,10 +89,10 @@ main() {
   t_version=${3}
 
 
-  release_yaml pipeline release.notags 00-pipelines ${p_version}
+  release_yaml pipeline release 00-pipelines ${p_version}
 
-  release_yaml triggers release.notags 00-triggers ${t_version}
-  release_yaml triggers interceptors.notags 01-interceptors ${t_version}
+  release_yaml triggers release 00-triggers ${t_version}
+  release_yaml triggers interceptors 01-interceptors ${t_version}
 
   if [[ ${TARGET} != "openshift" ]]; then
     d_version=${4}


### PR DESCRIPTION
for openshift we replace gcr images with quay.io, the image need
to have tags to fetch a particular release image. so we need to
fetch release yaml with images having tags.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
