### PR TITLE
[OpenShift] Read version to add in rbac resources from env

### DIFF
--- a/config/base/operator.yaml
+++ b/config/base/operator.yaml
@@ -35,6 +35,8 @@ spec:
         - name: tekton-operator
           image: ko://github.com/tektoncd/operator/cmd/kubernetes/operator
           env:
+            - name: VERSION
+              value: "devel"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -18,6 +18,7 @@ package tektonconfig
 
 import (
 	"context"
+	"os"
 
 	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
@@ -36,6 +37,10 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
+)
+
+const (
+	versionKey = "VERSION"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -84,6 +89,7 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		operatorClientSet: oe.operatorClientSet,
 		manifest:          oe.manifest,
 		ownerRef:          configOwnerRef(tc),
+		version:           os.Getenv(versionKey),
 	}
 	return r.createResources(ctx)
 }
@@ -106,6 +112,7 @@ func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonC
 
 	r := rbac{
 		kubeClientSet: oe.kubeClientSet,
+		version:       os.Getenv(versionKey),
 	}
 	return r.cleanUp(ctx)
 }


### PR DESCRIPTION
This reads the version from env to add as a label in rbac resources
instead of hardcoding. so on each upgrade all rbac resources will
get updated with new label.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
