### PR TITLE
[OpenShift] Fixes rbac for Operator service account

### DIFF
--- a/config/openshift/role.yaml
+++ b/config/openshift/role.yaml
@@ -103,6 +103,8 @@ rules:
   - list
   - update
   - watch
+  - bind
+  - escalate
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION

# Changes

Operator's service account cannot create rolebinding from clusterrole
which has roles it doesn't posses for which it requires `bind` verb.
and to create clusteroles it requires `escalate` verb if roles mentioned
in clusterrole are not possesed by it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```