### PR TITLE
[OpenShift] Disable quay image replacement

### DIFF
--- a/pkg/reconciler/openshift/common/testdata/test-prefix-images-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-prefix-images-expected.yaml
@@ -7,12 +7,12 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: v0.24.3
+    app.kubernetes.io/version: "v0.24.3"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: v0.24.3
+    pipeline.tekton.dev/release: "v0.24.3"
     # labels below are related to istio and should not be used for resource lookup
-    version: v0.24.3
+    version: "v0.24.3"
 spec:
   replicas: 1
   selector:
@@ -29,13 +29,13 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: v0.24.3
+        app.kubernetes.io/version: "v0.24.3"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: v0.24.3
+        pipeline.tekton.dev/release: "v0.24.3"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-controller
-        version: v0.24.3
+        version: "v0.24.3"
     spec:
       affinity:
         nodeAffinity:
@@ -49,26 +49,19 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
         - name: tekton-pipelines-controller
-          image: quay.io/openshift-pipeline/tektoncd-pipeline-controller:v0.24.3
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.24.3@sha256:18d0fb34fda7c5c877bca20ad700dee7a8accdde82a1e4c316c0e26ebe34ec2f
           args: [
             # Version, to be replace at release time
             "-version", "v0.24.3",
             # These images are built on-demand by `ko resolve` and are replaced
             # by image references by digest.
-            "-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.24.3",
-            "-git-image", "quay.io/openshift-pipeline/tektoncd-pipeline-git-init:v0.24.3",
-            "-entrypoint-image", "quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v0.24.3",
-            "-nop-image", "quay.io/openshift-pipeline/tektoncd-pipeline-nop:v0.24.3",
-            "-imagedigest-exporter-image", "quay.io/openshift-pipeline/tektoncd-pipeline-imagedigestexporter:v0.24.3",
-            "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v0.24.3",
-
+            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.24.3@sha256:d3266fba61acff36135f76b23190a8440eaaaa9ccd3e4da5cad69ef018db876a", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.24.3@sha256:a1dd5935163f54ef9585b393c6f1cef08199b349a0db3e9632013797f5c7eedf", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.24.3@sha256:aeaa85954d7ccec1a1cc297aeb2d774cf9aa1345a2e1a93b38b6073114cd47c0", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.24.3@sha256:e6e5fd3e5664cae763eb461908004cc3629578084e75edcd64600edcfe8dbf2c", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.24.3@sha256:6e891b023d2194fd9e796a1420a8179766de444fee2626272cde3b60259c51d9", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.24.3@sha256:ae7622314107d174acb94d42ddc76e05fe8c644855da5c1d48036f6aea645047",
             # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
-            "-gsutil-image", "no-image-available",
+            "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
             # The shell image must be root in order to create directories and copy files to PVCs.
             # gcr.io/distroless/base:debug as of Apirl 17, 2021
             # image shall not contains tag, so it will be supported on a runtime like cri-o
-            "-shell-image", "registry.access.redhat.com/ubi8/ubi-minimal:latest"
-          ]
+            "-shell-image", "gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4"]
           volumeMounts:
             - name: config-logging
               mountPath: /etc/config-logging

--- a/pkg/reconciler/openshift/common/testdata/test-prefix-images-interceptor-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-prefix-images-interceptor-expected.yaml
@@ -7,10 +7,10 @@ metadata:
     app.kubernetes.io/name: core-interceptors
     app.kubernetes.io/component: interceptors
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: v0.14.2
+    app.kubernetes.io/version: "v0.14.2"
     app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-    triggers.tekton.dev/release: v0.14.2
+    triggers.tekton.dev/release: "v0.14.2"
 spec:
   replicas: 1
   selector:
@@ -25,21 +25,18 @@ spec:
         app.kubernetes.io/name: core-interceptors
         app.kubernetes.io/component: interceptors
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: v0.14.2
+        app.kubernetes.io/version: "v0.14.2"
         app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-core-interceptors
-        triggers.tekton.dev/release: v0.14.2
+        triggers.tekton.dev/release: "v0.14.2"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-        version: v0.14.2
+        version: "v0.14.2"
     spec:
       serviceAccountName: tekton-triggers-core-interceptors
       containers:
         - name: tekton-triggers-core-interceptors
-          image: "quay.io/openshift-pipeline/tektoncd-triggers-interceptors:v0.14.2"
-          args: [
-            "-logtostderr",
-            "-stderrthreshold", "INFO",
-          ]
+          image: "gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/interceptors:v0.14.2@sha256:d62beb1410c8200837176799f6424da6eafebc577af067743399a31360cca63e"
+          args: ["-logtostderr", "-stderrthreshold", "INFO"]
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/pkg/reconciler/openshift/common/testdata/test-prefix-images-triggers-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-prefix-images-triggers-expected.yaml
@@ -7,10 +7,10 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: v0.14.2
+    app.kubernetes.io/version: "v0.14.2"
     app.kubernetes.io/part-of: tekton-triggers
     # tekton.dev/release value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-    triggers.tekton.dev/release: v0.14.2
+    triggers.tekton.dev/release: "v0.14.2"
 spec:
   replicas: 1
   selector:
@@ -27,29 +27,18 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: v0.14.2
+        app.kubernetes.io/version: "v0.14.2"
         app.kubernetes.io/part-of: tekton-triggers
         app: tekton-triggers-controller
-        triggers.tekton.dev/release: v0.14.2
+        triggers.tekton.dev/release: "v0.14.2"
         # version value replaced with inputs.params.versionTag in triggers/tekton/publish.yaml
-        version: v0.14.2
+        version: "v0.14.2"
     spec:
       serviceAccountName: tekton-triggers-controller
       containers:
         - name: tekton-triggers-controller
-          image: "quay.io/openshift-pipeline/tektoncd-triggers-controller:v0.14.2"
-          args: [
-            "-logtostderr",
-            "-stderrthreshold", "INFO",
-            "-el-image", "quay.io/openshift-pipeline/tektoncd-triggers-eventlistenersink:v0.14.2",
-            "-el-port", "8080",
-            "-el-readtimeout", "5",
-            "-el-writetimeout", "40",
-            "-el-idletimeout", "120",
-            "-el-timeouthandler", "30",
-            "-period-seconds", "10",
-            "-failure-threshold", "1"
-          ]
+          image: "gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/controller:v0.14.2@sha256:58baa0aa0eaca368b8090bcb6e88024847d14df2952cdfe7f22be6132a7732c9"
+          args: ["-logtostderr", "-stderrthreshold", "INFO", "-el-image", "gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/eventlistenersink:v0.14.2@sha256:b653776331a65a239df4bf833fc91bd0fe4dc28008ff4475f4cdd19415d93e55", "-el-port", "8080", "-el-readtimeout", "5", "-el-writetimeout", "40", "-el-idletimeout", "120", "-el-timeouthandler", "30", "-period-seconds", "10", "-failure-threshold", "1"]
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -37,14 +37,7 @@ func TestUpdateDeployments(t *testing.T) {
 	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 
-	pipelinesPrefix := "quay.io/openshift-pipeline/tektoncd-pipeline-"
-
-	replaceImages := map[string]string{
-		"-shell-image":  "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-		"-gsutil-image": "no-image-available",
-	}
-
-	newManifest, err := manifest.Transform(UpdateDeployments(pipelinesPrefix, replaceImages))
+	newManifest, err := manifest.Transform(RemoveRunAsUser())
 	assert.NilError(t, err)
 
 	got := &appsv1.Deployment{}
@@ -73,9 +66,7 @@ func TestUpdateDeploymentsTriggers(t *testing.T) {
 	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 
-	triggersPrefix := "quay.io/openshift-pipeline/tektoncd-triggers-"
-
-	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}))
+	newManifest, err := manifest.Transform(RemoveRunAsUser())
 	assert.NilError(t, err)
 	newManifest, err = newManifest.Transform(RemoveRunAsGroup())
 	assert.NilError(t, err)
@@ -106,9 +97,7 @@ func TestUpdateDeploymentsInterceptor(t *testing.T) {
 	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 
-	triggersPrefix := "quay.io/openshift-pipeline/tektoncd-triggers-"
-
-	newManifest, err := manifest.Transform(UpdateDeployments(triggersPrefix, map[string]string{}))
+	newManifest, err := manifest.Transform(RemoveRunAsUser())
 	assert.NilError(t, err)
 	newManifest, err = newManifest.Transform(RemoveRunAsGroup())
 	assert.NilError(t, err)

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -40,14 +40,6 @@ const (
 	// DefaultDisableAffinityAssistant is default value of disable affinity assistant flag
 	DefaultDisableAffinityAssistant = true
 	monitoringLabel                 = "openshift.io/cluster-monitoring=true"
-	pipelinesPrefix                 = "quay.io/openshift-pipeline/tektoncd-pipeline-"
-)
-
-var (
-	replaceImgs = map[string]string{
-		"-shell-image":  "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-		"-gsutil-image": "no-image-available",
-	}
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -77,7 +69,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		common.InjectLabelOnNamespace(monitoringLabel),
 		occommon.ApplyCABundles,
-		occommon.UpdateDeployments(pipelinesPrefix, replaceImgs),
+		occommon.RemoveRunAsUser(),
 	}
 }
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -28,8 +28,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const triggersPrefix = "quay.io/openshift-pipeline/tektoncd-triggers-"
-
 func OpenShiftExtension(ctx context.Context) common.Extension {
 	ext := openshiftExtension{
 		operatorClientSet: operatorclient.Get(ctx),
@@ -43,7 +41,7 @@ type openshiftExtension struct {
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{
-		occommon.UpdateDeployments(triggersPrefix, map[string]string{}),
+		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundles,
 	}


### PR DESCRIPTION
Currently, we don't have quay images for all versions for pipelines,
triggers so `make TARGET=openshift apply` would work with only
last build images that is v0.24.3 and v0.14.2.
This disable the image replacement so on openshift `make TARGET=openshift apply`
will deploy with gcr.io images.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
