### PR TITLE
Add enable-api-fields field for TektonTriggers

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -26,8 +26,8 @@ const (
 	ClusterTasksParam      = "clusterTasks"
 	PipelineTemplatesParam = "pipelineTemplates"
 
-	PipelineApiFieldAlpha  = "alpha"
-	PipelineApiFieldStable = "stable"
+	ApiFieldAlpha  = "alpha"
+	ApiFieldStable = "stable"
 )
 
 var (

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -91,3 +91,29 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
 	}
 }
+
+func Test_SetDefaults_Triggers_Properties(t *testing.T) {
+
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Profile: ProfileLite,
+			Trigger: Trigger{
+				TriggersProperties: TriggersProperties{
+					EnableApiFields: "alpha",
+				},
+			},
+		},
+	}
+
+	tc.SetDefaults(context.TODO())
+	if tc.Spec.Trigger.EnableApiFields == "stable" {
+		t.Error("Setting default failed for TektonConfig (spec.trigger.triggersProperties)")
+	}
+}

--- a/pkg/apis/operator/v1alpha1/tektonconfig_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_defaults.go
@@ -26,6 +26,7 @@ func (tc *TektonConfig) SetDefaults(ctx context.Context) {
 	}
 
 	tc.Spec.Pipeline.PipelineProperties.setDefaults()
+	tc.Spec.Trigger.TriggersProperties.setDefaults()
 
 	setAddonDefaults(&tc.Spec.Addon.Params)
 

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -46,7 +46,9 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(validateAddonParams(tc.Spec.Addon.Params, "spec.addon.params"))
 	}
 
-	return errs.Also(tc.Spec.Pipeline.PipelineProperties.validate("spec.pipeline"))
+	errs = errs.Also(tc.Spec.Pipeline.PipelineProperties.validate("spec.pipeline"))
+
+	return errs.Also(tc.Spec.Trigger.TriggersProperties.validate("spec.trigger"))
 }
 
 func (p Prune) validate() *apis.FieldError {

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -201,3 +201,27 @@ func Test_ValidateTektonConfig_InvalidPipelineProperties(t *testing.T) {
 	err := tc.Validate(context.TODO())
 	assert.Equal(t, "invalid value: test: spec.pipeline.enable-api-fields", err.Error())
 }
+
+func Test_ValidateTektonConfig_InvalidTriggerProperties(t *testing.T) {
+
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Profile: "all",
+			Trigger: Trigger{
+				TriggersProperties: TriggersProperties{
+					EnableApiFields: "test",
+				},
+			},
+		},
+	}
+
+	err := tc.Validate(context.TODO())
+	assert.Equal(t, "invalid value: test: spec.trigger.enable-api-fields", err.Error())
+}

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -49,7 +49,7 @@ func (p *PipelineProperties) setDefaults() {
 		p.EnableCustomTasks = ptr.Bool(false)
 	}
 	if p.EnableApiFields == "" {
-		p.EnableApiFields = PipelineApiFieldStable
+		p.EnableApiFields = ApiFieldStable
 	}
 	if p.ScopeWhenExpressionsToTask == nil {
 		p.ScopeWhenExpressionsToTask = ptr.Bool(false)

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -38,7 +38,7 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 func (p *PipelineProperties) validate(path string) (errs *apis.FieldError) {
 
 	if p.EnableApiFields != "" {
-		if p.EnableApiFields == PipelineApiFieldStable || p.EnableApiFields == PipelineApiFieldAlpha {
+		if p.EnableApiFields == ApiFieldStable || p.EnableApiFields == ApiFieldAlpha {
 			return errs
 		}
 		errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, path+".enable-api-fields"))

--- a/pkg/apis/operator/v1alpha1/tektontrigger_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_defaults.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+)
+
+func (tt *TektonTrigger) SetDefaults(ctx context.Context) {
+	tt.Spec.TriggersProperties.setDefaults()
+}
+
+func (p *TriggersProperties) setDefaults() {
+
+	if p.EnableApiFields == "" {
+		p.EnableApiFields = ApiFieldStable
+	}
+
+}

--- a/pkg/apis/operator/v1alpha1/tektontrigger_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_defaults_test.go
@@ -23,38 +23,29 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/ptr"
 )
 
-func Test_SetDefaults_PipelineProperties(t *testing.T) {
+func Test_SetDefaults_TriggersProperties(t *testing.T) {
 
-	tp := &TektonPipeline{
+	tt := &TektonTrigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "name",
 			Namespace: "namespace",
 		},
-		Spec: TektonPipelineSpec{
+		Spec: TektonTriggerSpec{
 			CommonSpec: CommonSpec{
 				TargetNamespace: "namespace",
 			},
 		},
 	}
 
-	properties := PipelineProperties{
-		DisableHomeEnvOverwrite:                  ptr.Bool(true),
-		DisableWorkingDirectoryOverwrite:         ptr.Bool(true),
-		DisableCredsInit:                         ptr.Bool(false),
-		RunningInEnvironmentWithInjectedSidecars: ptr.Bool(true),
-		RequireGitSshSecretKnownHosts:            ptr.Bool(false),
-		EnableTektonOciBundles:                   ptr.Bool(false),
-		EnableCustomTasks:                        ptr.Bool(false),
-		EnableApiFields:                          ApiFieldStable,
-		ScopeWhenExpressionsToTask:               ptr.Bool(false),
+	properties := TriggersProperties{
+		EnableApiFields: ApiFieldStable,
 	}
 
-	tp.SetDefaults(context.TODO())
+	tt.SetDefaults(context.TODO())
 
-	if d := cmp.Diff(properties, tp.Spec.PipelineProperties); d != "" {
+	if d := cmp.Diff(properties, tt.Spec.TriggersProperties); d != "" {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektontrigger_types.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_types.go
@@ -88,4 +88,5 @@ type Trigger struct {
 // defined for triggers only if user pass them
 type TriggersProperties struct {
 	DefaultServiceAccount string `json:"default-service-account,omitempty"`
+	EnableApiFields       string `json:"enable-api-fields,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
@@ -32,8 +32,16 @@ func (tr *TektonTrigger) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
 	}
 
-	return errs
+	return errs.Also(tr.Spec.TriggersProperties.validate("spec"))
 }
 
-func (tr *TektonTrigger) SetDefaults(ctx context.Context) {
+func (tr *TriggersProperties) validate(path string) (errs *apis.FieldError) {
+
+	if tr.EnableApiFields != "" {
+		if tr.EnableApiFields == ApiFieldStable || tr.EnableApiFields == ApiFieldAlpha {
+			return errs
+		}
+		errs = errs.Also(apis.ErrInvalidValue(tr.EnableApiFields, path+".enable-api-fields"))
+	}
+	return errs
 }

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -110,6 +110,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		return nil
 	}
 
+	// Pass the object through defaulting
+	tt.SetDefaults(ctx)
+
 	//find the valid tekton-pipeline installation
 	if _, err := common.PipelineReady(r.pipelineInformer); err != nil {
 		if err.Error() == common.PipelineNotReady {


### PR DESCRIPTION
# Changes

Since Triggers 0.16 release a new field was added `enable-api-field`
which can be used to enable features which are in `alpha`.
So this PR is to add `enable-api-fields` in TektonConfig/TektonTrigger
so that it can be configured via operator.

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Add support to configure `enable-api-field` for TektonTriggers via Operator
```