### PR TITLE
Set default value to TektonConfig object

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -91,7 +91,7 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 			logger.Errorf("error getting Tektonconfig, Name: ", instance.GetName())
 			return false, nil
 		}
-		err = tc.createInstance()
+		err = tc.createInstance(ctx)
 		if err != nil {
 			//log error and retry
 			logger.Errorf("error creating Tektonconfig instance, Name: ", instance.GetName())
@@ -108,7 +108,7 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 	}
 }
 
-func (tc tektonConfig) createInstance() error {
+func (tc tektonConfig) createInstance(ctx context.Context) error {
 	tcCR := &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: common.ConfigResourceName,
@@ -120,7 +120,8 @@ func (tc tektonConfig) createInstance() error {
 			},
 		},
 	}
+	tcCR.SetDefaults(ctx)
 	_, err := tc.operatorClientSet.OperatorV1alpha1().
-		TektonConfigs().Create(context.TODO(), tcCR, metav1.CreateOptions{})
+		TektonConfigs().Create(ctx, tcCR, metav1.CreateOptions{})
 	return err
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -108,6 +108,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 		return nil
 	}
 
+	tc.SetDefaults(ctx)
+
 	if err := r.extension.PreReconcile(ctx, tc); err != nil {
 		// If prereconcile updates the TektonConfig CR, it returns an error
 		// to reconcile


### PR DESCRIPTION
# Changes

Currently when running the Tekton operator if the controller pod is up
and webhook pod is not ready the controller will create the TektonConfig
object and that TektonConfig object will not have any default values.

This PR add the default values to TektonConfig object whenever the CR
get's created by the Controller so that even if the webhook pod is not
ready the TektonConfig CR can still have the default values.

Closes #368

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```