### PR TITLE
Refactor TektonConfig Reconciler and Cleanup

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonaddon_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -63,6 +65,17 @@ type TektonAddonStatus struct {
 	// TektonInstallerSet created to install addons
 	// +optional
 	AddonsInstallerSet map[string]string `json:"installerSets,omitempty"`
+}
+
+// Addon defines the field to customize Addon component
+type Addon struct {
+	// Params is the list of params passed for Addon customization
+	// +optional
+	Params []Param `json:"params,omitempty"`
+}
+
+func (a Addon) IsEmpty() bool {
+	return reflect.DeepEqual(a, Addon{})
 }
 
 // TektonAddonsList contains a list of TektonAddon

--- a/pkg/apis/operator/v1alpha1/tektonaddon_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"reflect"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -75,7 +73,7 @@ type Addon struct {
 }
 
 func (a Addon) IsEmpty() bool {
-	return reflect.DeepEqual(a, Addon{})
+	return len(a.Params) == 0
 }
 
 // TektonAddonsList contains a list of TektonAddon

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -24,11 +24,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var (
-	_ TektonComponent     = (*TektonConfig)(nil)
-	_ TektonComponentSpec = (*TektonConfigSpec)(nil)
-)
-
 // TektonConfig is the Schema for the TektonConfigs API
 // +genclient
 // +genreconciler:krshapedlogic=false
@@ -95,13 +90,13 @@ type TektonConfigSpec struct {
 type TektonConfigStatus struct {
 	duckv1.Status `json:",inline"`
 
+	// The profile installed
+	// +optional
+	Profile string `json:"profile,omitempty"`
+
 	// The version of the installed release
 	// +optional
 	Version string `json:"version,omitempty"`
-
-	// The url links of the manifests, separated by comma
-	// +optional
-	Manifests []string `json:"manifests,omitempty"`
 }
 
 // TektonConfigList contains a list of TektonConfig
@@ -110,17 +105,6 @@ type TektonConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TektonConfig `json:"items"`
-}
-
-// Addon defines the field to customize Addon component
-type Addon struct {
-	// Params is the list of params passed for Addon customization
-	// +optional
-	Params []Param `json:"params,omitempty"`
-}
-
-func (a Addon) IsEmpty() bool {
-	return reflect.DeepEqual(a, Addon{})
 }
 
 type Config struct {

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -505,11 +505,6 @@ func (in *TektonConfigSpec) DeepCopy() *TektonConfigSpec {
 func (in *TektonConfigStatus) DeepCopyInto(out *TektonConfigStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.Manifests != nil {
-		in, out := &in.Manifests, &out.Manifests
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektonconfig/extension.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension.go
@@ -25,7 +25,6 @@ import (
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonconfig/extension"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 func KubernetesExtension(ctx context.Context) common.Extension {
@@ -52,13 +51,7 @@ func (oe kubernetesExtension) PostReconcile(ctx context.Context, comp v1alpha1.T
 	}
 
 	if configInstance.Spec.Profile == common.ProfileLite || configInstance.Spec.Profile == common.ProfileBasic {
-		err := extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
+		return extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
 	}
 
 	return nil

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -185,7 +185,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		}
 	} else {
 		// if disabled then delete the installer Set if exist
-		return r.deleteInstallerSet(ctx, ta, clusterTaskInstallerSet)
+		if err := r.deleteInstallerSet(ctx, ta, clusterTaskInstallerSet); err != nil {
+			return err
+		}
 	}
 
 	err := r.checkComponentStatus(ctx, ta, clusterTaskInstallerSet)
@@ -207,7 +209,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		}
 	} else {
 		// if disabled then delete the installer Set if exist
-		return r.deleteInstallerSet(ctx, ta, pipelinesTemplateInstallerSet)
+		if err := r.deleteInstallerSet(ctx, ta, pipelinesTemplateInstallerSet); err != nil {
+			return err
+		}
 	}
 
 	err = r.checkComponentStatus(ctx, ta, pipelinesTemplateInstallerSet)

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"regexp"
 
-	mf "github.com/manifestival/manifestival"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	corev1 "k8s.io/api/core/v1"
@@ -50,7 +49,6 @@ var nsRegex = regexp.MustCompile(common.NamespaceIgnorePattern)
 type rbac struct {
 	kubeClientSet     kubernetes.Interface
 	operatorClientSet clientset.Interface
-	manifest          mf.Manifest
 	ownerRef          metav1.OwnerReference
 	version           string
 }

--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
@@ -48,17 +47,14 @@ const (
 type tektonConfig struct {
 	operatorClientSet versioned.Interface
 	kubeClientSet     kubernetes.Interface
-	manifest          mf.Manifest
 	namespace         string
 }
 
-func newTektonConfig(operatorClientSet versioned.Interface, kubeClientSet kubernetes.Interface,
-	manifest mf.Manifest) tektonConfig {
+func newTektonConfig(operatorClientSet versioned.Interface, kubeClientSet kubernetes.Interface) tektonConfig {
 
 	return tektonConfig{
 		operatorClientSet: operatorClientSet,
 		kubeClientSet:     kubeClientSet,
-		manifest:          manifest,
 		namespace:         os.Getenv("DEFAULT_TARGET_NAMESPACE"),
 	}
 }

--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -75,11 +75,6 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 			OperatorV1alpha1().
 			TektonConfigs().Get(context.TODO(), DefaultCRName, metav1.GetOptions{})
 		if err == nil {
-			if !instance.GetDeletionTimestamp().IsZero() {
-				// log deleting timestamp error and retry
-				logger.Errorf("deletionTimestamp is set on existing Tektonconfig instance, Name: %w", instance.GetName())
-				return false, nil
-			}
 			return true, nil
 		}
 		if !apierrs.IsNotFound(err) {


### PR DESCRIPTION
 Fixes addon component deletion 

If clustertask and pipelines templates are disabled then
due to return statement it used to return early without
executing remaning code.

-----

 Updates TektonConfig Conditions and cleanup

This updates the tektonconfig conditions and removes
unnecessary code

----

 Removes deletion timestamp check in Autocreation of TektonConfig

If TektonConfig has a deletion stamp, it won't be deleted
unless the operator is up and running as the object has
finalizer. waiting for it to get deleted will stop operator
from running and object still won't be deleted.
hence removing the condition for checking deletion timestamp
and letting user to create a new instance of tektonconfig
after deletion.



Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
