### PR TITLE
Fix adding default namespace as subjects to openshift-pipelines-clusterinterceptors clusterrolebinding

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -255,7 +255,7 @@ func (r *rbac) ensureSA(ctx context.Context, ns *corev1.Namespace) (*corev1.Serv
 		return nil, err
 	}
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("creating sa", "sa", pipelineSA, "ns", ns.Name)
+		logger.Info("creating sa ", pipelineSA, " ns", ns.Name)
 		return createSA(ctx, saInterface, ns.Name, r.ownerRef)
 	}
 
@@ -466,7 +466,9 @@ func (r *rbac) ensureClusterRoleBindings(ctx context.Context, sa *corev1.Service
 	rbacClient := r.kubeClientSet.RbacV1()
 	logger.Info("finding cluster-role ", clusterInterceptors)
 	if _, err := rbacClient.ClusterRoles().Get(ctx, clusterInterceptors, metav1.GetOptions{}); errors.IsNotFound(err) {
-		return r.createClusterRole(ctx)
+		if e := r.createClusterRole(ctx); e != nil {
+			return e
+		}
 	}
 
 	logger.Info("finding cluster-role-binding ", clusterInterceptors)


### PR DESCRIPTION
# Changes

Fixes adding of `default` namespace to `openshift-pipelines-clusterinterceptors` clusterrolebinding as subject

**Issue :** When operator installs for the first time there won't be `openshift-pipelines-clusterinterceptors` clusterrole so it installs and return from there without executing further code and because of that `default` namespace never added to subjects of `openshift-pipelines-clusterinterceptors` clusterrolebinding.

/cc @nikhil-thomas @vdemeester @sm43 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```