### PR TITLE
[OpenShift] Updates pipelines extension to use InstallerSet

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -58,9 +58,13 @@ type TektonPipelineStatus struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// The current installer set name
+	// The current installer set name for TektonPipeline
 	// +optional
 	TektonInstallerSet string `json:"tektonInstallerSet,omitempty"`
+
+	// The installer sets created for extension components
+	// +optional
+	ExtentionInstallerSets map[string]string `json:"extTektonInstallerSets,omitempty"`
 }
 
 // TektonPipelineList contains a list of TektonPipeline

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -810,6 +810,13 @@ func (in *TektonPipelineSpec) DeepCopy() *TektonPipelineSpec {
 func (in *TektonPipelineStatus) DeepCopyInto(out *TektonPipelineStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
+	if in.ExtentionInstallerSets != nil {
+		in, out := &in.ExtentionInstallerSets, &out.ExtentionInstallerSets
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -48,6 +48,7 @@ var (
 	pipelinePred                       = mf.ByKind("Pipeline")
 
 	// OpenShift Specific
+	serviceMonitorPred     = mf.ByKind("ServiceMonitor")
 	consoleCLIDownloadPred = mf.ByKind("ConsoleCLIDownload")
 	consoleQuickStartPred  = mf.ByKind("ConsoleQuickStart")
 	ConsoleYAMLSamplePred  = mf.ByKind("ConsoleYAMLSample")
@@ -95,6 +96,7 @@ func (i *installer) EnsureNamespaceScopedResources() error {
 			secretPred,
 			horizontalPodAutoscalerPred,
 			pipelinePred,
+			serviceMonitorPred,
 		)).Apply(); err != nil {
 		return err
 	}

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonpipeline
+
+import (
+	"context"
+	"fmt"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	createdByKey       = "operator.tekton.dev/created-by"
+	createdByValue     = "TektonPipeline"
+	releaseVersionKey  = "operator.tekton.dev/release-version"
+	targetNamespaceKey = "operator.tekton.dev/target-namespace"
+)
+
+// checkIfInstallerSetExist checks if installer set exists for a component and return true/false based on it
+// and if installer set which already exist is of older version/ or if target namespace is different then it
+// deletes and return false to create a new installer set
+func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVersion string,
+	tp *v1alpha1.TektonPipeline, component string) (bool, error) {
+
+	// Check if installer set is already created
+	compInstallerSet, ok := tp.Status.ExtentionInstallerSets[component]
+	if !ok {
+		return false, nil
+	}
+
+	if compInstallerSet != "" {
+		// if already created then check which version it is
+		ctIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
+			Get(ctx, compInstallerSet, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		// Check release version and target namespace
+		// If anyone of this is not as expected then delete existing
+		// installer set and create a new one
+
+		version, vOk := ctIs.Annotations[releaseVersionKey]
+		namespace, nOk := ctIs.Annotations[targetNamespaceKey]
+
+		if vOk && nOk {
+			if version == relVersion && namespace == tp.Spec.TargetNamespace {
+				// if installer set already exist
+				// release version and target namespace is as expected
+				// then ignore and move on
+				return true, nil
+			}
+		}
+
+		// release version/ target namespace doesn't exist or is different from expected
+		// deleted existing InstallerSet and create a new one
+
+		err = oc.OperatorV1alpha1().TektonInstallerSets().
+			Delete(ctx, compInstallerSet, metav1.DeleteOptions{})
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha1.TektonPipeline,
+	manifest mf.Manifest, releaseVersion, component, installerSetPrefix string) error {
+
+	is := makeInstallerSet(tp, manifest, installerSetPrefix, releaseVersion)
+
+	createdIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
+		Create(ctx, is, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(tp.Status.ExtentionInstallerSets) == 0 {
+		tp.Status.ExtentionInstallerSets = map[string]string{}
+	}
+
+	// Update the status of pipeline with created installerSet name
+	tp.Status.ExtentionInstallerSets[component] = createdIs.Name
+
+	_, err = oc.OperatorV1alpha1().TektonPipelines().
+		UpdateStatus(ctx, tp, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix, releaseVersion string) *v1alpha1.TektonInstallerSet {
+	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
+	return &v1alpha1.TektonInstallerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", prefix),
+			Labels: map[string]string{
+				createdByKey: createdByValue,
+			},
+			Annotations: map[string]string{
+				releaseVersionKey:  releaseVersion,
+				targetNamespaceKey: tp.Spec.TargetNamespace,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.TektonInstallerSetSpec{
+			Manifests: manifest.Resources(),
+		},
+	}
+}
+
+func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha1.TektonPipeline, component string) error {
+
+	compInstallerSet, ok := ta.Status.ExtentionInstallerSets[component]
+	if !ok {
+		return nil
+	}
+
+	if compInstallerSet != "" {
+		// delete the installer set
+		err := oc.OperatorV1alpha1().TektonInstallerSets().
+			Delete(ctx, ta.Status.ExtentionInstallerSets[component], metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		// clear the name of installer set from TektonPipeline status
+		delete(ta.Status.ExtentionInstallerSets, component)
+		_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This updates the extension to use installer set for pre and
post reconciler, this will allow change of targetnamespace now
previously the target namespace for extension resources was
hardcoded to openshift-pipelines and was not possible to change.
Installer set will allow this now.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
