### PR TITLE
Fixes AppendManifest used to read files from kodata

### DIFF
--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -174,19 +174,10 @@ func latestRelease(instance v1alpha1.TektonComponent) string {
 }
 
 func AppendManifest(manifest *mf.Manifest, yamlLocation string) error {
-	var files []string
-	if err := filepath.Walk(yamlLocation, func(path string, info os.FileInfo, err error) error {
-		files = append(files, path)
-		return nil
-	}); err != nil {
+	m, err := mf.ManifestFrom(mf.Recursive(yamlLocation))
+	if err != nil {
 		return err
 	}
-	for i := range files {
-		m, err := Fetch(files[i])
-		if err != nil {
-			return err
-		}
-		*manifest = manifest.Append(m)
-	}
+	*manifest = manifest.Append(m)
 	return nil
 }

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 )
@@ -46,4 +47,29 @@ func TestListReleases(t *testing.T) {
 	version, err := allReleases(&v1alpha1.TektonTrigger{})
 	util.AssertEqual(t, err, nil)
 	util.AssertDeepEqual(t, version, expectedVersionList)
+}
+
+func TestAppendManifest(t *testing.T) {
+
+	// Case 1
+	var manifest mf.Manifest
+	err := AppendManifest(&manifest, "testdata/kodata/tekton-addon")
+	if err != nil {
+		t.Fatal("failed to read yaml: ", err)
+	}
+
+	if len(manifest.Resources()) != 3 {
+		t.Fatalf("failed to find expected number of resource: %d found, expected 3", len(manifest.Resources()))
+	}
+
+	// Case 2
+	var newManifest mf.Manifest
+	err = AppendManifest(&newManifest, "testdata/kodata/tekton-addon/0.0.1")
+	if err != nil {
+		t.Fatal("failed to read yaml: ", err)
+	}
+
+	if len(newManifest.Resources()) != 1 {
+		t.Fatalf("failed to find expected number of resource: %d found, expected 3", len(newManifest.Resources()))
+	}
 }

--- a/pkg/reconciler/common/testdata/kodata/tekton-addon/0.0.2/01-clustertriggerbindings/bitbucket.yaml
+++ b/pkg/reconciler/common/testdata/kodata/tekton-addon/0.0.2/01-clustertriggerbindings/bitbucket.yaml
@@ -1,0 +1,22 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: bitbucket-pullreq-0.0.2
+spec:
+  params:
+    - name: gitrepo-url
+      value: $(body.pullRequest.fromRef.repository.links.clone[0].href)
+    - name: pullreq-sha
+      value: $(body.pullRequest.fromRef.latestCommit)
+    - name: pullreq-state
+      value: $(body.pullRequest.state)
+    - name: pullreq-number
+      value: $(body.pullRequest.id)
+    - name: pullreq-repo-name
+      value: $(body.pullRequest.toRef.repository.name)
+    - name: pullreq-html-url
+      value: $(body.pullRequest.links.self[0].href)
+    - name: pullreq-title
+      value: $(body.pullRequest.title)
+    - name: user-type
+      value: $(body.pullRequest.author.user.type)

--- a/pkg/reconciler/common/testdata/kodata/tekton-addon/bitbucket-1.yaml
+++ b/pkg/reconciler/common/testdata/kodata/tekton-addon/bitbucket-1.yaml
@@ -1,0 +1,22 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: bitbucket-pullreq-no-version
+spec:
+  params:
+    - name: gitrepo-url
+      value: $(body.pullRequest.fromRef.repository.links.clone[0].href)
+    - name: pullreq-sha
+      value: $(body.pullRequest.fromRef.latestCommit)
+    - name: pullreq-state
+      value: $(body.pullRequest.state)
+    - name: pullreq-number
+      value: $(body.pullRequest.id)
+    - name: pullreq-repo-name
+      value: $(body.pullRequest.toRef.repository.name)
+    - name: pullreq-html-url
+      value: $(body.pullRequest.links.self[0].href)
+    - name: pullreq-title
+      value: $(body.pullRequest.title)
+    - name: user-type
+      value: $(body.pullRequest.author.user.type)


### PR DESCRIPTION
Previously, if we pass a path to AppendManifest
for ex. `/kodata/tekton/abc.yaml` and later
        `/kodata/tekton/`
both use to read the file and add in the manifest, which
would make manifest to have the same resource twice.

This patch updates the AppendManifest func to use mf.ManifestFrom
    which will recursively read all files from a location by passing
    the path to it.

Closes #425 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
