### PR TITLE
Modify olm.skipRange handling in bundle generator

### DIFF
--- a/operatorhub/openshift/README.md
+++ b/operatorhub/openshift/README.md
@@ -7,24 +7,25 @@ bundle for using `local` strategy.
 
 **Note:** The input release.yaml could be a github release or the result of `ko resolve config`
 
-1. From the project root (tektoncd/operator) run
+ From the project root (tektoncd/operator) run
 
     ```bash
     OPERATOR_RELEASE_VERSION=x.y.z
     PREVIOUS_OPERATOR_RELEASE_VERSION=a.b.c
-    export BUNDLE_ARGS="--workspace operatorhub/openshift --operator-release-version ${OPERATOR_RELEASE_VERSION} --channels stable,preview --default-channel stable --fetch-strategy-local --upgrade-strategy-replaces --operator-release-previous-version ${PREVIOUS_OPERATOR_RELEASE_VERSION}"
+    export BUNDLE_ARGS="--workspace operatorhub/openshift --operator-release-version ${OPERATOR_RELEASE_VERSION} --channels stable,preview --default-channel stable --fetch-strategy-local --upgrade-strategy-replaces --operator-release-previous-version ${PREVIOUS_OPERATOR_RELEASE_VERSION} --olm-skip-range '>=1.5.0 <1.6.0'"
     make operator-bundle
     ```
 
    **CLI flags explained**
 
-   Flag                                          | Description
-       --------------------------------------------- | -----------
-   `--workspace operatorhub/openshift`           | the working directory where the operator bundle should be assembled
-   `--operator-release-version 1.6.0`            | version of the release (version of bundle)
-   `--channels stable,preview`                   | target release channel(s) (eg: stable,preview)
-   `--default-channel stable`                    | set default channel of the operator
-   `--fetch-strategy-local`                      | gather input resources definitions from a local yaml files
-   `--upgrade-strategy-replaces`                 | specify update strategy (use `replaces` or `semver`)
-   `--operator-release-previous-version 1.5.0`   | version of the previous operator release that will be replaced by the bundle being built
+   Flag                                                    | Description
+       ----------------------------------------------------| -----------
+   `--workspace operatorhub/openshift`                     | the working directory where the operator bundle should be assembled
+   `--operator-release-version 1.6.0`                      | version of the release (version of bundle)
+   `--channels stable,preview`                             | target release channel(s) (eg: stable,preview)
+   `--default-channel stable`                              | set default channel of the operator
+   `--fetch-strategy-local`                                | gather input resources definitions from a local yaml files
+   `--upgrade-strategy-replaces`                           | specify update strategy (use `replaces` or `semver`)
+   `--operator-release-previous-version 1.5.0`             | version of the previous operator release that will be replaced by the bundle being built
+   `--olm-skip-range '>=1.5.0 <1.6.0'`                     | add olm.skipRange to the CSV file in the bundle
     ````

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     description: Red Hat OpenShift Pipelines is a cloud-native CI/CD solution for
       building pipelines using Tekton concepts which run natively on OpenShift and
       Kubernetes.
-    olm.skipRange: '>=1.5.2 <1.6.0'
+    olm.skipRange: '>=1.5.0 <1.6.0'
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev",

--- a/operatorhub/tools/bundle-too-cli-flags.md
+++ b/operatorhub/tools/bundle-too-cli-flags.md
@@ -32,6 +32,8 @@ optional arguments:
   --channels CHANNELS   channels
   --default-channel DEFAULT_CHANNEL
                         default channel
+  --olm-skip-range OLM_SKIP_RANGE
+                        value for olm.skipRange annotation in CSV file in the bundle
   --addn-annotations <key1>=<val1>,<key2><val2>,...<keyn>=<valn>
                         additional annotations to be added to CSV file
   --addn-labels <key1>=<val1>,<key2><val2>,...<keyn>=<valn>

--- a/operatorhub/tools/bundle.py
+++ b/operatorhub/tools/bundle.py
@@ -33,6 +33,7 @@ def buildConfig():
     config["release-version"] = args.operator_release_version
     config["channels"] = args.channels
     config["default-channel"] = args.default_channel
+    config["olm-skip-range"] = args.olm_skip_range
     config["verbose"] = args.verbose
     debug(config, yaml.dump(config))
     return config
@@ -74,6 +75,7 @@ def setParser():
                         help='previous version')
     parser.add_argument('--channels', help='channels',required=True)
     parser.add_argument('--default-channel', help='default channel', required=True)
+    parser.add_argument('--olm-skip-range', help='value for olm.skipRange annotation in CSV file in the bundle', required=False)
     parser.add_argument('--addn-annotations',
                         help='additional annotations to be added to CSV file',
                         metavar='<key1>=<val1>,<key2><val2>,...<keyn>=<valn>')
@@ -222,8 +224,8 @@ def newCSVmods(config):
                 csv['spec']['version']
                 if config["upgrade-strategy"] == UPGRADE_STRATEGY_REPLACE:
                     csv['spec']['replaces'] = config["previous-release-version"]
-                    olm_skipRange = f'>={config["previous-release-version"]} <{config["release-version"]}'
-                    csv['metadata']['annotations']['olm.skipRange'] = olm_skipRange
+                if config["olm-skip-range"]:
+                    csv['metadata']['annotations']['olm.skipRange'] = config["olm-skip-range"]
                 if "addn-annotations" in config.keys():
                     csv['metadata']['annotations'].update(config["addn-annotations"])
                 if "addn-labels" in config.keys():


### PR DESCRIPTION
Add a `--olm-skip-range` flag to capture explicit value for
`olm.skipRange` annotation

Note: Earlier the tool used to compute the upper and lower bounds for
skipRange from `operator-version` and `previous-operator-version`
arguments. This lack the flexibility to set a skipRange which is defined
by a development teams release process.

Note: The already existing flag `--addn-annotations key1=val1,key2=val2` couldn't
 be used as the parsing fails on the special characters in skipRanges.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```