### PR TITLE
update cronjob api to v1

### DIFF
--- a/pkg/reconciler/common/prune_test.go
+++ b/pkg/reconciler/common/prune_test.go
@@ -114,7 +114,7 @@ func TestCompleteFlowPrune(t *testing.T) {
 	if err != nil {
 		assert.Error(t, err, "unable to initiate prune")
 	}
-	cronjobs, err := client.BatchV1beta1().CronJobs("").List(context.TODO(), metav1.ListOptions{})
+	cronjobs, err := client.BatchV1().CronJobs("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		assert.Error(t, err, "unable to get cronjobs ")
 	}
@@ -213,7 +213,7 @@ func TestAnnotationCmd(t *testing.T) {
 	if err != nil {
 		assert.Error(t, err, "unable to get ns list")
 	}
-	cronjobs, err := client.BatchV1beta1().CronJobs("").List(context.TODO(), metav1.ListOptions{})
+	cronjobs, err := client.BatchV1().CronJobs("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		assert.Error(t, err, "unable to get ns list")
 	}


### PR DESCRIPTION
Cronjob related api were using `batch/v1beta1` which is now
deprecated, with this it is updated to `batch/v1`

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
