### PR TITLE
[OpenShift] Fixes configmap update error & handles reconcile error

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 package v1alpha1
 
+import "fmt"
+
+var (
+	// RECONCILE_AGAIN_ERR
+	// When we updates spec or status we reconcile again and then proceed so
+	// that we proceed ahead with updated object
+	RECONCILE_AGAIN_ERR = fmt.Errorf("reconcile again and proceed")
+)
+
 const (
 	// Profiles
 	ProfileAll   = "all"

--- a/pkg/reconciler/kubernetes/tektonconfig/controller.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/controller.go
@@ -18,11 +18,11 @@ package tektonconfig
 
 import (
 	"context"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	tektonDashboardinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektondashboard"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig"
+	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 )

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -69,6 +69,10 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		if _, err := oe.operatorClientSet.OperatorV1alpha1().TektonConfigs().Update(ctx, config, v1.UpdateOptions{}); err != nil {
 			return err
 		}
+
+		// here we return an error intentionally so that we reconcile again
+		// and proceed further with an updated object
+		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
 	createRBACResource := true

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -88,9 +88,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	tc.SetDefaults(ctx)
 
 	if err := r.extension.PreReconcile(ctx, tc); err != nil {
-		// If pre-reconcile updates the TektonConfig CR, it returns an error
-		// to reconcile
-		if err.Error() == "reconcile" {
+		if err == v1alpha1.RECONCILE_AGAIN_ERR {
 			return err
 		}
 		tc.Status.MarkPreInstallFailed(err.Error())


### PR DESCRIPTION
This fixes the error which was occuring while updating configmap
as the obj passed was invalid so error was occuring, this fixes
those error.

Also, whenever we update spec or status of obj we return an error
so that we proceed further with an updated object. this patch also
handles those in tektonconfig.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
