### PR TITLE
docs: fix typo in toleration required by operator

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -63,7 +63,7 @@ On Kubernetes, `all` profile will install `TektonDashboard` and on OpenShift `Te
 Config provides fields to configure deployments created by the Operator.
 This provides following fields:
 - [`nodeSelector`][node-selector]
-- [`toleration`][toleration]
+- [`tolerations`][tolerations]
 
 User can pass the required fields and this would be passed to all Operator components which will get added in all
 deployments created by Operator.
@@ -73,7 +73,7 @@ Example:
 config:
   nodeSelector:
     key: value
-  toleration:
+  tolerations:
   - key: "key1"
     operator: "Equal"
     value: "value1"
@@ -165,5 +165,5 @@ This is an `Optional` section.
 
 
 [node-selector]:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-[toleration]:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[tolerations]:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [schedule]:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The operator is looking for `tolerations` instead of `toleration` as defined in the documentation. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Update documentation to reflect required tolerations config by operator
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
