### PR TITLE
Mutate tekton-pipelines namespace for ClusterRoles

### DIFF
--- a/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-role.yaml
+++ b/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-role.yaml
@@ -1,0 +1,23 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-webhook-cluster-access
+rules:
+  # […]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can Get the system namespace.
+    resourceNames: ["tekton-pipelines"]
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"]
+    verbs: ["update"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can update the system namespace finalizers.
+    resourceNames: ["tekton-pipelines"]


### PR DESCRIPTION

# Changes

This adds a new transformer that mutate tekton-pipelines namespaces
references in ClusterRoles rules to use the targetNamespace.

This fixes the webhook errors on OpenShift or if the operator uses a
different `targetNamespace` than `tekton-pipelines`

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sm43 @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
mutate tekton-pipelines namespaces reference in ClusterRoles. This fixes the webhook errors when using a different targetNamespace (such as, on the OpenShift target)
```
