### PR TITLE
Adds Hub UI Component in operator

### DIFF
--- a/config/base/300-operator_v1alpha1_hub_crd.yaml
+++ b/config/base/300-operator_v1alpha1_hub_crd.yaml
@@ -47,6 +47,9 @@ spec:
         - jsonPath: .status.apiUrl
           name: ApiUrl
           type: string
+        - jsonPath: .status.uiUrl
+          name: UiUrl
+          type: string
       schema:
         openAPIV3Schema:
           type: object

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -131,7 +131,7 @@ release_yaml_hub() {
   mkdir -p ${dirPath} || true
 
   url=""
-  components="db db-migration api"
+  components="db db-migration api ui"
 
   for component in ${components}; do
     dest=${dirPath}/${component}
@@ -142,6 +142,9 @@ release_yaml_hub() {
 
     [[ ${component} == "api" ]] && fileName=${component}-k8s.yaml
     [[ ${component} == "api" ]] && [[ ${TARGET} == "openshift" ]] && fileName=${component}-openshift.yaml
+
+    [[ ${component} == "ui" ]] && fileName=${component}-k8s.yaml
+    [[ ${component} == "ui" ]] && [[ ${TARGET} == "openshift" ]] && fileName=${component}-openshift.yaml
 
     url="https://github.com/tektoncd/hub/releases/download/${version}/${fileName}"
     echo $url

--- a/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
@@ -34,4 +34,5 @@ func (th *TektonHub) SetDefaults(ctx context.Context) {
 	if th.Spec.CommonSpec.TargetNamespace == "" {
 		th.Spec.CommonSpec.TargetNamespace = os.Getenv("DEFAULT_TARGET_NAMESPACE")
 	}
+
 }

--- a/pkg/apis/operator/v1alpha1/tektonhub_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_lifecycle.go
@@ -30,6 +30,9 @@ const (
 	// API
 	ApiDependenciesInstalled apis.ConditionType = "ApiDependenciesInstalled"
 	ApiInstallerSetAvailable apis.ConditionType = "ApiInstallSetAvailable"
+	// UI
+	UiDependenciesInstalled apis.ConditionType = "UiDependenciesInstalled"
+	UiInstallerSetAvailable apis.ConditionType = "UiInstallSetAvailable"
 )
 
 var (
@@ -45,6 +48,8 @@ var (
 		PreReconciler,
 		ApiDependenciesInstalled,
 		ApiInstallerSetAvailable,
+		UiDependenciesInstalled,
+		UiInstallerSetAvailable,
 		PostReconciler,
 	)
 )
@@ -159,6 +164,49 @@ func (ths *TektonHubStatus) MarkApiInstallerSetNotAvailable(msg string) {
 
 func (ths *TektonHubStatus) MarkApiInstallerSetAvailable() {
 	hubCondSet.Manage(ths).MarkTrue(ApiInstallerSetAvailable)
+}
+
+// UI
+func (ths *TektonHubStatus) MarkUiDependencyInstalling(msg string) {
+	ths.MarkNotReady("Dependencies installing for UI")
+	hubCondSet.Manage(ths).MarkFalse(
+		UiDependenciesInstalled,
+		"Error",
+		"Dependencies are installing for UI: %s", msg)
+}
+
+func (ths *TektonHubStatus) MarkUiDependencyMissing(msg string) {
+	ths.MarkNotReady("Missing Dependencies for UI")
+	hubCondSet.Manage(ths).MarkFalse(
+		UiDependenciesInstalled,
+		"Error",
+		"Dependencies are missing for UI: %s", msg)
+}
+
+func (ths *TektonHubStatus) MarkUiDependenciesInstalled() {
+	hubCondSet.Manage(ths).MarkTrue(UiDependenciesInstalled)
+}
+
+func (ths *TektonHubStatus) MarkUiInstallerSetNotAvailable(msg string) {
+	ths.MarkNotReady("TektonInstallerSet not ready for UI")
+	hubCondSet.Manage(ths).MarkFalse(
+		UiInstallerSetAvailable,
+		"Error",
+		"Installer set not ready for UI: %s", msg)
+}
+
+func (ths *TektonHubStatus) MarkUiInstallerSetAvailable() {
+	hubCondSet.Manage(ths).MarkTrue(UiInstallerSetAvailable)
+}
+
+// GetManifests gets the url links of the manifests.
+func (ths *TektonHubStatus) GetUiRoute() string {
+	return ths.UiRouteUrl
+}
+
+// SetManifests sets the url links of the manifests.
+func (ths *TektonHubStatus) SetUiRoute(routeUrl string) {
+	ths.UiRouteUrl = routeUrl
 }
 
 func (ths *TektonHubStatus) MarkPreReconcilerFailed(msg string) {

--- a/pkg/apis/operator/v1alpha1/tektonhub_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_lifecycle_test.go
@@ -74,6 +74,18 @@ func TestTektonHubHappyPath(t *testing.T) {
 	th.MarkApiDependenciesInstalled()
 	apistest.CheckConditionSucceeded(th, ApiDependenciesInstalled, t)
 
+	// UI
+	th.MarkUiDependenciesInstalled()
+	apistest.CheckConditionSucceeded(th, UiDependenciesInstalled, t)
+
+	// InstallerSet is not ready when deployment pods are not up
+	th.MarkUiInstallerSetNotAvailable("waiting for UI deployments")
+	apistest.CheckConditionFailed(th, UiInstallerSetAvailable, t)
+
+	// Installer set created for UI
+	th.MarkUiInstallerSetAvailable()
+	apistest.CheckConditionSucceeded(th, UiInstallerSetAvailable, t)
+
 	th.MarkPreReconcilerComplete()
 	apistest.CheckConditionSucceeded(th, PreReconciler, t)
 
@@ -138,6 +150,18 @@ func TestTektonHubErrorPath(t *testing.T) {
 	// Installer set created for API
 	th.MarkApiInstallerSetAvailable()
 	apistest.CheckConditionSucceeded(th, ApiInstallerSetAvailable, t)
+
+	// UI
+	th.MarkUiDependenciesInstalled()
+	apistest.CheckConditionSucceeded(th, UiDependenciesInstalled, t)
+
+	// InstallerSet is not ready when deployment pods are not up
+	th.MarkUiInstallerSetNotAvailable("waiting for UI deployments")
+	apistest.CheckConditionFailed(th, UiInstallerSetAvailable, t)
+
+	// Installer set created for UI
+	th.MarkUiInstallerSetAvailable()
+	apistest.CheckConditionSucceeded(th, UiInstallerSetAvailable, t)
 
 	th.MarkPostReconcilerComplete()
 	apistest.CheckConditionSucceeded(th, PostReconciler, t)

--- a/pkg/apis/operator/v1alpha1/tektonhub_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_types.go
@@ -83,6 +83,10 @@ type TektonHubStatus struct {
 	// +optional
 	AuthRouteUrl string `json:"authUrl,omitempty"`
 
+	// The URL route for UI which needs to be exposed
+	// +optional
+	UiRouteUrl string `json:"uiUrl,omitempty"`
+
 	// The current installer set name
 	// +optional
 	HubInstallerSet map[string]string `json:"hubInstallerSets,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonhub_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_validation.go
@@ -50,6 +50,7 @@ func (th *TektonHub) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(th.Spec.Db.validate("spec.db"))
 
 	return errs.Also(th.Spec.Api.validate("spec.api"))
+
 }
 
 func (db *DbSpec) validate(path string) (errs *apis.FieldError) {


### PR DESCRIPTION
  - This patch adds Hub UI in operator where it deploys
    Hub UI

  Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
