### PR TITLE
[CherryPick] [OpenShift] Adds SCC predicate in TektonInstallerSet

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -48,11 +48,12 @@ var (
 	pipelinePred                       = mf.ByKind("Pipeline")
 
 	// OpenShift Specific
-	serviceMonitorPred     = mf.ByKind("ServiceMonitor")
-	routePred              = mf.ByKind("Route")
-	consoleCLIDownloadPred = mf.ByKind("ConsoleCLIDownload")
-	consoleQuickStartPred  = mf.ByKind("ConsoleQuickStart")
-	ConsoleYAMLSamplePred  = mf.ByKind("ConsoleYAMLSample")
+	securityContextConstraints = mf.ByKind("SecurityContextConstraints")
+	serviceMonitorPred         = mf.ByKind("ServiceMonitor")
+	routePred                  = mf.ByKind("Route")
+	consoleCLIDownloadPred     = mf.ByKind("ConsoleCLIDownload")
+	consoleQuickStartPred      = mf.ByKind("ConsoleQuickStart")
+	ConsoleYAMLSamplePred      = mf.ByKind("ConsoleYAMLSample")
 )
 
 type installer struct {
@@ -80,6 +81,7 @@ func (i *installer) EnsureClusterScopedResources() error {
 			consoleCLIDownloadPred,
 			consoleQuickStartPred,
 			ConsoleYAMLSamplePred,
+			securityContextConstraints,
 		)).Apply(); err != nil {
 		return err
 	}


### PR DESCRIPTION
TektonInstallerSet was missing SecurityContextConstraints predicate
due to which scc was not getting installed in OpenShift, this adds it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
