### PR TITLE
Suffix _VERSION to "config" versions env vars.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
 
 KO = $(or ${KO_BIN},${KO_BIN},$(BIN)/ko)
 
-PIPELINES ?= latest
-TRIGGERS ?= latest
-DASHBOARD ?= latest
-RESULTS ?= latest
+PIPELINES_VERSION ?= latest
+TRIGGERS_VERSION ?= latest
+DASHBOARD_VERSION ?= latest
+RESULTS_VERSION ?= latest
 
 $(BIN)/ko: PACKAGE=github.com/google/ko/cmd/ko
 
@@ -87,7 +87,7 @@ bin/%: cmd/% FORCE
 
 .PHONY: get-releases
 get-releases: |
-	$Q ./hack/fetch-releases.sh $(TARGET) $(PIPELINES) $(TRIGGERS) $(DASHBOARD) $(RESULTS) || exit ;
+	$Q ./hack/fetch-releases.sh $(TARGET) $(PIPELINES_VERSION) $(TRIGGERS_VERSION) $(DASHBOARD_VERSION) $(RESULTS_VERSION) || exit ;
 
 .PHONY: apply
 apply: | $(KO) $(KUSTOMIZE) get-releases ; $(info $(M) ko apply on $(TARGET)) @ ## Apply config to the current cluster
@@ -116,4 +116,3 @@ generated: | vendor ; $(info $(M) update generated files) ## Update generated fi
 .PHONY: vendor
 vendor: ; $(info $(M) update vendor folder)  ## Update vendor folder
 	$Q ./hack/update-deps.sh
-

--- a/test/config.sh
+++ b/test/config.sh
@@ -1,4 +1,4 @@
-export PIPELINES=latest
-export TRIGGERS=latest
-export RESULTS=latest
-export DASHBOARD=latest
+export PIPELINES_VERSION=latest
+export TRIGGERS_VERSION=latest
+export RESULTS_VERSION=latest
+export DASHBOARD_VERSION=latest

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -29,11 +29,11 @@ source $(dirname $0)/config.sh
 function install_operator_resources() {
 
   echo :Payload Targets:
-  echo Pipelines: ${PIPELINES}
-  echo Triggers: ${TRIGGERS}
+  echo Pipelines: ${PIPELINES_VERSION}
+  echo Triggers: ${TRIGGERS_VERSION}
   if [[ ${TARGET} != "openshift" ]]; then
-    echo Results: ${RESULTS}
-    echo Dashboard: ${DASHBOARD}
+    echo Results: ${RESULTS_VERSION}
+    echo Dashboard: ${DASHBOARD_VERSION}
   fi
   echo '------------------------------'
 


### PR DESCRIPTION


# Changes

The idea here is to use `PIPELINES_VERSIONS`, `TRIGGERS_VERSIONS`, …
in `test/config.sh` and the `Makefile` in order to be able to just
source the config.sh on a release branch and follow the
cheatsheet *safely*.

With #490, it should "smooth" the bugfix release process and reduce possible human-errors, getting us closer to release automation 👼🏼 .

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @nikhil-thomas @sm43 
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
