### PR TITLE
Updates Operator for Results v0.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ KO = $(or ${KO_BIN},${KO_BIN},$(BIN)/ko)
 PIPELINES_VERSION ?= latest
 TRIGGERS_VERSION ?= latest
 DASHBOARD_VERSION ?= latest
-RESULTS_VERSION ?= latest
+RESULTS_VERSION ?= v0.3.1 # latest returns an older version hence hard coding to v0.3.1 for now (tektoncd/results#138)
 
 $(BIN)/ko: PACKAGE=github.com/google/ko/cmd/ko
 

--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -20,7 +20,7 @@ To install Tekton Result on your cluster follow steps as given below:
   the following properties:
 
     - namespace: `tekton-pipelines`
-    - name: `tekton-results-mysql`
+    - name: `tekton-results-postgres`
     - contains the fields:
         - `user=root`
         - `password=<your password>`
@@ -30,7 +30,7 @@ To install Tekton Result on your cluster follow steps as given below:
   Update namespace value in the command if Tekton Pipelines is installed in a different namespace..
 
    ```sh
-   $ kubectl create secret generic tekton-results-mysql --namespace=tekton-pipelines --from-literal=user=root --from-literal=password=$(openssl rand -base64 20)
+   $ kubectl create secret generic tekton-results-postgres --namespace="tekton-pipelines" --from-literal=POSTGRES_USER=postgres --from-literal=POSTGRES_PASSWORD=$(openssl rand -base64 20)
    ```
 - Generate cert/key pair. 
   Note: Feel free to use any cert management software to do this!

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	DbSecretName  = "tekton-results-mysql"
+	DbSecretName  = "tekton-results-postgres"
 	TlsSecretName = "tekton-results-tls"
 )
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -1,4 +1,4 @@
 export PIPELINES_VERSION=latest
 export TRIGGERS_VERSION=latest
-export RESULTS_VERSION=latest
+export RESULTS_VERSION=v0.3.1
 export DASHBOARD_VERSION=latest

--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -125,8 +125,8 @@ func createSecret(t *testing.T, clients *utils.Clients, namespace string) {
 			Name: tektonresult.DbSecretName,
 		},
 		Data: map[string][]byte{
-			"user":     []byte("root"),
-			"password": []byte("test"),
+			"POSTGRES_USER":     []byte("postgres"),
+			"POSTGRES_PASSWORD": []byte("test"),
 		},
 	}
 


### PR DESCRIPTION
In v0.3.1, the db secret name is changed as Results API now uses a
Postgres implementation instead of MySQL.

Also, updates the CI to fetch 0.3.1 for testing instead of latest because
of a bug  https://github.com/tektoncd/results/issues/138

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note

Results API now uses a Postgres implementation instead of MySQL. Due to deployment selector changes, this version cannot be cleanly upgraded from a previous version. If you are upgrading, please delete previous deployments first by running:

    kubectl delete deployment tekton-results-watcher tekton-results-api -n tekton-pipelines

```