### PR TITLE
[Openshift] Remove openshit-client as we manage this task directly

### DIFF
--- a/hack/openshift/update-tasks.sh
+++ b/hack/openshift/update-tasks.sh
@@ -185,9 +185,9 @@ main() {
     "buildah"  "quay.io/buildah"  \
     "registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee"
 
-  change_task_image "$dest_dir" "$version"  \
-    "openshift-client"  'quay.io/openshift/origin-cli:$(params.VERSION)'  \
-    'image-registry.openshift-image-registry.svc:5000/openshift/cli:$(params.VERSION)'
+#  change_task_image "$dest_dir" "$version"  \
+#    "openshift-client"  'quay.io/openshift/origin-cli:$(params.VERSION)'  \
+#    'image-registry.openshift-image-registry.svc:5000/openshift/cli:$(params.VERSION)'
 
   # ./manifest-tool inspect registry.redhat.io/openshift-serverless-1/client-kn-rhel8:0.22
   change_task_image "$dest_dir" "$version"  \


### PR DESCRIPTION
# Changes
As part of the this  [PR](https://github.com/tektoncd/operator/pull/484) we removed openshift-client task from update-task, hence removing from change_task_image.
This will fix the nightly-pipeline sync which is broken right now 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
