### PR TITLE
[OpenShift] add rights to delete securitycontextconstraints

### DIFF
--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -255,6 +255,7 @@ rules:
   - get
   - create
   - update
+  - delete
 - apiGroups:
   - route.openshift.io
   resources:


### PR DESCRIPTION


# Changes

In case of uninstalling or even deleting an InstallerSet, the operator
might try to delete SecurityContextConstraints. As of today, it fails
because it doesn't have the right to do so.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sm43 @savitaashture @nikhil-thomas 
This will be needed to be cherry-picked in 0.50.x release branch 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
add rights to delete securitycontextconstraints for openshift
```
