### PR TITLE
Validates component CR name in webhook

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var (
 	// RECONCILE_AGAIN_ERR
@@ -61,4 +63,13 @@ var (
 		ClusterTasksParam:      defaultParamValue,
 		PipelineTemplatesParam: defaultParamValue,
 	}
+)
+
+var (
+	PipelineResourceName  = "pipeline"
+	TriggerResourceName   = "trigger"
+	DashboardResourceName = "dashboard"
+	AddonResourceName     = "addon"
+	ConfigResourceName    = "config"
+	ResultResourceName    = "result"
 )

--- a/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -26,6 +27,11 @@ func (ta *TektonAddon) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if ta.GetName() != AddonResourceName {
+		errMsg := fmt.Sprintf("metadata.name,  Only one instance of TektonAddon is allowed by name, %s", AddonResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(ta.GetName(), errMsg))
 	}
 
 	if ta.Spec.TargetNamespace == "" {

--- a/pkg/apis/operator/v1alpha1/tektonaddon_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_validation_test.go
@@ -49,7 +49,7 @@ func Test_ValidateTektonAddon_InvalidParam(t *testing.T) {
 
 	ta := &TektonAddon{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "addon",
 			Namespace: "namespace",
 		},
 		Spec: TektonAddonSpec{
@@ -73,7 +73,7 @@ func Test_ValidateTektonAddon_InvalidParamValue(t *testing.T) {
 
 	ta := &TektonAddon{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "addon",
 			Namespace: "namespace",
 		},
 		Spec: TektonAddonSpec{
@@ -97,7 +97,7 @@ func Test_ValidateTektonAddon_ClusterTaskIsFalseAndPipelineTemplateIsTrue(t *tes
 
 	ta := &TektonAddon{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "addon",
 			Namespace: "namespace",
 		},
 		Spec: TektonAddonSpec{

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -26,6 +27,11 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if tc.GetName() != ConfigResourceName {
+		errMsg := fmt.Sprintf("metadata.name,  Only one instance of TektonConfig is allowed by name, %s", ConfigResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(tc.GetName(), errMsg))
 	}
 
 	if tc.Spec.TargetNamespace == "" {

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -50,7 +50,7 @@ func Test_ValidateTektonConfig_MissingTargetNamespace(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{},
@@ -64,7 +64,7 @@ func Test_ValidateTektonConfig_InvalidProfile(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -83,7 +83,7 @@ func Test_ValidateTektonConfig_InvalidPruningResource(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -106,7 +106,7 @@ func Test_ValidateTektonConfig_MissingKeepKeepsinceSchedule(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -128,7 +128,7 @@ func Test_ValidateTektonConfig_MissingSchedule(t *testing.T) {
 	keep := uint(2)
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -151,7 +151,7 @@ func Test_ValidateTektonConfig_InvalidAddonParam(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -178,7 +178,7 @@ func Test_ValidateTektonConfig_InvalidAddonParamValue(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -205,7 +205,7 @@ func Test_ValidateTektonConfig_InvalidPipelineProperties(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{
@@ -229,7 +229,7 @@ func Test_ValidateTektonConfig_InvalidTriggerProperties(t *testing.T) {
 
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "config",
 			Namespace: "namespace",
 		},
 		Spec: TektonConfigSpec{

--- a/pkg/apis/operator/v1alpha1/tektondashboard_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -26,6 +27,11 @@ func (td *TektonDashboard) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if td.GetName() != DashboardResourceName {
+		errMsg := fmt.Sprintf("metadata.name,  Only one instance of TektonDashboard is allowed by name, %s", DashboardResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(td.GetName(), errMsg))
 	}
 
 	if td.Spec.TargetNamespace == "" {

--- a/pkg/apis/operator/v1alpha1/tektondashboard_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_validation_test.go
@@ -29,7 +29,7 @@ func Test_ValidateTektonDashboard_MissingTargetNamespace(t *testing.T) {
 
 	td := &TektonDashboard{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "dashboard",
 			Namespace: "namespace",
 		},
 		Spec: TektonDashboardSpec{},

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -26,6 +27,11 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if tp.GetName() != PipelineResourceName {
+		errMsg := fmt.Sprintf("metadata.name, Only one instance of TektonPipeline is allowed by name, %s", PipelineResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(tp.GetName(), errMsg))
 	}
 
 	if tp.Spec.TargetNamespace == "" {

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
@@ -29,7 +29,7 @@ func Test_ValidateTektonPipeline_MissingTargetNamespace(t *testing.T) {
 
 	tp := &TektonPipeline{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "pipeline",
 			Namespace: "namespace",
 		},
 		Spec: TektonPipelineSpec{},

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
@@ -26,6 +27,11 @@ func (tr *TektonTrigger) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInDelete(ctx) {
 		return nil
+	}
+
+	if tr.GetName() != TriggerResourceName {
+		errMsg := fmt.Sprintf("metadata.name,  Only one instance of TektonTrigger is allowed by name, %s", TriggerResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(tr.GetName(), errMsg))
 	}
 
 	if tr.Spec.TargetNamespace == "" {

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation_test.go
@@ -29,7 +29,7 @@ func Test_ValidateTektonTrigger_MissingTargetNamespace(t *testing.T) {
 
 	tr := &TektonTrigger{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
+			Name:      "trigger",
 			Namespace: "namespace",
 		},
 		Spec: TektonTriggerSpec{},

--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -27,19 +27,10 @@ import (
 )
 
 var (
+	Interval = 10 * time.Second
+	Timeout  = 1 * time.Minute
 	// DefaultSA is the default service account
-	DefaultSA             = "pipeline"
-	PipelineResourceName  = "pipeline"
-	TriggerResourceName   = "trigger"
-	DashboardResourceName = "dashboard"
-	AddonResourceName     = "addon"
-	ConfigResourceName    = "config"
-	ResultResourceName    = "result"
-	ProfileLite           = "lite"
-	ProfileBasic          = "basic"
-	ProfileAll            = "all"
-	Interval              = 10 * time.Second
-	Timeout               = 1 * time.Minute
+	DefaultSA = "pipeline"
 )
 
 const (
@@ -68,7 +59,7 @@ func PipelineReady(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPi
 }
 
 func getPipelineRes(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPipeline, error) {
-	res, err := informer.Lister().Get(PipelineResourceName)
+	res, err := informer.Lister().Get(v1alpha1.PipelineResourceName)
 	return res, err
 }
 
@@ -90,6 +81,6 @@ func TriggerReady(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrig
 }
 
 func getTriggerRes(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrigger, error) {
-	res, err := informer.Lister().Get(TriggerResourceName)
+	res, err := informer.Lister().Get(v1alpha1.TriggerResourceName)
 	return res, err
 }

--- a/pkg/reconciler/kubernetes/tektonconfig/extension.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension.go
@@ -46,20 +46,20 @@ func (oe kubernetesExtension) PreReconcile(context.Context, v1alpha1.TektonCompo
 func (oe kubernetesExtension) PostReconcile(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 
-	if configInstance.Spec.Profile == common.ProfileAll {
+	if configInstance.Spec.Profile == v1alpha1.ProfileAll {
 		return extension.CreateDashboardCR(comp, oe.operatorClientSet.OperatorV1alpha1())
 	}
 
-	if configInstance.Spec.Profile == common.ProfileLite || configInstance.Spec.Profile == common.ProfileBasic {
-		return extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
+	if configInstance.Spec.Profile == v1alpha1.ProfileLite || configInstance.Spec.Profile == v1alpha1.ProfileBasic {
+		return extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
 	}
 
 	return nil
 }
 func (oe kubernetesExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
-	if configInstance.Spec.Profile == common.ProfileAll {
-		return extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
+	if configInstance.Spec.Profile == v1alpha1.ProfileAll {
+		return extension.TektonDashboardCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
 	}
 	return nil
 }

--- a/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard.go
@@ -38,7 +38,7 @@ func CreateDashboardCR(instance v1alpha1.TektonComponent, client operatorv1alpha
 	if _, err := ensureTektonDashboardExists(client.TektonDashboards(), configInstance); err != nil {
 		return errors.New(err.Error())
 	}
-	if _, err := waitForTektonDashboardState(client.TektonDashboards(), common.DashboardResourceName,
+	if _, err := waitForTektonDashboardState(client.TektonDashboards(), v1alpha1.DashboardResourceName,
 		isTektonDashboardReady); err != nil {
 		log.Println("TektonDashboard is not in ready state: ", err)
 		return err
@@ -47,7 +47,7 @@ func CreateDashboardCR(instance v1alpha1.TektonComponent, client operatorv1alpha
 }
 
 func ensureTektonDashboardExists(clients op.TektonDashboardInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonDashboard, error) {
-	tdCR, err := GetDashboard(clients, common.DashboardResourceName)
+	tdCR, err := GetDashboard(clients, v1alpha1.DashboardResourceName)
 	if err == nil {
 		// if the dashboard spec is changed then update the instance
 		updated := false
@@ -83,7 +83,7 @@ func ensureTektonDashboardExists(clients op.TektonDashboardInterface, config *v1
 	if apierrs.IsNotFound(err) {
 		tdCR = &v1alpha1.TektonDashboard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: common.DashboardResourceName,
+				Name: v1alpha1.DashboardResourceName,
 			},
 			Spec: v1alpha1.TektonDashboardSpec{
 				CommonSpec: v1alpha1.CommonSpec{
@@ -128,7 +128,7 @@ func isTektonDashboardReady(s *v1alpha1.TektonDashboard, err error) (bool, error
 
 // TektonDashboardCRDelete deletes tha TektonDashboard to see if all resources will be deleted
 func TektonDashboardCRDelete(clients op.TektonDashboardInterface, name string) error {
-	if _, err := GetDashboard(clients, common.DashboardResourceName); err != nil {
+	if _, err := GetDashboard(clients, v1alpha1.DashboardResourceName); err != nil {
 		if apierrs.IsNotFound(err) {
 			return nil
 		}

--- a/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
@@ -19,8 +19,8 @@ package extension
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 	ts "knative.dev/pkg/reconciler/testing"
@@ -32,13 +32,13 @@ func TestTektonDashboardCreateAndDeleteCR(t *testing.T) {
 	tConfig := pipeline.GetTektonConfig()
 	err := CreateDashboardCR(tConfig, c.OperatorV1alpha1())
 	util.AssertNotEqual(t, err, nil)
-	err = TektonDashboardCRDelete(c.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
+	err = TektonDashboardCRDelete(c.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
 	util.AssertEqual(t, err, nil)
 }
 
 func TestTektonDashboardCRDelete(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonDashboardCRDelete(c.OperatorV1alpha1().TektonDashboards(), common.DashboardResourceName)
+	err := TektonDashboardCRDelete(c.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
 	util.AssertEqual(t, err, nil)
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -106,9 +106,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	logger := logging.FromContext(ctx)
 	tp.Status.InitializeConditions()
 
-	if tp.GetName() != common.PipelineResourceName {
+	if tp.GetName() != v1alpha1.PipelineResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			common.PipelineResourceName,
+			v1alpha1.PipelineResourceName,
 			tp.GetName(),
 		)
 		logger.Error(msg)
@@ -312,7 +312,7 @@ func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, tpSpecH
 	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", common.PipelineResourceName),
+			GenerateName: fmt.Sprintf("%s-", v1alpha1.PipelineResourceName),
 			Labels: map[string]string{
 				createdByKey: createdByValue,
 			},

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -101,9 +101,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 
 	logger.Infow("Reconciling TektonResults", "status", tr.Status)
 
-	if tr.GetName() != common.ResultResourceName {
+	if tr.GetName() != v1alpha1.ResultResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			common.ResultResourceName,
+			v1alpha1.ResultResourceName,
 			tr.GetName(),
 		)
 		logger.Error(msg)

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -106,9 +106,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	logger := logging.FromContext(ctx)
 	tt.Status.InitializeConditions()
 
-	if tt.GetName() != common.TriggerResourceName {
+	if tt.GetName() != v1alpha1.TriggerResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			common.TriggerResourceName,
+			v1alpha1.TriggerResourceName,
 			tt.GetName(),
 		)
 		logger.Error(msg)
@@ -352,7 +352,7 @@ func makeInstallerSet(tt *v1alpha1.TektonTrigger, manifest mf.Manifest, ttSpecHa
 	ownerRef := *metav1.NewControllerRef(tt, tt.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", common.TriggerResourceName),
+			GenerateName: fmt.Sprintf("%s-", v1alpha1.TriggerResourceName),
 			Labels: map[string]string{
 				createdByKey: createdByValue,
 			},

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -120,9 +120,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	logger := logging.FromContext(ctx)
 	ta.Status.InitializeConditions()
 
-	if ta.GetName() != common.AddonResourceName {
+	if ta.GetName() != v1alpha1.AddonResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			common.AddonResourceName,
+			v1alpha1.AddonResourceName,
 			ta.GetName(),
 		)
 		logger.Error(msg)

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -108,7 +108,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	}
 
 	if configInstance.Spec.Profile == v1alpha1.ProfileBasic || configInstance.Spec.Profile == v1alpha1.ProfileLite {
-		return extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
+		return extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName)
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 	if configInstance.Spec.Profile == v1alpha1.ProfileAll {
-		if err := extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName); err != nil {
+		if err := extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon.go
@@ -38,7 +38,7 @@ func CreateAddonCR(instance v1alpha1.TektonComponent, client operatorv1alpha1.Op
 	if _, err := ensureTektonAddonExists(client.TektonAddons(), configInstance); err != nil {
 		return errors.New(err.Error())
 	}
-	if _, err := waitForTektonAddonState(client.TektonAddons(), common.AddonResourceName,
+	if _, err := waitForTektonAddonState(client.TektonAddons(), v1alpha1.AddonResourceName,
 		isTektonAddonReady); err != nil {
 		log.Println("TektonAddon is not in ready state: ", err)
 		return err
@@ -47,7 +47,7 @@ func CreateAddonCR(instance v1alpha1.TektonComponent, client operatorv1alpha1.Op
 }
 
 func ensureTektonAddonExists(clients op.TektonAddonInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonAddon, error) {
-	taCR, err := GetAddon(clients, common.AddonResourceName)
+	taCR, err := GetAddon(clients, v1alpha1.AddonResourceName)
 	if err == nil {
 		// if the addon spec is changed then update the instance
 		updated := false
@@ -80,7 +80,7 @@ func ensureTektonAddonExists(clients op.TektonAddonInterface, config *v1alpha1.T
 	if apierrs.IsNotFound(err) {
 		taCR = &v1alpha1.TektonAddon{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            common.AddonResourceName,
+				Name:            v1alpha1.AddonResourceName,
 				OwnerReferences: []metav1.OwnerReference{ownerRef},
 			},
 			Spec: v1alpha1.TektonAddonSpec{
@@ -126,7 +126,7 @@ func isTektonAddonReady(s *v1alpha1.TektonAddon, err error) (bool, error) {
 
 // TektonAddonCRDelete deletes tha TektonAddon to see if all resources will be deleted
 func TektonAddonCRDelete(clients op.TektonAddonInterface, name string) error {
-	if _, err := GetAddon(clients, common.AddonResourceName); err != nil {
+	if _, err := GetAddon(clients, v1alpha1.AddonResourceName); err != nil {
 		if apierrs.IsNotFound(err) {
 			return nil
 		}

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
@@ -19,8 +19,8 @@ package extension
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 	ts "knative.dev/pkg/reconciler/testing"
@@ -32,13 +32,13 @@ func TestTektonAddonCreateAndDeleteCR(t *testing.T) {
 	tConfig := pipeline.GetTektonConfig()
 	err := CreateAddonCR(tConfig, c.OperatorV1alpha1())
 	util.AssertNotEqual(t, err, nil)
-	err = TektonAddonCRDelete(c.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
+	err = TektonAddonCRDelete(c.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName)
 	util.AssertEqual(t, err, nil)
 }
 
 func TestTektonAddonCRDelete(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonAddonCRDelete(c.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
+	err := TektonAddonCRDelete(c.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName)
 	util.AssertEqual(t, err, nil)
 }

--- a/pkg/reconciler/shared/tektonconfig/controller.go
+++ b/pkg/reconciler/shared/tektonconfig/controller.go
@@ -67,7 +67,7 @@ func NewExtensibleController(generator common.ExtensionGenerator) injection.Cont
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
-		namespaceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(enqueueCustomName(impl, common.ConfigResourceName)))
+		namespaceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(enqueueCustomName(impl, v1alpha1.ConfigResourceName)))
 
 		if os.Getenv("AUTOINSTALL_COMPONENTS") == "true" {
 			// try to ensure that there is an instance of tektonConfig

--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -102,10 +101,10 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 func (tc tektonConfig) createInstance(ctx context.Context) error {
 	tcCR := &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ConfigResourceName,
+			Name: v1alpha1.ConfigResourceName,
 		},
 		Spec: v1alpha1.TektonConfigSpec{
-			Profile: common.ProfileAll,
+			Profile: v1alpha1.ProfileAll,
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: tc.namespace,
 			},

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
@@ -39,7 +39,7 @@ func CreatePipelineCR(instance v1alpha1.TektonComponent, client operatorv1alpha1
 	if _, err := ensureTektonPipelineExists(client.TektonPipelines(), configInstance); err != nil {
 		return errors.New(err.Error())
 	}
-	if _, err := waitForTektonPipelineState(client.TektonPipelines(), common.PipelineResourceName,
+	if _, err := waitForTektonPipelineState(client.TektonPipelines(), v1alpha1.PipelineResourceName,
 		isTektonPipelineReady); err != nil {
 		log.Println("TektonPipeline is not in ready state: ", err)
 		return err
@@ -48,7 +48,7 @@ func CreatePipelineCR(instance v1alpha1.TektonComponent, client operatorv1alpha1
 }
 
 func ensureTektonPipelineExists(clients op.TektonPipelineInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonPipeline, error) {
-	tpCR, err := GetPipeline(clients, common.PipelineResourceName)
+	tpCR, err := GetPipeline(clients, v1alpha1.PipelineResourceName)
 	if err == nil {
 		// if the pipeline spec is changed then update the instance
 		updated := false
@@ -84,7 +84,7 @@ func ensureTektonPipelineExists(clients op.TektonPipelineInterface, config *v1al
 	if apierrs.IsNotFound(err) {
 		tpCR = &v1alpha1.TektonPipeline{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: common.PipelineResourceName,
+				Name: v1alpha1.PipelineResourceName,
 			},
 			Spec: v1alpha1.TektonPipelineSpec{
 				CommonSpec: v1alpha1.CommonSpec{
@@ -131,7 +131,7 @@ func isTektonPipelineReady(s *v1alpha1.TektonPipeline, err error) (bool, error) 
 
 // TektonPipelineCRDelete deletes tha TektonPipeline to see if all resources will be deleted
 func TektonPipelineCRDelete(clients op.TektonPipelineInterface, name string) error {
-	if _, err := GetPipeline(clients, common.PipelineResourceName); err != nil {
+	if _, err := GetPipeline(clients, v1alpha1.PipelineResourceName); err != nil {
 		if apierrs.IsNotFound(err) {
 			return nil
 		}
@@ -167,7 +167,7 @@ func verifyNoTektonPipelineCR(clients op.TektonPipelineInterface) error {
 func GetTektonConfig() *v1alpha1.TektonConfig {
 	return &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: common.ConfigResourceName,
+			Name: v1alpha1.ConfigResourceName,
 		},
 		Spec: v1alpha1.TektonConfigSpec{
 			Profile: "all",

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
@@ -19,8 +19,8 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	ts "knative.dev/pkg/reconciler/testing"
 )
@@ -31,13 +31,13 @@ func TestTektonPipelineCreateAndDeleteCR(t *testing.T) {
 	tConfig := GetTektonConfig()
 	err := CreatePipelineCR(tConfig, c.OperatorV1alpha1())
 	util.AssertNotEqual(t, err, nil)
-	err = TektonPipelineCRDelete(c.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName)
+	err = TektonPipelineCRDelete(c.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
 	util.AssertEqual(t, err, nil)
 }
 
 func TestTektonPipelineCRDelete(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonPipelineCRDelete(c.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName)
+	err := TektonPipelineCRDelete(c.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
 	util.AssertEqual(t, err, nil)
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -50,13 +50,13 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 	logger := logging.FromContext(ctx)
 
 	if original.Spec.Profile == v1alpha1.ProfileLite {
-		return pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName)
+		return pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
 	} else {
 		// TektonPipeline and TektonTrigger is common for profile type basic and all
-		if err := pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName); err != nil {
+		if err := pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName); err != nil {
 			return err
 		}
-		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName); err != nil {
+		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName); err != nil {
 			return err
 		}
 	}
@@ -75,9 +75,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	tc.Status.InitializeConditions()
 
 	logger.Infow("Reconciling TektonConfig", "status", tc.Status)
-	if tc.GetName() != common.ConfigResourceName {
+	if tc.GetName() != v1alpha1.ConfigResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			common.ConfigResourceName,
+			v1alpha1.ConfigResourceName,
 			tc.GetName(),
 		)
 		logger.Error(msg)
@@ -110,7 +110,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 			return err
 		}
 	} else {
-		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName); err != nil {
+		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
 			return err
 		}

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,7 +33,6 @@ import (
 
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	operatorv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 )
 
 func CreateTriggerCR(instance v1alpha1.TektonComponent, client operatorv1alpha1.OperatorV1alpha1Interface) error {
@@ -40,7 +40,7 @@ func CreateTriggerCR(instance v1alpha1.TektonComponent, client operatorv1alpha1.
 	if _, err := ensureTektonTriggerExists(client.TektonTriggers(), configInstance); err != nil {
 		return errors.New(err.Error())
 	}
-	if _, err := waitForTektonTriggerState(client.TektonTriggers(), common.TriggerResourceName,
+	if _, err := waitForTektonTriggerState(client.TektonTriggers(), v1alpha1.TriggerResourceName,
 		isTektonTriggerReady); err != nil {
 		log.Println("TektonTrigger is not in ready state: ", err)
 		return err
@@ -49,7 +49,7 @@ func CreateTriggerCR(instance v1alpha1.TektonComponent, client operatorv1alpha1.
 }
 
 func ensureTektonTriggerExists(clients op.TektonTriggerInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonTrigger, error) {
-	ttCR, err := GetTrigger(clients, common.TriggerResourceName)
+	ttCR, err := GetTrigger(clients, v1alpha1.TriggerResourceName)
 	if err == nil {
 		// if the trigger spec is changed then update the instance
 		updated := false
@@ -85,7 +85,7 @@ func ensureTektonTriggerExists(clients op.TektonTriggerInterface, config *v1alph
 	if apierrs.IsNotFound(err) {
 		ttCR = &v1alpha1.TektonTrigger{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: common.TriggerResourceName,
+				Name: v1alpha1.TriggerResourceName,
 			},
 			Spec: v1alpha1.TektonTriggerSpec{
 				CommonSpec: v1alpha1.CommonSpec{
@@ -131,7 +131,7 @@ func isTektonTriggerReady(s *v1alpha1.TektonTrigger, err error) (bool, error) {
 
 // TektonTriggerCRDelete deletes tha TektonTrigger to see if all resources will be deleted
 func TektonTriggerCRDelete(clients op.TektonTriggerInterface, name string) error {
-	if _, err := GetTrigger(clients, common.TriggerResourceName); err != nil {
+	if _, err := GetTrigger(clients, v1alpha1.TriggerResourceName); err != nil {
 		if apierrs.IsNotFound(err) {
 			return nil
 		}

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -19,8 +19,8 @@ package trigger
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 	ts "knative.dev/pkg/reconciler/testing"
@@ -35,13 +35,13 @@ func TestTektonTriggerCreateAndDeleteCR(t *testing.T) {
 	// recheck triggers creation
 	err = CreateTriggerCR(tConfig, c.OperatorV1alpha1())
 	util.AssertNotEqual(t, err, nil)
-	err = TektonTriggerCRDelete(c.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName)
+	err = TektonTriggerCRDelete(c.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName)
 	util.AssertEqual(t, err, nil)
 }
 
 func TestTektonTriggerCRDelete(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonTriggerCRDelete(c.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName)
+	err := TektonTriggerCRDelete(c.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName)
 	util.AssertEqual(t, err, nil)
 }

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/test/client"
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
@@ -38,7 +37,7 @@ func TestTektonConfigDeployment(t *testing.T) {
 	clients := client.Setup(t)
 
 	crNames := utils.ResourceNames{
-		TektonConfig: common.ConfigResourceName,
+		TektonConfig: v1alpha1.ConfigResourceName,
 		Namespace:    "tekton-operator",
 	}
 
@@ -73,7 +72,7 @@ func TestTektonConfigDeployment(t *testing.T) {
 		runRbacTest(t, clients)
 	}
 
-	if platform == "openshift" && tc.Spec.Profile == common.ProfileAll {
+	if platform == "openshift" && tc.Spec.Profile == v1alpha1.ProfileAll {
 		runAddonTest(t, clients, tc)
 	}
 
@@ -93,9 +92,9 @@ func runAddonTest(t *testing.T, clients *utils.Clients, tc *v1alpha1.TektonConfi
 
 	// Make sure TektonAddon is created
 	t.Run("ensure-addon-is-created", func(t *testing.T) {
-		addon, err = clients.Operator.TektonAddons().Get(context.TODO(), common.AddonResourceName, metav1.GetOptions{})
+		addon, err = clients.Operator.TektonAddons().Get(context.TODO(), v1alpha1.AddonResourceName, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("failed to get TektonAddon CR: %s : %v", common.AddonResourceName, err)
+			t.Fatalf("failed to get TektonAddon CR: %s : %v", v1alpha1.AddonResourceName, err)
 		}
 	})
 

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -27,7 +27,6 @@ import (
 
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 
 	"knative.dev/pkg/test/logging"
 
@@ -67,7 +66,7 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 				Name: names.TektonConfig,
 			},
 			Spec: v1alpha1.TektonConfigSpec{
-				Profile: common.ProfileAll,
+				Profile: v1alpha1.ProfileAll,
 				CommonSpec: v1alpha1.CommonSpec{
 					TargetNamespace: cm.Data["DEFAULT_TARGET_NAMESPACE"],
 				},


### PR DESCRIPTION
  - This patch adds a check where it validates the name
    of the component CR before applying it on the cluster

  - This patch also moves all the constants to `pkg/apis/const.go`

Fixes: #497

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
