### PR TITLE
fix pruning enabled by default

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -100,6 +100,7 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 }
 
 func (tc tektonConfig) createInstance(ctx context.Context) error {
+	pruneKeep := uint(100)
 	tcCR := &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: common.ConfigResourceName,
@@ -108,6 +109,12 @@ func (tc tektonConfig) createInstance(ctx context.Context) error {
 			Profile: common.ProfileAll,
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: tc.namespace,
+			},
+			Pruner: v1alpha1.Prune{
+				Resources: []string{"pipelinerun", "taskrun"},
+				Keep:      &pruneKeep,
+				KeepSince: nil,
+				Schedule:  "0 8 * * *",
 			},
 		},
 	}


### PR DESCRIPTION
adds the default value to instance of tektonconfig

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
