### PR TITLE
[OpenShift] Fix forbidden error for community tasks

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -346,14 +346,16 @@ func (r *Reconciler) ensureClusterTasks(ctx context.Context, ta *v1alpha1.Tekton
 	communityClusterTaskManifest := r.manifest
 
 	if err := r.appendCommunityTarget(ctx, &communityClusterTaskManifest, ta); err != nil {
-		return err
-	}
+		// Continue if failed to resolve community task URL.
+		// (Ex: on disconnected cluster community tasks won't be reachable because of proxy).
+		logging.FromContext(ctx).Error("Failed to get community task: Skipping community tasks installation  ", err)
+	} else {
+		if err := r.communityTransform(ctx, &communityClusterTaskManifest, ta); err != nil {
+			return err
+		}
 
-	if err := r.communityTransform(ctx, &communityClusterTaskManifest, ta); err != nil {
-		return err
+		clusterTaskManifest = clusterTaskManifest.Append(communityClusterTaskManifest)
 	}
-
-	clusterTaskManifest = clusterTaskManifest.Append(communityClusterTaskManifest)
 
 	if err := createInstallerSet(ctx, r.operatorClientSet, ta, clusterTaskManifest,
 		r.version, clusterTaskInstallerSet, "addon-clustertasks"); err != nil {


### PR DESCRIPTION
# Changes

On disconnected cluster there could be scenario where community task URLs won't be reachable so as part of this PR adding changes to log the error and continue with next steps instead of returning error.

/cc @nikhil-thomas @concaf @vdemeester

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```