### PR TITLE
[OpenShift] Limit configmaps watched by the webhook

### DIFF
--- a/config/openshift/base/500-webhooks.yaml
+++ b/config/openshift/base/500-webhooks.yaml
@@ -47,3 +47,10 @@ webhooks:
       name: tekton-operator-webhook
       namespace: openshift-operators
   name: config.webhook.operator.tekton.dev
+  # Only watch configmap from openshift-operators
+  # The other way would be to watch object with operator.tekton.dev/release but it's broader
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: ["openshift-operators"]


### PR DESCRIPTION


# Changes

Before this change, the webhook is gonna be very noisy as it will run
a reconciler loop for any configmap changes in the cluster. With this
change, we only watch configmap changes in openshift-operators.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sm43 @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```