### PR TITLE
Adds e2e tests for Operator features

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -39,9 +39,9 @@ import (
 
 const (
 	// Pipelines ConfigMap
-	featureFlag    = "feature-flags"
-	configDefaults = "config-defaults"
-	configMetrics  = "config-observability"
+	FeatureFlag    = "feature-flags"
+	ConfigDefaults = "config-defaults"
+	ConfigMetrics  = "config-observability"
 
 	proxyLabel = "operator.tekton.dev/disable-proxy=true"
 
@@ -344,9 +344,9 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	// adding extension's transformers first to run them before `extra` transformers
 	trns := r.extension.Transformers(instance)
 	extra := []mf.Transformer{
-		common.AddConfigMapValues(featureFlag, pipeline.Spec.PipelineProperties),
-		common.AddConfigMapValues(configDefaults, pipeline.Spec.OptionalPipelineProperties),
-		common.AddConfigMapValues(configMetrics, pipeline.Spec.PipelineMetricsProperties),
+		common.AddConfigMapValues(FeatureFlag, pipeline.Spec.PipelineProperties),
+		common.AddConfigMapValues(ConfigDefaults, pipeline.Spec.OptionalPipelineProperties),
+		common.AddConfigMapValues(ConfigMetrics, pipeline.Spec.PipelineMetricsProperties),
 		common.ApplyProxySettings,
 		common.DeploymentImages(images),
 		common.InjectLabelOnNamespace(proxyLabel),

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -40,8 +40,8 @@ import (
 
 // Triggers ConfigMap
 const (
-	configDefaults = "config-defaults-triggers"
-	featureFlag    = "feature-flags-triggers"
+	ConfigDefaults = "config-defaults-triggers"
+	FeatureFlag    = "feature-flags-triggers"
 
 	createdByKey       = "operator.tekton.dev/created-by"
 	createdByValue     = "TektonTrigger"
@@ -300,8 +300,8 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	// adding extension's transformers first to run them before `extra` transformers
 	trns := r.extension.Transformers(trigger)
 	extra := []mf.Transformer{
-		common.AddConfigMapValues(configDefaults, trigger.Spec.OptionalTriggersProperties),
-		common.AddConfigMapValues(featureFlag, trigger.Spec.TriggersProperties),
+		common.AddConfigMapValues(ConfigDefaults, trigger.Spec.OptionalTriggersProperties),
+		common.AddConfigMapValues(FeatureFlag, trigger.Spec.TriggersProperties),
 		common.ApplyProxySettings,
 		common.DeploymentImages(triggerImages),
 		common.AddConfiguration(trigger.Spec.Config),

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -48,8 +48,4 @@ function install_operator_resources() {
   # TODO: parameterize namespace, operator can run in a namespace different from the namespace where tektonpipelines is installed
   wait_until_pods_running ${OPERATOR_NAMESPACE} || fail_test "Tekton Operator controller did not come up"
 
-  # Make sure that everything is cleaned up in the current namespace.
-  for res in tektonpipelines tektontriggers tektondashboards; do
-    kubectl delete --ignore-not-found=true ${res}.operator.tekton.dev --all
-  done
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,7 +32,7 @@ failed=0
 header "Setting up environment"
 install_operator_resources
 
-echo "Wait for TektonConfig creation"
+echo "Wait for controller to start and create TektonConfig"
 sleep 30
 
 header "Running Go e2e tests"

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -22,33 +22,46 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonpipeline"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
 	"github.com/tektoncd/operator/test/client"
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 )
 
-// TestTektonPipelinesDeployment verifies the TektonPipelines creation, deployment recreation, and TektonPipelines deletion.
+// TestTektonConfigDeployment does following checks
+// - make sure TektonConfig is created if AUTOINSTALL_COMPONENTS is true
+// - waits till TektonConfig ready status becomes true
+// - in case of OpenShift, runs rbac and addon test
+// - changes profile from all to basic and validates changes
+// - deletes a components and make sure it is recreated
+// - updates field in TektonConfig Spec and make sure they are reflected in configmaps
+// - Deletes and recreates TektonConfig and validates webhook adds all defaults
 func TestTektonConfigDeployment(t *testing.T) {
 	clients := client.Setup(t)
 
 	crNames := utils.ResourceNames{
-		TektonConfig: v1alpha1.ConfigResourceName,
-		Namespace:    "tekton-operator",
+		TektonConfig:    v1alpha1.ConfigResourceName,
+		Namespace:       "tekton-operator",
+		TargetNamespace: "tekton-pipelines",
 	}
 
 	platform := os.Getenv("TARGET")
 
 	if platform == "openshift" {
 		crNames.Namespace = "openshift-operators"
+		crNames.TargetNamespace = "openshift-pipelines"
 	}
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownConfig(clients, crNames.TektonConfig) })
-	defer utils.TearDownPipeline(clients, crNames.TektonConfig)
+	defer utils.TearDownConfig(clients, crNames.TektonConfig)
 
 	var (
 		tc  *v1alpha1.TektonConfig
@@ -76,10 +89,184 @@ func TestTektonConfigDeployment(t *testing.T) {
 		runAddonTest(t, clients, tc)
 	}
 
+	runFeatureTest(t, clients, tc, crNames)
+
 	// Delete the TektonConfig CR instance to see if all resources will be removed
 	t.Run("delete-config", func(t *testing.T) {
 		resources.AssertTektonConfigCRReadyStatus(t, clients, crNames)
 		resources.TektonConfigCRDelete(t, clients, crNames)
+	})
+}
+
+func runFeatureTest(t *testing.T, clients *utils.Clients, tc *v1alpha1.TektonConfig, names utils.ResourceNames) {
+
+	t.Run("change-profile", func(t *testing.T) {
+
+		tc, err := clients.Operator.TektonConfigs().Get(context.TODO(), v1alpha1.ConfigResourceName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get tektonconfig: %v", err)
+		}
+
+		// make sure dashboard is created in case of k8s and
+		// addon in case of openshift
+		if os.Getenv("TARGET") == "openshift" {
+			if _, err := clients.Operator.TektonAddons().Get(context.TODO(), v1alpha1.AddonResourceName, metav1.GetOptions{}); err != nil {
+				t.Fatalf("failed to get tektonaddon")
+			}
+		} else {
+			if _, err := clients.Operator.TektonDashboards().Get(context.TODO(), v1alpha1.DashboardResourceName, metav1.GetOptions{}); err != nil {
+				t.Fatalf("failed to get dashboard")
+			}
+		}
+
+		// change the profile and make sure it is reflected on the cluster
+		// ALL -> BASIC
+		tc.Spec.Profile = v1alpha1.ProfileBasic
+
+		tc, err = clients.Operator.TektonConfigs().Update(context.TODO(), tc, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("failed to update tektonconfig: %v", err)
+		}
+
+		if tc.Spec.Profile != v1alpha1.ProfileBasic {
+			t.Fatal("failed to change profile in TektonConfig")
+		}
+
+		// wait till the component is deleted
+		time.Sleep(time.Second * 20)
+
+		// now, make sure dashboard is deleted in case of k8s and
+		// addon is deleted in case of openshift
+		if os.Getenv("TARGET") == "openshift" {
+			if _, err := clients.Operator.TektonAddons().Get(context.TODO(), v1alpha1.AddonResourceName, metav1.GetOptions{}); err == nil {
+				t.Fatalf("expected error but got nil, tektonaddon not deleted")
+			}
+		} else {
+			if _, err := clients.Operator.TektonDashboards().Get(context.TODO(), v1alpha1.DashboardResourceName, metav1.GetOptions{}); err == nil {
+				t.Fatalf("expected error but got nil, tektondashboard not deleted")
+			}
+		}
+	})
+
+	t.Run("change-spec-configuration-and-validate", func(t *testing.T) {
+
+		tc, err := clients.Operator.TektonConfigs().Get(context.TODO(), v1alpha1.ConfigResourceName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get tektonconfig: %v", err)
+		}
+
+		// Change spec field and check if it has changed in the configmap for components
+
+		// pipelines feature-flags configMap
+		tc.Spec.Pipeline.PipelineProperties.EnableCustomTasks = ptr.Bool(true)
+		tc.Spec.Pipeline.PipelineProperties.EnableTektonOciBundles = ptr.Bool(true)
+
+		// pipeline config-defaults configMap
+		tc.Spec.Pipeline.OptionalPipelineProperties.DefaultServiceAccount = "foo"
+
+		// triggers feature-flags configMap
+		tc.Spec.Trigger.TriggersProperties.EnableApiFields = v1alpha1.ApiFieldAlpha
+
+		// triggers config-defaults configMap
+		tc.Spec.Trigger.OptionalTriggersProperties.DefaultServiceAccount = "foo"
+
+		tc, err = clients.Operator.TektonConfigs().Update(context.TODO(), tc, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("failed to update tektonconfig: %v", err)
+		}
+
+		// wait for a few seconds and it reconcile
+		time.Sleep(time.Second * 5)
+
+		// Validate changes to Pipelines ConfigMaps
+
+		featureFlags, err := clients.KubeClient.CoreV1().ConfigMaps(tc.Spec.TargetNamespace).Get(context.TODO(), tektonpipeline.FeatureFlag, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get pipelines configMap: %s : %v", tektonpipeline.FeatureFlag, err)
+		}
+
+		if featureFlags.Data["enable-custom-tasks"] != "true" || featureFlags.Data["enable-tekton-oci-bundles"] != "true" {
+			t.Fatalf("failed to update changes to pipelines configMap: %s ", tektonpipeline.FeatureFlag)
+		}
+
+		configDefaults, err := clients.KubeClient.CoreV1().ConfigMaps(tc.Spec.TargetNamespace).Get(context.TODO(), tektonpipeline.ConfigDefaults, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get pipelines configMap: %s : %v", tektonpipeline.ConfigDefaults, err)
+		}
+
+		if configDefaults.Data["default-service-account"] != "foo" {
+			t.Fatalf("failed to update changes to pipelines configMap: %s ", tektonpipeline.ConfigDefaults)
+		}
+
+		// Validate changes to Triggers ConfigMaps
+
+		featureFlags, err = clients.KubeClient.CoreV1().ConfigMaps(tc.Spec.TargetNamespace).Get(context.TODO(), tektontrigger.FeatureFlag, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get triggers configMap: %s : %v", tektontrigger.FeatureFlag, err)
+		}
+
+		if featureFlags.Data["enable-api-fields"] != v1alpha1.ApiFieldAlpha {
+			t.Fatalf("failed to update changes to triggers configMap: %s", tektontrigger.FeatureFlag)
+		}
+
+		configDefaults, err = clients.KubeClient.CoreV1().ConfigMaps(tc.Spec.TargetNamespace).Get(context.TODO(), tektontrigger.ConfigDefaults, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get triggers configMap: %s : %v", tektontrigger.ConfigDefaults, err)
+		}
+
+		if configDefaults.Data["default-service-account"] != "foo" {
+			t.Fatalf("failed to update changes to triggers configMap: %s :", tektontrigger.ConfigDefaults)
+		}
+	})
+
+	t.Run("delete-component-and-recreate", func(t *testing.T) {
+
+		// delete a component and make sure it is recreated
+		if err := clients.Operator.TektonPipelines().Delete(context.TODO(), v1alpha1.PipelineResourceName, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("failed to get delete tektonpipeline")
+		}
+
+		// wait till the component is recreated
+		time.Sleep(time.Second * 20)
+
+		// component must be recreated
+		if _, err := clients.Operator.TektonPipelines().Get(context.TODO(), v1alpha1.PipelineResourceName, metav1.GetOptions{}); err != nil {
+			t.Fatalf("failed to get tektonpipeline, component not recreated")
+		}
+	})
+
+	t.Run("delete-current-config", func(t *testing.T) {
+		resources.AssertTektonConfigCRReadyStatus(t, clients, names)
+		resources.TektonConfigCRDelete(t, clients, names)
+	})
+
+	t.Run("create-new-config-and-let-webhook-add-defaults", func(t *testing.T) {
+
+		tc := &v1alpha1.TektonConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: v1alpha1.ConfigResourceName,
+			},
+			Spec: v1alpha1.TektonConfigSpec{
+				Profile: v1alpha1.ProfileAll,
+				CommonSpec: v1alpha1.CommonSpec{
+					TargetNamespace: names.TargetNamespace,
+				},
+			},
+		}
+
+		var err error
+		tc, err = clients.Operator.TektonConfigs().Create(context.TODO(), tc, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create tektonconfig: %v", err)
+		}
+
+		if d := cmp.Diff(tc.Spec.Pipeline, v1alpha1.Pipeline{}); d == "" {
+			t.Fatalf("expected defaulting for pipeline properties but failed: %v", d)
+		}
+
+		if d := cmp.Diff(tc.Spec.Trigger, v1alpha1.Trigger{}); d == "" {
+			t.Fatalf("expected defaulting for triggers properties but failed: %v", d)
+		}
 	})
 }
 

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
@@ -50,9 +49,7 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 	}
 
 	tcCR, err := clients.Get(context.TODO(), names.TektonConfig, metav1.GetOptions{})
-	// this timeout is needed to make sure that the e2e tests work
-	// TODO: https://github.com/tektoncd/operator/issues/401
-	time.Sleep(120 * time.Second)
+
 	if cm.Data["AUTOINSTALL_COMPONENTS"] == "true" {
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This adds new e2e test for features in Operator.

// TestTektonConfigDeployment does following checks
// - make sure TektonConfig is created if AUTOINSTALL_COMPONENTS is true
// - waits till TektonConfig ready status becomes true
// - in case of OpenShift, runs rbac and addon test
// - changes profile from all to basic and validates changes
// - deletes a components and make sure it is recreated
// - updates field in TektonConfig Spec and make sure they are reflected in configmaps
// - Deletes and recreates TektonConfig and validates webhook adds all defaults

/cc @vdemeester @nikhil-thomas 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
