### PR TITLE
[OpenShift] Limit configmaps watched by the webhook

### DIFF
--- a/config/base/tekton-config-defaults.yaml
+++ b/config/base/tekton-config-defaults.yaml
@@ -18,7 +18,7 @@ metadata:
   name: tekton-config-defaults
   labels:
     operator.tekton.dev/release: devel
-
+    app.kubernetes.io/part-of: tekton-operator
 data:
   AUTOINSTALL_COMPONENTS: "true"
   DEFAULT_TARGET_NAMESPACE: ""

--- a/config/openshift/base/500-webhooks.yaml
+++ b/config/openshift/base/500-webhooks.yaml
@@ -47,3 +47,9 @@ webhooks:
       name: tekton-operator-webhook
       namespace: openshift-operators
   name: config.webhook.operator.tekton.dev
+  objectSelector:
+    matchExpressions:
+      - key: operator.tekton.dev/release
+        operator: Exists
+    #matchLabels:
+    #  app.kubernetes.io/part-of: tekton-operator


### PR DESCRIPTION

# Changes

Before this change, the webhook is gonna be very noisy as it will run
a reconciler loop for any configmap changes in the cluster. With this
change, we only watch configmap changes in openshift-operators.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @concaf @sm43 @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
