### PR TITLE
[Cherry-Pick] Fix usage of dynamic names in webhook configurations

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -48,7 +49,7 @@ func SetTypes(platform string) {
 }
 
 func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	name := findMutatingWebhookConfigurationNameOrDie(ctx, "webhook.operator.tekton.dev")
+	name := findAndUpdateMutatingWebhookConfigurationNameOrDie(ctx, "webhook.operator.tekton.dev")
 	return defaulting.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
@@ -70,7 +71,7 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 }
 
 func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	name := findValidatingWebhookConfigurationNameOrDie(ctx, "validation.webhook.operator.tekton.dev")
+	name := findAndUpdateValidatingWebhookConfigurationNameOrDie(ctx, "validation.webhook.operator.tekton.dev")
 	return validation.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
@@ -93,7 +94,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 }
 
 func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	name := findValidatingWebhookConfigurationNameOrDie(ctx, "config.webhook.operator.tekton.dev")
+	name := findAndUpdateValidatingWebhookConfigurationNameOrDie(ctx, "config.webhook.operator.tekton.dev")
 	return configmaps.NewAdmissionController(ctx,
 		// Name of the configmap webhook.
 		name,
@@ -107,40 +108,79 @@ func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 	)
 }
 
-func findMutatingWebhookConfigurationNameOrDie(ctx context.Context, namePrefix string) string {
+func findAndUpdateMutatingWebhookConfigurationNameOrDie(ctx context.Context, namePrefix string) string {
 	logger := logging.FromContext(ctx)
-
 	kubeClientSet := kubeclient.Get(ctx)
+
 	mutatingWebhookConfigurations, err := kubeClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		logger.Error(err)
 		logger.Fatal("MutatingWebhookConfiguration with prefix ", namePrefix, " not found")
 		return ""
 	}
+
+	// Find the mutatingWebhookConfiguration with the given generateName prefix
+	var mutatingWebhookConfiguration *v1.MutatingWebhookConfiguration
 	for _, item := range mutatingWebhookConfigurations.Items {
 		if strings.HasPrefix(item.Name, namePrefix) {
-			return item.Name
+			mutatingWebhookConfiguration = &item
+			break
 		}
 	}
-	logger.Fatal("MutatingWebhookConfiguration with prefix ", namePrefix, " not found")
-	return ""
+	if mutatingWebhookConfiguration == nil {
+		logger.Fatal("MutatingWebhookConfiguration with prefix ", namePrefix, " not found")
+		return ""
+	}
+	webhookName := mutatingWebhookConfiguration.Name
+
+	// Update the webhooks[*].name field with the generated Name (metadata.name) of the mutatingWebhookConfiguration
+	for i := range mutatingWebhookConfiguration.Webhooks {
+		mutatingWebhookConfiguration.Webhooks[i].Name = webhookName
+	}
+	_, err = kubeClientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, mutatingWebhookConfiguration, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err)
+		logger.Fatal("Could not update MutatingWebhookConfiguration ", webhookName)
+		return ""
+	}
+
+	return webhookName
 }
 
-func findValidatingWebhookConfigurationNameOrDie(ctx context.Context, namePrefix string) string {
+func findAndUpdateValidatingWebhookConfigurationNameOrDie(ctx context.Context, namePrefix string) string {
 	logger := logging.FromContext(ctx)
-
 	kubeClientSet := kubeclient.Get(ctx)
+
 	validatingWebhookConfigurations, err := kubeClientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		logger.Error(err)
 		logger.Fatal("ValidatingWebhookConfiguration with prefix ", namePrefix, " not found")
 		return ""
 	}
+
+	// Find the validatingWebhookConfiguration with the given generateName prefix
+	var validatingWebhookConfiguration *v1.ValidatingWebhookConfiguration
 	for _, item := range validatingWebhookConfigurations.Items {
 		if strings.HasPrefix(item.Name, namePrefix) {
-			return item.Name
+			validatingWebhookConfiguration = &item
+			break
 		}
 	}
-	logger.Fatal("ValidatingWebhookConfiguration with prefix ", namePrefix, " not found")
-	return ""
+	if validatingWebhookConfiguration == nil {
+		logger.Fatal("ValidatingWebhookConfiguration with prefix ", namePrefix, " not found")
+		return ""
+	}
+	webhookName := validatingWebhookConfiguration.Name
+
+	// Update the webhooks[*].name field with the generated Name (metadata.name) of the validatingWebhookConfiguration
+	for i := range validatingWebhookConfiguration.Webhooks {
+		validatingWebhookConfiguration.Webhooks[i].Name = webhookName
+	}
+	_, err = kubeClientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(ctx, validatingWebhookConfiguration, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err)
+		logger.Fatal("Could not update ValidatingWebhookConfiguration ", webhookName)
+		return ""
+	}
+	return webhookName
 }


### PR DESCRIPTION
Add mechanism to find the generateName and set that as the
webhook[*].name in mutatingWebhookConfigurations and
validatingWebhookConfigurations

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit 866a1ffb833e151f261f4e9c479f5d7054e26ff5)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```
