### PR TITLE
[cherry-pick] remove taskrun from default prune resource

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -111,7 +111,7 @@ func (tc tektonConfig) createInstance(ctx context.Context) error {
 				TargetNamespace: tc.namespace,
 			},
 			Pruner: v1alpha1.Prune{
-				Resources: []string{"pipelinerun", "taskrun"},
+				Resources: []string{"pipelinerun"},
 				Keep:      &pruneKeep,
 				KeepSince: nil,
 				Schedule:  "0 8 * * *",


### PR DESCRIPTION
this removes taskrun from default prune resource, now only
pipelinerun is default prune resource.
reason: taskruns associated with pipelineruns are by default
deleted, and if a taskrun is not associated to any pipelinerun
then user can explicitly add it to the prune resources.

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
