### PR TITLE
Refactor tekton pipeline and tekton trigger controller

### DIFF
--- a/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
+++ b/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initcontroller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/zapr"
+	mfc "github.com/manifestival/client-go-client"
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"go.uber.org/zap"
+	"knative.dev/pkg/injection"
+)
+
+type Controller struct {
+	Manifest         *mf.Manifest
+	Logger           *zap.SugaredLogger
+	VersionConfigMap string
+}
+
+func (ctrl Controller) InitController(ctx context.Context) (mf.Manifest, string) {
+
+	mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
+	if err != nil {
+		ctrl.Logger.Fatalw("Error creating client from injected config", zap.Error(err))
+	}
+	mflogger := zapr.NewLogger(ctrl.Logger.Named("manifestival").Desugar())
+
+	manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+	if err != nil {
+		ctrl.Logger.Fatalw("Error creating initial manifest", zap.Error(err))
+	}
+
+	ctrl.Manifest = &manifest
+	if err := ctrl.fetchSourceManifests(ctx); err != nil {
+		ctrl.Logger.Fatalw("failed to read manifest", err)
+	}
+
+	var releaseVersion string
+	// Read the release version of component
+	releaseVersion, err = common.FetchVersionFromConfigMap(manifest, ctrl.VersionConfigMap)
+	if err != nil {
+		if common.IsFetchVersionError(err) {
+			ctrl.Logger.Warnf("failed to read version information from ConfigMap %s", ctrl.VersionConfigMap, err)
+			releaseVersion = "Unknown"
+		} else {
+			ctrl.Logger.Fatalw("Error while reading ConfigMap", zap.Error(err))
+		}
+	}
+
+	return manifest, releaseVersion
+}
+
+// fetchSourceManifests mutates the passed manifest by appending one
+// appropriate for the passed TektonComponent
+func (ctrl Controller) fetchSourceManifests(ctx context.Context) error {
+	switch {
+	case strings.Contains(ctrl.VersionConfigMap, "pipeline"):
+		var pipeline *v1alpha1.TektonPipeline
+		if err := common.AppendTarget(ctx, ctrl.Manifest, pipeline); err != nil {
+			return err
+		}
+		// add proxy configs to pipeline if any
+		return addProxy(ctrl.Manifest)
+	case strings.Contains(ctrl.VersionConfigMap, "triggers"):
+		var trigger *v1alpha1.TektonTrigger
+		return common.AppendTarget(ctx, ctrl.Manifest, trigger)
+	}
+
+	return nil
+}
+
+func addProxy(manifest *mf.Manifest) error {
+	koDataDir := os.Getenv(common.KoEnvKey)
+	proxyLocation := filepath.Join(koDataDir, "webhook")
+	return common.AppendManifest(manifest, proxyLocation)
+}

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -18,19 +18,14 @@ package tektonpipeline
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 
-	"github.com/go-logr/zapr"
-	mfc "github.com/manifestival/client-go-client"
-	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineInformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonPipelineReconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonpipeline"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
-	"go.uber.org/zap"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -51,32 +46,12 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 
-		mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
-		if err != nil {
-			logger.Fatalw("Error creating client from injected config", zap.Error(err))
-		}
-		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
-		if err != nil {
-			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		ctrl := initcontroller.Controller{
+			Logger:           logger,
+			VersionConfigMap: versionConfigMap,
 		}
 
-		// Reads the source manifest from kodata while initializing the contoller
-		if err := fetchSourceManifests(ctx, &manifest); err != nil {
-			logger.Fatalw("failed to read manifest", err)
-		}
-
-		var releaseVersion string
-		// Read the release version of pipelines
-		releaseVersion, err = common.FetchVersionFromConfigMap(manifest, versionConfigMap)
-		if err != nil {
-			if common.IsFetchVersionError(err) {
-				logger.Warnf("failed to read version information from ConfigMap %s", versionConfigMap, err)
-				releaseVersion = "Unknown"
-			} else {
-				logger.Fatalw("Error while reading ConfigMap", zap.Error(err))
-			}
-		}
+		manifest, releaseVersion := ctrl.InitController(ctx)
 
 		metrics, err := NewRecorder()
 		if err != nil {
@@ -106,21 +81,4 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		return impl
 	}
-}
-
-// fetchSourceManifests mutates the passed manifest by appending one
-// appropriate for the passed TektonComponent
-func fetchSourceManifests(ctx context.Context, manifest *mf.Manifest) error {
-	var pipeline *v1alpha1.TektonPipeline
-	if err := common.AppendTarget(ctx, manifest, pipeline); err != nil {
-		return err
-	}
-	// add proxy configs to pipeline if any
-	return addProxy(manifest)
-}
-
-func addProxy(manifest *mf.Manifest) error {
-	koDataDir := os.Getenv(common.KoEnvKey)
-	proxyLocation := filepath.Join(koDataDir, "webhook")
-	return common.AppendManifest(manifest, proxyLocation)
 }

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -19,12 +19,10 @@ package tektontrigger
 import (
 	"context"
 
-	"github.com/go-logr/zapr"
-	mfc "github.com/manifestival/client-go-client"
-	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
+
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
-	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -51,32 +49,12 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 
-		mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
-		if err != nil {
-			logger.Fatalw("Error creating client from injected config", zap.Error(err))
-		}
-		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-		manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
-		if err != nil {
-			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		ctrl := initcontroller.Controller{
+			Logger:           logger,
+			VersionConfigMap: versionConfigMap,
 		}
 
-		// Reads the source manifest from kodata while initializing the contoller
-		if err := fetchSourceManifests(ctx, &manifest); err != nil {
-			logger.Fatalw("failed to read manifest", err)
-		}
-
-		var releaseVersion string
-		// Read the release version of triggers
-		releaseVersion, err = common.FetchVersionFromConfigMap(manifest, versionConfigMap)
-		if err != nil {
-			if common.IsFetchVersionError(err) {
-				logger.Warnf("failed to read version information from ConfigMap %s", versionConfigMap, err)
-				releaseVersion = "Unknown"
-			} else {
-				logger.Fatalw("Error while reading ConfigMap", zap.Error(err))
-			}
-		}
+		manifest, releaseVersion := ctrl.InitController(ctx)
 
 		metrics, err := NewRecorder()
 		if err != nil {
@@ -107,11 +85,4 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		return impl
 	}
-}
-
-// fetchSourceManifests mutates the passed manifest by appending one
-// appropriate for the passed TektonComponent
-func fetchSourceManifests(ctx context.Context, manifest *mf.Manifest) error {
-	var trigger *v1alpha1.TektonTrigger
-	return common.AppendTarget(ctx, manifest, trigger)
 }


### PR DESCRIPTION
  - This patch adds a function shared among tektonpipeline and tektontrigger
    which fetches the manifest from the kodata directory for pipelines and
    triggers and fetches the release version of the tekton component

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
