### PR TITLE
Skips adding owner reference in Webhook configuration

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
@@ -25,7 +25,9 @@ import (
 func injectOwner(owner []v1.OwnerReference) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		kind := u.GetKind()
-		if kind == "CustomResourceDefinition" {
+		if kind == "CustomResourceDefinition" ||
+			kind == "ValidatingWebhookConfiguration" ||
+			kind == "MutatingWebhookConfiguration" {
 			return nil
 		}
 		u.SetOwnerReferences(owner)


### PR DESCRIPTION
This updates installerset to exclude adding owner reference in
ValidatingWebhookConfiguration and MutatingWebhookConfiguration as
when we apply the the owner reference for them is changed to the
namespace it is targeting. so, installerset adding owner ref just
log an error while updating. to avoid it we skip adding the ref.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
