### PR TITLE
Improve e2e test script

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,37 +2,53 @@
 
 ## Run E2E Tests Locally
 
-To run run e2e tests locally,
+To run run e2e tests locally (outside Tektoncd Plumbing CI):
 
-set environment variables:
-- `E2E_DEBUG=on`
-- `KO_DOCKER_REPO=<container image registry>`
+If cluster is already available, then skip creation of GKE cluster by setting
+`E2E_SKIP_CLUSTER_CREATION` environment variable:
 
-```shell script
-export E2E_DEBUG=on
+```bash
+export E2E_SKIP_CLUSTER_CREATION=true
+```
+
+If operator is already installed. (For example installed using any of the releases for Kubernetes or OpenShift),
+then skip operator installation by setting `E2E_SKIP_OPERATOR_INSTALLATION` environment variable:
+
+```bash
+export E2E_SKIP_OPERATOR_INSTALLATION=true
+```
+
+Else, set `KO_DOCKER_ENV` so that operator resources could be installed before running 
+e2e tests.
+
+```bash
+unset E2E_SKIP_OPERATOR_INSTALLATION
 export KO_DOCKER_REPO=<container image registry>
 ```
+
 Then run:
 
 ```shell script
 ./test/e2e-tests.sh
 ```
-## Running TESTS
 
-if a cluster is already setup, then set `E2E_DEBUG` variable to skip initialization of a GKE cluster.
+## Example 1: Testing in dev
+
+if a cluster is already available and if we are testing code in development, then set `E2E_SKIP_CLUSTER_CREATION` variable to skip initialization of a GKE cluster.
 
 ```shell script
-export E2E_DEBUG=on
+export E2E_SKIP_CLUSTER_CREATION=true
+KO_DOCKER_REPO=<container image registry>
+./test/e2e-tests.sh
 ```
 
-## Running e2e Tests on Kubernetes
+## Example 2: Testing an Operator release for OpenShift
+
+To test an already released version of the operator build for OpenShift Platform, using an
+already existing OpenShift Cluster.
+
+Install the operator on OpenShift. Then,
 
 ```shell script
-    ./test/e2e-tests.sh
-```
-
-## Running e2e Tests on Openshift
-
-```shell script
-    TARGET=openshift ./test/e2e-tests.sh
+E2E_SKIP_CLUSTER_CREATION=true E2E_SKIP_OPERATOR_INSTALLATION=true TARGET=openshift ./test/e2e-tests.sh
 ```

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -26,11 +26,11 @@ KUBECONFIG_PARAM=${KUBECONFIG:+"--kubeconfig $KUBECONFIG"}
 
 echo "Running tests on ${TARGET}"
 
-[[ -z ${E2E_DEBUG} ]] && initialize $@
+[[ -z ${E2E_SKIP_CLUSTER_CREATION} ]] && initialize $@
 failed=0
 
 header "Setting up environment"
-install_operator_resources
+[[ -z ${E2E_SKIP_OPERATOR_INSTALLATION} ]] && install_operator_resources
 
 echo "Wait for controller to start and create TektonConfig"
 sleep 30


### PR DESCRIPTION
Add a new variable to disable operator installation before testing

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```