### PR TITLE
Schedule tkn serve cli pod also on infra node

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonaddon_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_types.go
@@ -50,6 +50,9 @@ type TektonAddonSpec struct {
 	// The params to customize different components of Addon
 	// +optional
 	Params []Param `json:"params,omitempty"`
+	// Config holds the configuration for resources created by Addon
+	// +optional
+	Config Config `json:"config,omitempty"`
 }
 
 // TektonAddonStatus defines the observed state of TektonAddon

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -402,6 +402,7 @@ func (in *TektonAddonSpec) DeepCopyInto(out *TektonAddonSpec) {
 		*out = make([]Param, len(*in))
 		copy(*out, *in)
 	}
+	in.Config.DeepCopyInto(&out.Config)
 	return
 }
 

--- a/pkg/reconciler/openshift/tektonaddon/extension.go
+++ b/pkg/reconciler/openshift/tektonaddon/extension.go
@@ -31,8 +31,11 @@ import (
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/injection"
@@ -84,33 +87,76 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	logger := logging.FromContext(ctx)
 	addon := comp.(*v1alpha1.TektonAddon)
 
-	miscellaneousManifest := oe.manifest
 	exist, err := checkIfInstallerSetExist(ctx, oe.operatorClientSet, oe.version, addon, miscellaneousResourcesInstallerSet)
 	if err != nil {
 		return err
 	}
 	if !exist {
 
-		if err := applyAddons(&miscellaneousManifest, "05-tkncliserve"); err != nil {
+		manifest, err := getMiscellaneousManifest(ctx, addon, oe.manifest, comp)
+		if err != nil {
 			return err
 		}
 
-		if err := getOptionalAddons(&miscellaneousManifest, comp); err != nil {
-			return err
-		}
-
-		images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.AddonsImagePrefix))
-		extraTranformers := []mf.Transformer{
-			common.DeploymentImages(images),
-		}
-		if err := addonTransform(ctx, &miscellaneousManifest, addon, extraTranformers...); err != nil {
-			return err
-		}
-
-		if err := createInstallerSet(ctx, oe.operatorClientSet, addon, miscellaneousManifest, oe.version,
+		if err := createInstallerSet(ctx, oe.operatorClientSet, addon, manifest, oe.version,
 			miscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
 			return err
 		}
+	}
+
+	// Check if installer set is already created
+	compInstallerSet, ok := addon.Status.AddonsInstallerSet[miscellaneousResourcesInstallerSet]
+	if !ok {
+		return v1alpha1.RECONCILE_AGAIN_ERR
+	}
+
+	installedTIS, err := oe.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		Get(ctx, compInstallerSet, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			manifest, err := getMiscellaneousManifest(ctx, addon, oe.manifest, comp)
+			if err != nil {
+				return err
+			}
+
+			if err := createInstallerSet(ctx, oe.operatorClientSet, addon, manifest, oe.version,
+				miscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
+				return err
+			}
+		}
+		logger.Error("failed to get InstallerSet: %s", err)
+		return err
+	}
+
+	expectedSpecHash, err := hash.Compute(addon.Spec)
+	if err != nil {
+		return err
+	}
+
+	// spec hash stored on installerSet
+	lastAppliedHash := installedTIS.GetAnnotations()[tektoninstallerset.LastAppliedHashKey]
+
+	if lastAppliedHash != expectedSpecHash {
+
+		manifest, err := getMiscellaneousManifest(ctx, addon, oe.manifest, comp)
+		if err != nil {
+			return err
+		}
+
+		// Update the spec hash
+		current := installedTIS.GetAnnotations()
+		current[tektoninstallerset.LastAppliedHashKey] = expectedSpecHash
+		installedTIS.SetAnnotations(current)
+
+		// Update the manifests
+		installedTIS.Spec.Manifests = manifest.Resources()
+
+		if _, err = oe.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+			Update(ctx, installedTIS, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+
+		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
 	existingInstallerSet, ok := addon.Status.AddonsInstallerSet[miscellaneousResourcesInstallerSet]
@@ -220,4 +266,24 @@ func getRouteHost(manifest *mf.Manifest) (string, error) {
 		}
 	}
 	return hostUrl, nil
+}
+
+func getMiscellaneousManifest(ctx context.Context, addon *v1alpha1.TektonAddon, miscellaneousManifest mf.Manifest, comp v1alpha1.TektonComponent) (mf.Manifest, error) {
+	if err := applyAddons(&miscellaneousManifest, "05-tkncliserve"); err != nil {
+		return mf.Manifest{}, err
+	}
+
+	if err := getOptionalAddons(&miscellaneousManifest, comp); err != nil {
+		return mf.Manifest{}, err
+	}
+
+	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.AddonsImagePrefix))
+	extraTranformers := []mf.Transformer{
+		common.DeploymentImages(images),
+		common.AddConfiguration(addon.Spec.Config),
+	}
+	if err := addonTransform(ctx, &miscellaneousManifest, addon, extraTranformers...); err != nil {
+		return mf.Manifest{}, err
+	}
+	return miscellaneousManifest, nil
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon.go
@@ -62,6 +62,11 @@ func ensureTektonAddonExists(ctx context.Context, clients op.TektonAddonInterfac
 			updated = true
 		}
 
+		if !reflect.DeepEqual(taCR.Spec.Config, config.Spec.Config) {
+			taCR.Spec.Config = config.Spec.Config
+			updated = true
+		}
+
 		if taCR.ObjectMeta.OwnerReferences == nil {
 			ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
 			taCR.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
@@ -88,6 +93,7 @@ func ensureTektonAddonExists(ctx context.Context, clients op.TektonAddonInterfac
 					TargetNamespace: config.Spec.TargetNamespace,
 				},
 				Params: config.Spec.Addon.Params,
+				Config: config.Spec.Config,
 			},
 		}
 		return clients.Create(ctx, taCR, metav1.CreateOptions{})


### PR DESCRIPTION
This will add the field in the tekton addon CRD so that nodeselector
and tolerations can be passed to tekton addon cr from config cr and
use those values in scheduling the tkn serve cli pod using already
existing transformer

Added the hash value in the installerset and if it changes, it again
read the manifest and assign to the installerset

This will fix tkn serve cli pod not getting scheduled on infra nodes
if configured in subscription and config CR

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Schedule tkn serve cli pod also on infra node
```