### PR TITLE
operatorhub: call Makefile instead of importing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include operatorhub/Makefile
+# include operatorhub/Makefile
 
 MODULE   = $(shell env GO111MODULE=on $(GO) list -m)
 DATE         ?= $(shell date +%FT%T%z)
@@ -98,6 +98,10 @@ apply: | $(KO) $(KUSTOMIZE) get-releases ; $(info $(M) ko apply on $(TARGET)) @ 
 .PHONY: apply-cr
 apply-cr: | ; $(info $(M) apply CRs on $(TARGET)) @ ## Apply the CRs to the current cluster
 	$Q kubectl apply -f config/crs/$(TARGET)/$(CR)
+
+.PHONY: operator-bundle
+operator-bundle:
+	make -C operatorhub operator-bundle
 
 .PHONY: clean-cr
 clean-cr: | ; $(info $(M) clean CRs on $(TARGET)) @ ## Clean the CRs to the current cluster

--- a/operatorhub/Makefile
+++ b/operatorhub/Makefile
@@ -7,6 +7,9 @@ $(BIN)/operator-sdk: | $(BIN) ; $(info $(M) getting operator-sdk)
 	@./operatorhub/tools/install_operator-sdk.sh $(BIN)
 
 .PHONY: operator-bundle
-operator-bundle: | $(OPERATOR_SDK)
+operator-bundle: | $(OPERATOR_SDK) openshift/release-artifacts/bundle/manifests
 	@$(info BUNDLE_ARGS: $(BUNDLE_ARGS))
-	@OPERATOR_SDK=$(OPERATOR_SDK) operatorhub/tools/bundle.py ${BUNDLE_ARGS}
+	@OPERATOR_SDK=$(OPERATOR_SDK) ./tools/bundle.py ${BUNDLE_ARGS}
+
+openshift/release-artifacts/bundle/manifests:
+	mkdir -p openshift/release-artifacts/bundle/manifests


### PR DESCRIPTION


# Changes

Having a `Makefile` in operatorhub means it should be able to run on
its own (without the root `Makefile`). This mean we shouldn't need to
import it, but we can rather call it using `make -C …`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
