### PR TITLE
Moves installerSet keys at one place & cleanup

### DIFF
--- a/pkg/reconciler/common/utils.go
+++ b/pkg/reconciler/common/utils.go
@@ -17,8 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 
 	mf "github.com/manifestival/manifestival"
@@ -54,16 +52,4 @@ func FetchVersionFromConfigMap(manifest mf.Manifest, configMapName string) (stri
 	}
 
 	return "", configMapError
-}
-
-// ComputeHashOf generates an unique hash/string for the
-// object pass to it.
-func ComputeHashOf(obj interface{}) (string, error) {
-	h := sha256.New()
-	d, err := json.Marshal(obj)
-	if err != nil {
-		return "", err
-	}
-	h.Write(d)
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/pkg/reconciler/common/utils_test.go
+++ b/pkg/reconciler/common/utils_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
-	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"gotest.tools/v3/assert"
 )
 
@@ -67,47 +66,4 @@ func TestFetchVersionFromConfigMap_VersionKeyNotFound(t *testing.T) {
 	}
 
 	assert.Error(t, err, configMapError.Error())
-}
-
-func TestComputeHashOf(t *testing.T) {
-	tp := &v1alpha1.TektonPipeline{
-		Spec: v1alpha1.TektonPipelineSpec{
-			CommonSpec: v1alpha1.CommonSpec{TargetNamespace: "tekton"},
-			Config: v1alpha1.Config{
-				NodeSelector: map[string]string{
-					"abc": "xyz",
-				},
-			},
-		},
-	}
-
-	hash, err := ComputeHashOf(tp.Spec)
-	if err != nil {
-		t.Fatal("unexpected error while computing hash of obj")
-	}
-
-	// Again, calculate the hash without changing object
-
-	hash2, err := ComputeHashOf(tp.Spec)
-	if err != nil {
-		t.Fatal("unexpected error while computing hash of obj")
-	}
-
-	if hash != hash2 {
-		t.Fatal("hash changed without changing the object")
-	}
-
-	// Now, change the object
-
-	tp.Spec.TargetNamespace = "changed"
-
-	hash3, err := ComputeHashOf(tp.Spec)
-	if err != nil {
-		t.Fatal("unexpected error while computing hash of obj")
-	}
-
-	// Hash should be changed now
-	if hash == hash3 {
-		t.Fatal("hash not changed after changing the object")
-	}
 }

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -18,12 +18,10 @@ package tektondashboard
 
 import (
 	"context"
+
 	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
-	"go.uber.org/zap"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	tektonDashboardinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektondashboard"
@@ -31,6 +29,8 @@ import (
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonDashboardreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektondashboard"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"go.uber.org/zap"
+	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"

--- a/pkg/reconciler/kubernetes/tektoninstallerset/const.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/const.go
@@ -14,22 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hash
+package tektoninstallerset
 
-import (
-	"crypto/sha256"
-	"encoding/json"
-	"fmt"
+const (
+	LastAppliedHashKey = "operator.tekton.dev/last-applied-hash"
+	CreatedByKey       = "operator.tekton.dev/created-by"
+	ReleaseVersionKey  = "operator.tekton.dev/release-version"
+	TargetNamespaceKey = "operator.tekton.dev/target-namespace"
 )
-
-// Compute generates an unique hash/string for the
-// object pass to it.
-func Compute(obj interface{}) (string, error) {
-	h := sha256.New()
-	d, err := json.Marshal(obj)
-	if err != nil {
-		return "", err
-	}
-	h.Write(d)
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -27,6 +27,8 @@ import (
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	tektonpipelinereconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonpipeline"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,14 +45,8 @@ const (
 	ConfigDefaults = "config-defaults"
 	ConfigMetrics  = "config-observability"
 
-	proxyLabel = "operator.tekton.dev/disable-proxy=true"
-
-	// TektonInstallerSet keys
-	lastAppliedHashKey = "operator.tekton.dev/last-applied-hash"
-	createdByKey       = "operator.tekton.dev/created-by"
-	createdByValue     = "TektonPipeline"
-	releaseVersionKey  = "operator.tekton.dev/release-version"
-	targetNamespaceKey = "operator.tekton.dev/target-namespace"
+	proxyLabel     = "operator.tekton.dev/disable-proxy=true"
+	createdByValue = "TektonPipeline"
 )
 
 // Reconciler implements controller.Reconciler for TektonPipeline resources.
@@ -88,7 +84,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", createdByKey, createdByValue),
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, createdByValue),
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonPipeline", err)
 		return err
@@ -160,8 +156,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 		return err
 	}
 
-	installerSetTargetNamespace := installedTIS.Annotations[targetNamespaceKey]
-	installerSetReleaseVersion := installedTIS.Annotations[releaseVersionKey]
+	installerSetTargetNamespace := installedTIS.Annotations[tektoninstallerset.TargetNamespaceKey]
+	installerSetReleaseVersion := installedTIS.Annotations[tektoninstallerset.ReleaseVersionKey]
 
 	// Check if TargetNamespace of existing TektonInstallerSet is same as expected
 	// Check if Release Version in TektonInstallerSet is same as expected
@@ -197,13 +193,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 		// TektonInstallerSet with computing new hash of TektonPipeline Spec
 
 		// Hash of TektonPipeline Spec
-		expectedSpecHash, err := common.ComputeHashOf(tp.Spec)
+		expectedSpecHash, err := hash.Compute(tp.Spec)
 		if err != nil {
 			return err
 		}
 
 		// spec hash stored on installerSet
-		lastAppliedHash := installedTIS.GetAnnotations()[lastAppliedHashKey]
+		lastAppliedHash := installedTIS.GetAnnotations()[tektoninstallerset.LastAppliedHashKey]
 
 		if lastAppliedHash != expectedSpecHash {
 			manifest := r.manifest
@@ -214,7 +210,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 
 			// Update the spec hash
 			current := installedTIS.GetAnnotations()
-			current[lastAppliedHashKey] = expectedSpecHash
+			current[tektoninstallerset.LastAppliedHashKey] = expectedSpecHash
 			installedTIS.SetAnnotations(current)
 
 			// Update the manifests
@@ -299,7 +295,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tp *v1alpha1.Tekton
 	// in further reconciliation we compute hash of tp spec and check with
 	// annotation, if they are same then we skip updating the object
 	// otherwise we update the manifest
-	specHash, err := common.ComputeHashOf(tp.Spec)
+	specHash, err := hash.Compute(tp.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -320,12 +316,12 @@ func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, tpSpecH
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", v1alpha1.PipelineResourceName),
 			Labels: map[string]string{
-				createdByKey: createdByValue,
+				tektoninstallerset.CreatedByKey: createdByValue,
 			},
 			Annotations: map[string]string{
-				releaseVersionKey:  releaseVersion,
-				targetNamespaceKey: tp.Spec.TargetNamespace,
-				lastAppliedHashKey: tpSpecHash,
+				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.TargetNamespaceKey: tp.Spec.TargetNamespace,
+				tektoninstallerset.LastAppliedHashKey: tpSpecHash,
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -28,6 +28,8 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektontriggerreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektontrigger"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,11 +45,7 @@ const (
 	ConfigDefaults = "config-defaults-triggers"
 	FeatureFlag    = "feature-flags-triggers"
 
-	createdByKey       = "operator.tekton.dev/created-by"
-	createdByValue     = "TektonTrigger"
-	releaseVersionKey  = "operator.tekton.dev/release-version"
-	targetNamespaceKey = "operator.tekton.dev/target-namespace"
-	lastAppliedHashKey = "operator.tekton.dev/last-applied-hash"
+	createdByValue = "TektonTrigger"
 )
 
 // Reconciler implements controller.Reconciler for TektonTrigger resources.
@@ -88,7 +86,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", createdByKey, createdByValue),
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, createdByValue),
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonTrigger", err)
 		return err
@@ -175,8 +173,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		return err
 	}
 
-	installerSetTargetNamespace := installedTIS.Annotations[targetNamespaceKey]
-	installerSetReleaseVersion := installedTIS.Annotations[releaseVersionKey]
+	installerSetTargetNamespace := installedTIS.Annotations[tektoninstallerset.TargetNamespaceKey]
+	installerSetReleaseVersion := installedTIS.Annotations[tektoninstallerset.ReleaseVersionKey]
 
 	// Check if TargetNamespace of existing TektonInstallerSet is same as expected
 	// Check if Release Version in TektonInstallerSet is same as expected
@@ -214,13 +212,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		// TektonInstallerSet with computing new hash of TektonTrigger Spec
 
 		// Hash of TektonPipeline Spec
-		expectedSpecHash, err := common.ComputeHashOf(tt.Spec)
+		expectedSpecHash, err := hash.Compute(tt.Spec)
 		if err != nil {
 			return err
 		}
 
 		// spec hash stored on installerSet
-		lastAppliedHash := installedTIS.GetAnnotations()[lastAppliedHashKey]
+		lastAppliedHash := installedTIS.GetAnnotations()[tektoninstallerset.LastAppliedHashKey]
 
 		if lastAppliedHash != expectedSpecHash {
 
@@ -232,7 +230,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 
 			// Update the spec hash
 			current := installedTIS.GetAnnotations()
-			current[lastAppliedHashKey] = expectedSpecHash
+			current[tektoninstallerset.LastAppliedHashKey] = expectedSpecHash
 			installedTIS.SetAnnotations(current)
 
 			// Update the manifests
@@ -338,7 +336,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tt *v1alpha1.Tekton
 	// in further reconciliation we compute hash of tt spec and check with
 	// annotation, if they are same then we skip updating the object
 	// otherwise we update the manifest
-	specHash, err := common.ComputeHashOf(tt.Spec)
+	specHash, err := hash.Compute(tt.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -360,12 +358,12 @@ func makeInstallerSet(tt *v1alpha1.TektonTrigger, manifest mf.Manifest, ttSpecHa
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", v1alpha1.TriggerResourceName),
 			Labels: map[string]string{
-				createdByKey: createdByValue,
+				tektoninstallerset.CreatedByKey: createdByValue,
 			},
 			Annotations: map[string]string{
-				releaseVersionKey:  releaseVersion,
-				targetNamespaceKey: tt.Spec.TargetNamespace,
-				lastAppliedHashKey: ttSpecHash,
+				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.TargetNamespaceKey: tt.Spec.TargetNamespace,
+				tektoninstallerset.LastAppliedHashKey: ttSpecHash,
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -30,6 +30,7 @@ import (
 	informer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektonaddonreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonaddon"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	tektonaddon "github.com/tektoncd/operator/pkg/reconciler/openshift/tektonaddon/pipelinetemplates"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -70,10 +71,7 @@ const (
 	consoleCLIInstallerSet             = "ConsoleCLIInstallerSet"
 	miscellaneousResourcesInstallerSet = "MiscellaneousResourcesInstallerSet"
 
-	createdByKey       = "operator.tekton.dev/created-by"
-	createdByValue     = "TektonAddon"
-	releaseVersionKey  = "operator.tekton.dev/release-version"
-	targetNamespaceKey = "operator.tekton.dev/target-namespace"
+	createdByValue = "TektonAddon"
 )
 
 // Check that our Reconciler implements controller.Reconciler
@@ -389,7 +387,7 @@ func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVe
 			return false, err
 		}
 
-		version, ok := ctIs.Annotations[releaseVersionKey]
+		version, ok := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]
 		if ok && version == relVersion {
 			// if installer set already exist and release version is same
 			// then ignore and move on
@@ -443,11 +441,11 @@ func makeInstallerSet(ta *v1alpha1.TektonAddon, manifest mf.Manifest, prefix, re
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", prefix),
 			Labels: map[string]string{
-				createdByKey: createdByValue,
+				tektoninstallerset.CreatedByKey: createdByValue,
 			},
 			Annotations: map[string]string{
-				releaseVersionKey:  releaseVersion,
-				targetNamespaceKey: ta.Spec.TargetNamespace,
+				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.TargetNamespaceKey: ta.Spec.TargetNamespace,
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},

--- a/pkg/reconciler/openshift/tektonconfig/common.go
+++ b/pkg/reconciler/openshift/tektonconfig/common.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -67,8 +68,8 @@ func makeInstallerSet(tc *v1alpha1.TektonConfig, name, releaseVersion string, la
 			Name:   name,
 			Labels: labels,
 			Annotations: map[string]string{
-				releaseVersionKey:  releaseVersion,
-				targetNamespaceKey: tc.Spec.TargetNamespace,
+				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.TargetNamespaceKey: tc.Spec.TargetNamespace,
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
@@ -122,7 +123,7 @@ func checkIfInstallerSetExist(ctx context.Context, oc versioned.Interface, relVe
 			return false, err
 		}
 
-		if version, ok := ctIs.Annotations[releaseVersionKey]; ok && version == relVersion {
+		if version, ok := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]; ok && version == relVersion {
 			// if installer set already exist and release version is same
 			// then ignore and move on
 			return true, nil

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,10 +43,7 @@ const (
 	trustedCABundleConfigMap = "config-trusted-cabundle"
 	clusterInterceptors      = "openshift-pipelines-clusterinterceptors"
 	namespaceVersionLabel    = "openshift-pipelines.tekton.dev/namespace-reconcile-version"
-	createdByKey             = "operator.tekton.dev/created-by"
 	createdByValue           = "RBAC"
-	releaseVersionKey        = "operator.tekton.dev/release-version"
-	targetNamespaceKey       = "operator.tekton.dev/target-namespace"
 	componentName            = "rhosp-rbac"
 	rbacParamName            = "createRbacResource"
 )
@@ -141,7 +139,7 @@ func (r *rbac) createResources(ctx context.Context) error {
 	}
 	if !exist {
 		if err := createInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, map[string]string{
-			createdByKey: createdByValue,
+			tektoninstallerset.CreatedByKey: createdByValue,
 		}, r.version, componentName, "rbac-resources"); err != nil {
 			return err
 		}

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -24,16 +24,12 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	createdByKey       = "operator.tekton.dev/created-by"
-	createdByValue     = "TektonPipeline"
-	releaseVersionKey  = "operator.tekton.dev/release-version"
-	targetNamespaceKey = "operator.tekton.dev/target-namespace"
-)
+const createdByValue = "TektonPipeline"
 
 // checkIfInstallerSetExist checks if installer set exists for a component and return true/false based on it
 // and if installer set which already exist is of older version/ or if target namespace is different then it
@@ -62,8 +58,8 @@ func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVe
 		// If anyone of this is not as expected then delete existing
 		// installer set and create a new one
 
-		version, vOk := ctIs.Annotations[releaseVersionKey]
-		namespace, nOk := ctIs.Annotations[targetNamespaceKey]
+		version, vOk := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]
+		namespace, nOk := ctIs.Annotations[tektoninstallerset.TargetNamespaceKey]
 
 		if vOk && nOk {
 			if version == relVersion && namespace == tp.Spec.TargetNamespace {
@@ -120,11 +116,11 @@ func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix,
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", prefix),
 			Labels: map[string]string{
-				createdByKey: createdByValue,
+				tektoninstallerset.CreatedByKey: createdByValue,
 			},
 			Annotations: map[string]string{
-				releaseVersionKey:  releaseVersion,
-				targetNamespaceKey: tp.Spec.TargetNamespace,
+				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.TargetNamespaceKey: tp.Spec.TargetNamespace,
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},

--- a/pkg/reconciler/shared/hash/hash_test.go
+++ b/pkg/reconciler/shared/hash/hash_test.go
@@ -1,8 +1,25 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hash
 
 import (
-	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 )
 
 func TestCompute(t *testing.T) {

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -20,12 +20,14 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonpipeline"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
 	"github.com/tektoncd/operator/test/client"
@@ -295,7 +297,7 @@ func runAddonTest(t *testing.T, clients *utils.Clients, tc *v1alpha1.TektonConfi
 	t.Run("validate-addon-params", func(t *testing.T) {
 
 		addonsIS, err := clients.Operator.TektonInstallerSets().List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "operator.tekton.dev/created-by=TektonAddon",
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, "TektonAddon"),
 		})
 		if err != nil {
 			t.Fatalf("failed to get InstallerSet: %v", err)
@@ -330,7 +332,7 @@ func runAddonTest(t *testing.T, clients *utils.Clients, tc *v1alpha1.TektonConfi
 		time.Sleep(time.Second * 10)
 
 		addonsIS, err = clients.Operator.TektonInstallerSets().List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "operator.tekton.dev/created-by=TektonAddon",
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, "TektonAddon"),
 		})
 		if err != nil {
 			t.Fatalf("failed to get InstallerSet: %v", err)


### PR DESCRIPTION
This moves the keys for installerSet and single place instead of
having in each package. Also cleanups duplicate code.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

/cc @savitaashture @nikhil-thomas 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
