### PR TITLE
Stop overriding system defaults in SSL_CERT_DIR

### DIFF
--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -114,7 +114,7 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 			}
 		}
 
-		// we wiil mount the certs at this location so we don't override the existing certs
+		// We will mount the certs at this location so we don't override the existing certs
 		sslCertDir := "/tekton-custom-certs"
 		for _, env := range c.Env {
 			if env.Name == "SSL_CERT_DIR" {

--- a/pkg/reconciler/proxy/proxy_test.go
+++ b/pkg/reconciler/proxy/proxy_test.go
@@ -39,7 +39,7 @@ func TestUpdateVolume(t *testing.T) {
 	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 1)
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].Env), 1)
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Name, "SSL_CERT_DIR")
-	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Value, "/tekton-custom-certs")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Value, "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "testv")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "testcm")
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 1)


### PR DESCRIPTION
# Changes

Prior to this commit, we used to set default value of SSL_CERT_DIR in
our TaskRun, etc pods to `/tekton-custom-certs`; while this worked for
certs mounted via the bundle config maps, this broke use cases where users
relied on default locations (like `/etc/ssl/certs`,
`/etc/pki/tls/certs`, etc) for already existing or user-mounted certificates.

This commit fixes that by setting SSL_CERT_DIR as a list of directories
which contains `/tekton-custom-certs` and the system default locations
as well.

# Release Notes

```release-note
System default locations for certificates are no longer overridden by SSL_CERT_DIR
```