### PR TITLE
[cherry-pick] Treat SSL_CERT_DIR as a colon separated list

### DIFF
--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -125,14 +126,16 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 		// Let's mount the certificates now.
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
-				Name:      trustedCAConfigMapVolume,
-				MountPath: filepath.Join(sslCertDir, trustedCAKey),
+				Name: trustedCAConfigMapVolume,
+				// We only want the first entry in SSL_CERT_DIR for the mount
+				MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], trustedCAKey),
 				SubPath:   trustedCAKey,
 				ReadOnly:  true,
 			},
 			corev1.VolumeMount{
-				Name:      serviceCAConfigMapVolume,
-				MountPath: filepath.Join(sslCertDir, serviceCAKey),
+				Name: serviceCAConfigMapVolume,
+				// We only want the first entry in SSL_CERT_DIR for the mount
+				MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], serviceCAKey),
 				SubPath:   serviceCAKey,
 				ReadOnly:  true,
 			},

--- a/pkg/reconciler/proxy/proxy.go
+++ b/pkg/reconciler/proxy/proxy.go
@@ -429,24 +429,28 @@ func updateVolume(pod corev1.Pod, volumeName, configmapName, key string) corev1.
 			//
 			// Copied from https://golang.org/src/crypto/x509/root_linux.go
 			var certDirectories = []string{
+				// Ordering is important here - we will be using the "first"
+				// element in SSL_CERT_DIR to do the volume mounts.
 				sslCertDir,                     // /tekton-custom-certs
 				"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
 				"/etc/pki/tls/certs",           // Fedora/RHEL
 				"/system/etc/security/cacerts", // Android
 			}
 
+			// SSL_CERT_DIR accepts a colon separated list of directories
+			sslCertDir = strings.Join(certDirectories, ":")
 			c.Env = append(c.Env, corev1.EnvVar{
-				Name: "SSL_CERT_DIR",
-				// SSL_CERT_DIR accepts a colon separated list of directories
-				Value: strings.Join(certDirectories, ":"),
+				Name:  "SSL_CERT_DIR",
+				Value: sslCertDir,
 			})
 		}
 
 		// Let's mount the certificates now.
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
-				Name:      volumeName,
-				MountPath: filepath.Join(sslCertDir, key),
+				Name: volumeName,
+				// We only want the first entry in SSL_CERT_DIR for the mount
+				MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], key),
 				SubPath:   key,
 				ReadOnly:  true,
 			},


### PR DESCRIPTION
Prior to this commit, we used to treat SSL_CERT_DIR as a string
containing one directory but it is/can be a colon separated list of
directories. This commit fixes that assumption.