### PR TITLE
[cherry-pick] Schedule tkn serve cli pod also on infra node

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonaddon_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_types.go
@@ -50,6 +50,9 @@ type TektonAddonSpec struct {
 	// The params to customize different components of Addon
 	// +optional
 	Params []Param `json:"params,omitempty"`
+	// Config holds the configuration for resources created by Addon
+	// +optional
+	Config Config `json:"config,omitempty"`
 }
 
 // TektonAddonStatus defines the observed state of TektonAddon

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -402,6 +402,7 @@ func (in *TektonAddonSpec) DeepCopyInto(out *TektonAddonSpec) {
 		*out = make([]Param, len(*in))
 		copy(*out, *in)
 	}
+	in.Config.DeepCopyInto(&out.Config)
 	return
 }
 

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon.go
@@ -62,6 +62,11 @@ func ensureTektonAddonExists(clients op.TektonAddonInterface, config *v1alpha1.T
 			updated = true
 		}
 
+		if !reflect.DeepEqual(taCR.Spec.Config, config.Spec.Config) {
+			taCR.Spec.Config = config.Spec.Config
+			updated = true
+		}
+
 		if taCR.ObjectMeta.OwnerReferences == nil {
 			ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
 			taCR.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
@@ -88,6 +93,7 @@ func ensureTektonAddonExists(clients op.TektonAddonInterface, config *v1alpha1.T
 					TargetNamespace: config.Spec.TargetNamespace,
 				},
 				Params: config.Spec.Addon.Params,
+				Config: config.Spec.Config,
 			},
 		}
 		return clients.Create(context.TODO(), taCR, metav1.CreateOptions{})


### PR DESCRIPTION
This will add the field in the tekton addon CRD so that nodeselector
and tolerations can be passed to tekton addon cr from config cr and
use those values in scheduling the tkn serve cli pod using already
existing transformer

Added the hash value in the installerset and if it changes, it again
read the manifest and assign to the installerset

This will fix tkn serve cli pod not getting scheduled on infra nodes
if configured in subscription and config CR

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
[cherry-pick] Schedule tkn serve cli pod also on infra node
```