### PR TITLE
.Update OWNERS on operator 🙃

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,12 @@
 
 approvers:
 - vdemeester
-- sthaha
 - nikhil-thomas
 - savitaashture
 - houshengbo
 - vincent-pli
+- sm43
 reviewers:
 - pradeepitm12
 - piyush-garg
-- sm43
+- concaf


### PR DESCRIPTION

# Changes

This changes does 3 things:
- Removes @sthaha from approvers (as inactive for a long time 🙏)
- Move @sm43 to approvers
- Adds @concaf to reviewers

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
