### PR TITLE
Adds config map for operator version

### DIFF
--- a/cmd/kubernetes/operator/kodata/info/operator-config.yaml
+++ b/cmd/kubernetes/operator/kodata/info/operator-config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operators-info
+  labels:
+    app.kubernetes.io/instance: default
+data:
+  # Contains operator version which can be queried by external
+  # tools such as CLI.
+  version: 'devel'

--- a/cmd/openshift/operator/kodata/info/operator-config.yaml
+++ b/cmd/openshift/operator/kodata/info/operator-config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operators-info
+  labels:
+    app.kubernetes.io/instance: default
+data:
+  # Contains operator version which can be queried by external
+  # tools such as CLI.
+  version: 'devel'

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
 	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -60,6 +61,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		c := &Reconciler{
 			operatorClientSet: operatorclient.Get(ctx),
+			kubeClientSet:     kubeclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
 			releaseVersion:    releaseVersion,

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -123,6 +123,7 @@ spec:
       sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/base/*.yaml
       sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/${KUBE_DISTRO}/base/*.yaml
       sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\("-version"\), "devel"/\1, "$(params.versionTag)"/g' ${PROJECT_ROOT}/config/${KUBE_DISTRO}/overlays/default/*.yaml
+      sed -i -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${PROJECT_ROOT}/cmd/${KUBE_DISTRO}/operator/kodata/info/operator-config.yaml
 
       # Publish images and create release.yaml
       mkdir -p $OUTPUT_RELEASE_DIR


### PR DESCRIPTION
  - This patch adds a config map which has the operator verison.
    The config map is created in the tektonConfig pre-reconciler

  - First it checks in the tektonConfig reconciler if the targetNs
    exists, if not it creates the targetNs and then in the pipeline
    reconciler if the tektonConfig instance exists then just add the
    labels from the release yamls if the targetNs is `tekton-pipelines`

Fixes: https://github.com/tektoncd/operator/issues/539

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
 ```release-note
 - Adds a config map which has the operator verison
 - This config map can be used by `tkn cli` which would give
   the operator version in the output of `tkn version` command
```