### PR TITLE
Skips Namespace deletion on installlerSet deletion

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
@@ -27,7 +27,8 @@ func injectOwner(owner []v1.OwnerReference) mf.Transformer {
 		kind := u.GetKind()
 		if kind == "CustomResourceDefinition" ||
 			kind == "ValidatingWebhookConfiguration" ||
-			kind == "MutatingWebhookConfiguration" {
+			kind == "MutatingWebhookConfiguration" ||
+			kind == "Namespace" {
 			return nil
 		}
 		u.SetOwnerReferences(owner)
@@ -35,12 +36,14 @@ func injectOwner(owner []v1.OwnerReference) mf.Transformer {
 	}
 }
 
-func injectOwnerForCRDs(owner []v1.OwnerReference) mf.Transformer {
+func injectOwnerForCRDsAndNamespace(owner []v1.OwnerReference) mf.Transformer {
 	if len(owner) == 0 {
 		return func(u *unstructured.Unstructured) error { return nil }
 	}
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "CustomResourceDefinition" {
+		kind := u.GetKind()
+		if kind != "CustomResourceDefinition" &&
+			kind != "Namespace" {
 			return nil
 		}
 		u.SetOwnerReferences(owner)

--- a/pkg/reconciler/kubernetes/tektoninstallerset/transformers_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/transformers_test.go
@@ -39,7 +39,7 @@ func TestInjectOwner_CRDs(t *testing.T) {
 		BlockOwnerDeletion: ptr.Bool(true),
 	}}
 
-	manifest, err := sourceManifest.Transform(injectOwnerForCRDs(owners))
+	manifest, err := sourceManifest.Transform(injectOwnerForCRDsAndNamespace(owners))
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}
@@ -75,7 +75,7 @@ func TestInjectOwner_NonCRDs(t *testing.T) {
 	}}
 
 	// Must not add owner as resource is non-crd
-	manifest, err := sourceManifest.Transform(injectOwnerForCRDs(owners))
+	manifest, err := sourceManifest.Transform(injectOwnerForCRDsAndNamespace(owners))
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}


### PR DESCRIPTION
Previoulsy, if we delete an installerSet with Namespace eg pipelines
it would delete ns too which means it would delete resources from other
installerSet and the other installerSet will try to recreate it. so it
might corrupt the resources.

this update the installerSet to skip the deletion and update the owner of namespace to
the owner of installerSet which means namespace will be deleted when TektonPipeline CR
is deleted and not when its installerSet is deleted.

this also updates the deletion flow in finalizer of TektonConfig.
delete the resources in the reverse way of deletion.
so delete platform specific first then triggers and then pipelines.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
