### PR TITLE
Updates reconciler to use operator version to decide for Upgrades

### DIFF
--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -57,18 +57,19 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		readonlyManifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
+		readonlyManifest, operatorRV, dashboardRV := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
 
-		fullaccessManifest, _ := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: false})
+		fullaccessManifest, _, _ := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: false})
 
 		c := &Reconciler{
-			kubeClientSet:      kubeClient,
-			operatorClientSet:  operatorclient.Get(ctx),
-			extension:          generator(ctx),
-			readonlyManifest:   readonlyManifest,
-			fullaccessManifest: fullaccessManifest,
-			pipelineInformer:   tektonPipelineInformer,
-			releaseVersion:     releaseVersion,
+			kubeClientSet:           kubeClient,
+			operatorClientSet:       operatorclient.Get(ctx),
+			extension:               generator(ctx),
+			readonlyManifest:        readonlyManifest,
+			fullaccessManifest:      fullaccessManifest,
+			pipelineInformer:        tektonPipelineInformer,
+			dashboardReleaseVersion: dashboardRV,
+			operatorReleaseVersion:  operatorRV,
 		}
 		impl := tektonDashboardreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -51,7 +51,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, operatorRV, pipelinesRV := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
@@ -59,11 +59,12 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		}
 
 		c := &Reconciler{
-			operatorClientSet: operatorclient.Get(ctx),
-			extension:         generator(ctx),
-			manifest:          manifest,
-			releaseVersion:    releaseVersion,
-			metrics:           metrics,
+			operatorClientSet:       operatorclient.Get(ctx),
+			extension:               generator(ctx),
+			manifest:                manifest,
+			pipelinesReleaseVersion: pipelinesRV,
+			operatorReleaseVersion:  operatorRV,
+			metrics:                 metrics,
 		}
 		impl := tektonPipelineReconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -54,7 +54,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, operatorRV, triggersRV := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
@@ -62,12 +62,13 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		}
 
 		c := &Reconciler{
-			operatorClientSet: operatorclient.Get(ctx),
-			pipelineInformer:  tektonPipelineinformer.Get(ctx),
-			extension:         generator(ctx),
-			manifest:          manifest,
-			releaseVersion:    releaseVersion,
-			metrics:           metrics,
+			operatorClientSet:      operatorclient.Get(ctx),
+			pipelineInformer:       tektonPipelineinformer.Get(ctx),
+			extension:              generator(ctx),
+			manifest:               manifest,
+			triggersReleaseVersion: triggersRV,
+			operatorReleaseVersion: operatorRV,
+			metrics:                metrics,
 		}
 		impl := tektonTriggerreconciler.NewImpl(ctx, c)
 


### PR DESCRIPTION
Previously, if we don't change a component version and do a release
then installerSet will not get replaced and operator will be using the same
as component version was not changed.
so, now we use operator version to decide whethere to upgrade or not and
save the same in installerSet.
so if operator version changes we recreate installerSet for that
component.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
