### PR TITLE
Fix multiple installersets for tektonaddon

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/const.go
+++ b/pkg/reconciler/openshift/tektonaddon/const.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tekton Authors
+Copyright 2022 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tektoninstallerset
+package tektonaddon
 
 const (
-	LastAppliedHashKey = "operator.tekton.dev/last-applied-hash"
-	CreatedByKey       = "operator.tekton.dev/created-by"
-	ReleaseVersionKey  = "operator.tekton.dev/release-version"
-	TargetNamespaceKey = "operator.tekton.dev/target-namespace"
-	InstallerSetType   = "operator.tekton.dev/type"
+	ClusterTaskInstallerSet            = "ClusterTask"
+	PipelinesTemplateInstallerSet      = "PipelinesTemplate"
+	TriggersResourcesInstallerSet      = "TriggersResources"
+	ConsoleCLIInstallerSet             = "ConsoleCLI"
+	MiscellaneousResourcesInstallerSet = "MiscellaneousResources"
+	CreatedByValue                     = "TektonAddon"
 )

--- a/pkg/reconciler/openshift/tektonaddon/extension.go
+++ b/pkg/reconciler/openshift/tektonaddon/extension.go
@@ -87,31 +87,29 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	logger := logging.FromContext(ctx)
 	addon := comp.(*v1alpha1.TektonAddon)
 
-	exist, err := checkIfInstallerSetExist(ctx, oe.operatorClientSet, oe.version, addon, miscellaneousResourcesInstallerSet)
+	exist, err := checkIfInstallerSetExist(ctx, oe.operatorClientSet, oe.version,
+		fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, MiscellaneousResourcesInstallerSet))
 	if err != nil {
 		return err
 	}
 	if !exist {
-
 		manifest, err := getMiscellaneousManifest(ctx, addon, oe.manifest, comp)
 		if err != nil {
 			return err
 		}
 
 		if err := createInstallerSet(ctx, oe.operatorClientSet, addon, manifest, oe.version,
-			miscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
+			MiscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
 			return err
 		}
-	}
-
-	// Check if installer set is already created
-	compInstallerSet, ok := addon.Status.AddonsInstallerSet[miscellaneousResourcesInstallerSet]
-	if !ok {
 		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
+	// Check if installer set is already created
 	installedTIS, err := oe.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-		Get(ctx, compInstallerSet, metav1.GetOptions{})
+		List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, MiscellaneousResourcesInstallerSet),
+		})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			manifest, err := getMiscellaneousManifest(ctx, addon, oe.manifest, comp)
@@ -120,9 +118,10 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 			}
 
 			if err := createInstallerSet(ctx, oe.operatorClientSet, addon, manifest, oe.version,
-				miscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
+				MiscellaneousResourcesInstallerSet, "addon-openshift"); err != nil {
 				return err
 			}
+			return v1alpha1.RECONCILE_AGAIN_ERR
 		}
 		logger.Error("failed to get InstallerSet: %s", err)
 		return err
@@ -134,7 +133,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	}
 
 	// spec hash stored on installerSet
-	lastAppliedHash := installedTIS.GetAnnotations()[tektoninstallerset.LastAppliedHashKey]
+	lastAppliedHash := installedTIS.Items[0].GetAnnotations()[tektoninstallerset.LastAppliedHashKey]
 
 	if lastAppliedHash != expectedSpecHash {
 
@@ -144,33 +143,31 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 		}
 
 		// Update the spec hash
-		current := installedTIS.GetAnnotations()
+		current := installedTIS.Items[0].GetAnnotations()
 		current[tektoninstallerset.LastAppliedHashKey] = expectedSpecHash
-		installedTIS.SetAnnotations(current)
+		installedTIS.Items[0].SetAnnotations(current)
 
 		// Update the manifests
-		installedTIS.Spec.Manifests = manifest.Resources()
+		installedTIS.Items[0].Spec.Manifests = manifest.Resources()
 
 		if _, err = oe.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-			Update(ctx, installedTIS, metav1.UpdateOptions{}); err != nil {
+			Update(ctx, &installedTIS.Items[0], metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 
 		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
-	existingInstallerSet, ok := addon.Status.AddonsInstallerSet[miscellaneousResourcesInstallerSet]
-	if !ok {
-		return v1alpha1.RECONCILE_AGAIN_ERR
-	}
 	installedAddonIS, err := oe.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-		Get(ctx, existingInstallerSet, metav1.GetOptions{})
+		List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, MiscellaneousResourcesInstallerSet),
+		})
 	if err != nil {
 		logger.Error("failed to get InstallerSet: %s", err)
 		return err
 	}
 
-	ready := installedAddonIS.Status.GetCondition(apis.ConditionReady)
+	ready := installedAddonIS.Items[0].Status.GetCondition(apis.ConditionReady)
 	if ready == nil {
 		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
@@ -180,7 +177,8 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	}
 
 	consolecliManifest := oe.manifest
-	exist, err = checkIfInstallerSetExist(ctx, oe.operatorClientSet, oe.version, addon, consoleCLIInstallerSet)
+	exist, err = checkIfInstallerSetExist(ctx, oe.operatorClientSet, oe.version,
+		fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, ConsoleCLIInstallerSet))
 	if err != nil {
 		return err
 	}
@@ -203,7 +201,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 		}
 
 		if err := createInstallerSet(ctx, oe.operatorClientSet, addon, consolecliManifest, oe.version,
-			consoleCLIInstallerSet, "addon-consolecli"); err != nil {
+			ConsoleCLIInstallerSet, "addon-consolecli"); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -65,16 +65,6 @@ const (
 	providerTypeRedHat    = "redhat"
 )
 
-const (
-	clusterTaskInstallerSet            = "ClusterTaskInstallerSet"
-	pipelinesTemplateInstallerSet      = "PipelinesTemplateInstallerSet"
-	triggersResourcesInstallerSet      = "TriggersResourcesInstallerSet"
-	consoleCLIInstallerSet             = "ConsoleCLIInstallerSet"
-	miscellaneousResourcesInstallerSet = "MiscellaneousResourcesInstallerSet"
-
-	createdByValue = "TektonAddon"
-)
-
 // Check that our Reconciler implements controller.Reconciler
 var _ tektonaddonreconciler.Interface = (*Reconciler)(nil)
 var _ tektonaddonreconciler.Finalizer = (*Reconciler)(nil)
@@ -180,7 +170,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	// with their manifest
 	if ctVal == "true" {
 
-		exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version, ta, clusterTaskInstallerSet)
+		exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version,
+			fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, ClusterTaskInstallerSet))
 		if err != nil {
 			return err
 		}
@@ -190,13 +181,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		}
 	} else {
 		// if disabled then delete the installer Set if exist
-		if err := r.deleteInstallerSet(ctx, ta, clusterTaskInstallerSet); err != nil {
+		if err := r.deleteInstallerSet(ctx,
+			fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, ClusterTaskInstallerSet)); err != nil {
 			return err
 		}
 	}
 
-	err := r.checkComponentStatus(ctx, ta, clusterTaskInstallerSet)
-	if err != nil {
+	if err := r.checkComponentStatus(ctx, fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, ClusterTaskInstallerSet)); err != nil {
 		ta.Status.MarkInstallerSetNotReady(err.Error())
 		return nil
 	}
@@ -205,7 +196,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	// with their manifest
 	if ptVal == "true" {
 
-		exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version, ta, pipelinesTemplateInstallerSet)
+		exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version,
+			fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, PipelinesTemplateInstallerSet))
 		if err != nil {
 			return err
 		}
@@ -214,20 +206,20 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		}
 	} else {
 		// if disabled then delete the installer Set if exist
-		if err := r.deleteInstallerSet(ctx, ta, pipelinesTemplateInstallerSet); err != nil {
+		if err := r.deleteInstallerSet(ctx, fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, PipelinesTemplateInstallerSet)); err != nil {
 			return err
 		}
 	}
 
-	err = r.checkComponentStatus(ctx, ta, pipelinesTemplateInstallerSet)
-	if err != nil {
+	if err := r.checkComponentStatus(ctx, fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, PipelinesTemplateInstallerSet)); err != nil {
 		ta.Status.MarkInstallerSetNotReady(err.Error())
 		return nil
 	}
 
 	// Ensure Triggers resources
 
-	exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version, ta, triggersResourcesInstallerSet)
+	exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.version,
+		fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, TriggersResourcesInstallerSet))
 	if err != nil {
 		return err
 	}
@@ -235,7 +227,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		return r.ensureTriggerResources(ctx, ta)
 	}
 
-	err = r.checkComponentStatus(ctx, ta, triggersResourcesInstallerSet)
+	err = r.checkComponentStatus(ctx, fmt.Sprintf("%s=%s", tektoninstallerset.InstallerSetType, TriggersResourcesInstallerSet))
 	if err != nil {
 		ta.Status.MarkInstallerSetNotReady(err.Error())
 		return nil
@@ -254,34 +246,31 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 
 	ta.Status.MarkPostReconcilerComplete()
 
+	ta.Status.SetVersion(r.version)
+
 	return nil
 }
 
-func (r *Reconciler) checkComponentStatus(ctx context.Context, ta *v1alpha1.TektonAddon, component string) error {
+func (r *Reconciler) checkComponentStatus(ctx context.Context, labelSelector string) error {
 
 	// Check if installer set is already created
-	compInstallerSet, ok := ta.Status.AddonsInstallerSet[component]
-	if !ok {
-		return nil
+	installerSets, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
 
-	if compInstallerSet != "" {
-
-		ctIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-			Get(ctx, compInstallerSet, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		ready := ctIs.Status.GetCondition(apis.ConditionReady)
-		if ready == nil || ready.Status == corev1.ConditionUnknown {
-			return fmt.Errorf("InstallerSet %s: waiting for installation", ctIs.Name)
-		} else if ready.Status == corev1.ConditionFalse {
-			return fmt.Errorf("InstallerSet %s: ", ready.Message)
-		}
+	ready := installerSets.Items[0].Status.GetCondition(apis.ConditionReady)
+	if ready == nil || ready.Status == corev1.ConditionUnknown {
+		return fmt.Errorf("InstallerSet %s: waiting for installation", installerSets.Items[0].Name)
+	} else if ready.Status == corev1.ConditionFalse {
+		return fmt.Errorf("InstallerSet %s: ", ready.Message)
 	}
 
 	return nil
@@ -299,7 +288,7 @@ func (r *Reconciler) ensureTriggerResources(ctx context.Context, ta *v1alpha1.Te
 	}
 
 	if err := createInstallerSet(ctx, r.operatorClientSet, ta, triggerResourcesManifest, r.version,
-		triggersResourcesInstallerSet, "addon-triggers"); err != nil {
+		TriggersResourcesInstallerSet, "addon-triggers"); err != nil {
 		return err
 	}
 
@@ -325,7 +314,7 @@ func (r *Reconciler) ensurePipelineTemplates(ctx context.Context, ta *v1alpha1.T
 	}
 
 	if err := createInstallerSet(ctx, r.operatorClientSet, ta, pipelineTemplateManifest, r.version,
-		pipelinesTemplateInstallerSet, "addon-pipelines"); err != nil {
+		PipelinesTemplateInstallerSet, "addon-pipelines"); err != nil {
 		return err
 	}
 
@@ -358,7 +347,7 @@ func (r *Reconciler) ensureClusterTasks(ctx context.Context, ta *v1alpha1.Tekton
 	}
 
 	if err := createInstallerSet(ctx, r.operatorClientSet, ta, clusterTaskManifest,
-		r.version, clusterTaskInstallerSet, "addon-clustertasks"); err != nil {
+		r.version, ClusterTaskInstallerSet, "addon-clustertasks"); err != nil {
 		return err
 	}
 
@@ -369,40 +358,37 @@ func (r *Reconciler) ensureClusterTasks(ctx context.Context, ta *v1alpha1.Tekton
 // and if installer set which already exist is of older version then it deletes and return false to create a new
 // installer set
 func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVersion string,
-	ta *v1alpha1.TektonAddon, component string) (bool, error) {
+	labelSelector string) (bool, error) {
 
-	// Check if installer set is already created
-	compInstallerSet, ok := ta.Status.AddonsInstallerSet[component]
-	if !ok {
-		return false, nil
+	installerSets, err := oc.OperatorV1alpha1().TektonInstallerSets().
+		List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
 	}
 
-	if compInstallerSet != "" {
+	if len(installerSets.Items) == 1 {
 		// if already created then check which version it is
-		ctIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
-			Get(ctx, compInstallerSet, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-
-		version, ok := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]
+		version, ok := installerSets.Items[0].Labels[tektoninstallerset.ReleaseVersionKey]
 		if ok && version == relVersion {
 			// if installer set already exist and release version is same
 			// then ignore and move on
 			return true, nil
 		}
+	}
 
-		// release version doesn't exist or is different from expected
-		// deleted existing InstallerSet and create a new one
-
-		err = oc.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, compInstallerSet, metav1.DeleteOptions{})
-		if err != nil {
-			return false, err
-		}
+	// release version doesn't exist or is different from expected
+	// deleted existing InstallerSet and create a new one
+	// or there is more than one installerset (unexpected)
+	if err = oc.OperatorV1alpha1().TektonInstallerSets().
+		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		}); err != nil {
+		return false, err
 	}
 
 	return false, nil
@@ -416,41 +402,27 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha
 		return err
 	}
 
-	is := makeInstallerSet(ta, manifest, installerSetPrefix, releaseVersion, specHash)
+	is := makeInstallerSet(ta, manifest, installerSetPrefix, releaseVersion, component, specHash)
 
-	createdIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
-		Create(ctx, is, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	if len(ta.Status.AddonsInstallerSet) == 0 {
-		ta.Status.AddonsInstallerSet = map[string]string{}
-	}
-
-	// Update the status of addon with created installerSet name
-	ta.Status.AddonsInstallerSet[component] = createdIs.Name
-	ta.Status.SetVersion(releaseVersion)
-
-	_, err = oc.OperatorV1alpha1().TektonAddons().
-		UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-	if err != nil {
+	if _, err := oc.OperatorV1alpha1().TektonInstallerSets().
+		Create(ctx, is, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func makeInstallerSet(ta *v1alpha1.TektonAddon, manifest mf.Manifest, prefix, releaseVersion, specHash string) *v1alpha1.TektonInstallerSet {
+func makeInstallerSet(ta *v1alpha1.TektonAddon, manifest mf.Manifest, prefix, releaseVersion, component, specHash string) *v1alpha1.TektonInstallerSet {
 	ownerRef := *metav1.NewControllerRef(ta, ta.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", prefix),
 			Labels: map[string]string{
-				tektoninstallerset.CreatedByKey: createdByValue,
+				tektoninstallerset.CreatedByKey:      CreatedByValue,
+				tektoninstallerset.InstallerSetType:  component,
+				tektoninstallerset.ReleaseVersionKey: releaseVersion,
 			},
 			Annotations: map[string]string{
-				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
 				tektoninstallerset.TargetNamespaceKey: ta.Spec.TargetNamespace,
 				tektoninstallerset.LastAppliedHashKey: specHash,
 			},
@@ -462,28 +434,14 @@ func makeInstallerSet(ta *v1alpha1.TektonAddon, manifest mf.Manifest, prefix, re
 	}
 }
 
-func (r *Reconciler) deleteInstallerSet(ctx context.Context, ta *v1alpha1.TektonAddon, component string) error {
+func (r *Reconciler) deleteInstallerSet(ctx context.Context, labelSelector string) error {
 
-	compInstallerSet, ok := ta.Status.AddonsInstallerSet[component]
-	if !ok {
-		return nil
-	}
-
-	if compInstallerSet != "" {
-		// delete the installer set
-		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, ta.Status.AddonsInstallerSet[component], metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
-		// clear the name of installer set from TektonAddon status
-		delete(ta.Status.AddonsInstallerSet, component)
-		_, err = r.operatorClientSet.OperatorV1alpha1().TektonAddons().
-			UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
 	}
 
 	return nil

--- a/test/e2e/openshift/tektonaddondeployment_test.go
+++ b/test/e2e/openshift/tektonaddondeployment_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package openshift
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -85,6 +86,11 @@ func TestTektonAddonsDeployment(t *testing.T) {
 	// Test if TektonAddon can reach the READY status
 	t.Run("create-addon", func(t *testing.T) {
 		resources.AssertTektonAddonCRReadyStatus(t, clients, crNames)
+	})
+
+	// Test if TektonInstallerSets are created.
+	t.Run("verify-tektoninstallersets", func(t *testing.T) {
+		resources.AssertTektonInstallerSets(t, clients)
 	})
 
 	// Delete the TektonAddon CR instance to see if all resources will be removed

--- a/test/utils/clients.go
+++ b/test/utils/clients.go
@@ -139,3 +139,11 @@ func (c *Clients) TektonResult() operatorv1alpha1.TektonResultInterface {
 func (c *Clients) TektonResultAll() operatorv1alpha1.TektonResultInterface {
 	return c.Operator.TektonResults()
 }
+
+func (c *Clients) TektonInstallerSet() operatorv1alpha1.TektonInstallerSetInterface {
+	return c.Operator.TektonInstallerSets()
+}
+
+func (c *Clients) TektonInstallerSetAll() operatorv1alpha1.TektonInstallerSetInterface {
+	return c.Operator.TektonInstallerSets()
+}


### PR DESCRIPTION
# Changes

This PR fixes creation of multiple installer set for clustertasks addon


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```