### PR TITLE
Remove redundant call to MarkInstallerSetAvailable

### DIFF
--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -251,9 +251,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	// Mark InstallerSet Available
 	tt.Status.MarkInstallerSetAvailable()
 
-	// Mark InstallerSet Available
-	tt.Status.MarkInstallerSetAvailable()
-
 	ready := installedTIS.Status.GetCondition(apis.ConditionReady)
 	if ready == nil {
 		tt.Status.MarkInstallerSetNotReady("Waiting for installation")


### PR DESCRIPTION
# Changes

This commit removes a redundant call to `TektonTriggerStatus.MarkInstallerSetAvailable()`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

```release-note
NONE
```