### PR TITLE
[cherry-pick] fix cronjob creation with irrelevant config change

### DIFF
--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -439,7 +438,7 @@ func diffLastAppliedPruneConfig(ctx context.Context, k kubernetes.Interface, def
 
 	// this will take care of the prune related annotations in the namespace
 	if oldAnnotations != "" {
-		computedAnnotationsHash, err := hash.Compute(oldAnnotations)
+		computedAnnotationsHash, err := ComputeHashOf(oldAnnotations)
 		if err != nil {
 			return changed, err
 		}
@@ -451,7 +450,7 @@ func diffLastAppliedPruneConfig(ctx context.Context, k kubernetes.Interface, def
 		return changed, nil
 	}
 
-	computedDefaultConfigHash, err := hash.Compute(defaultconf)
+	computedDefaultConfigHash, err := ComputeHashOf(defaultconf)
 	if err != nil {
 		return changed, err
 	}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
