### PR TITLE
Fix duplicate InstallerSets in Pipeline Reconciler

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -16,18 +16,12 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"fmt"
-)
-
-var (
-	// RECONCILE_AGAIN_ERR
-	// When we updates spec or status we reconcile again and then proceed so
-	// that we proceed ahead with updated object
-	RECONCILE_AGAIN_ERR = fmt.Errorf("reconcile again and proceed")
-)
+import "fmt"
 
 const (
+	// operatorVersion
+	VersionEnvKey = "VERSION"
+
 	// Profiles
 	ProfileAll   = "all"
 	ProfileBasic = "basic"
@@ -42,6 +36,16 @@ const (
 
 	ApiFieldAlpha  = "alpha"
 	ApiFieldStable = "stable"
+)
+
+var (
+	// RECONCILE_AGAIN_ERR
+	// When we updates spec or status we reconcile again and then proceed so
+	// that we proceed ahead with updated object
+	RECONCILE_AGAIN_ERR = fmt.Errorf("reconcile again and proceed")
+
+	// VERSION_ENV_NOT_SET_ERR Error when VERSION environment variable is not set
+	VERSION_ENV_NOT_SET_ERR = fmt.Errorf("version environment variable %s is not set or empty", VersionEnvKey)
 )
 
 var (

--- a/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
+++ b/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"go.uber.org/zap"
 	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
 )
 
 type Controller struct {
@@ -39,6 +40,16 @@ type Controller struct {
 
 type PayloadOptions struct {
 	ReadOnly bool
+}
+
+func OperatorVersion(ctx context.Context) (string, error) {
+	logger := logging.FromContext(ctx)
+	operatorVersion, ok := os.LookupEnv(v1alpha1.VersionEnvKey)
+	if !ok || operatorVersion == "" {
+		logger.Errorf(v1alpha1.VERSION_ENV_NOT_SET_ERR.Error())
+		return "", v1alpha1.VERSION_ENV_NOT_SET_ERR
+	}
+	return operatorVersion, nil
 }
 
 func (ctrl Controller) InitController(ctx context.Context, opts PayloadOptions) (mf.Manifest, string) {

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -57,9 +57,14 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		readonlyManifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
+		readonlyManifest, dashboardVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
 
 		fullaccessManifest, _ := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: false})
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
+		}
 
 		c := &Reconciler{
 			kubeClientSet:      kubeClient,
@@ -68,7 +73,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			readonlyManifest:   readonlyManifest,
 			fullaccessManifest: fullaccessManifest,
 			pipelineInformer:   tektonPipelineInformer,
-			releaseVersion:     releaseVersion,
+			dashboardVersion:   dashboardVer,
+			operatorVersion:    operatorVer,
 		}
 		impl := tektonDashboardreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
@@ -52,12 +52,11 @@ type Reconciler struct {
 	fullaccessManifest mf.Manifest
 	// Platform-specific behavior to affect the transform
 	// enqueueAfter enqueues a obj after a duration
-	enqueueAfter func(obj interface{}, after time.Duration)
-	extension    common.Extension
-
-	releaseVersion string
-
+	enqueueAfter     func(obj interface{}, after time.Duration)
+	extension        common.Extension
 	pipelineInformer pipelineinformer.TektonPipelineInformer
+	operatorVersion  string
+	dashboardVersion string
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -179,7 +178,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, td *v1alpha1.TektonDashb
 	// If any of the thing above is not same then delete the existing TektonInstallerSet
 	// and create a new with expected properties
 
-	if installerSetTargetNamespace != td.Spec.TargetNamespace || installerSetReleaseVersion != r.releaseVersion {
+	if installerSetTargetNamespace != td.Spec.TargetNamespace || installerSetReleaseVersion != r.operatorVersion {
 		// Delete the existing TektonInstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Delete(ctx, existingInstallerSet, metav1.DeleteOptions{})
@@ -286,7 +285,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, td *v1alpha1.TektonDashb
 func (r *Reconciler) updateTektonDashboardStatus(ctx context.Context, td *v1alpha1.TektonDashboard, createdIs *v1alpha1.TektonInstallerSet) error {
 	// update the td with TektonInstallerSet and releaseVersion
 	td.Status.SetTektonInstallerSet(createdIs.Name)
-	td.Status.SetVersion(r.releaseVersion)
+	td.Status.SetVersion(r.dashboardVersion)
 
 	// Update the status with TektonInstallerSet so that any new thread
 	// reconciling with know that TektonInstallerSet is created otherwise
@@ -335,7 +334,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, td *v1alpha1.Tekton
 	}
 
 	// create installer set
-	tis := makeInstallerSet(td, manifest, specHash, r.releaseVersion)
+	tis := makeInstallerSet(td, manifest, specHash, r.operatorVersion)
 	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, tis, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/reconciler/kubernetes/tektoninstallerset/query.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektoninstallerset
+
+import (
+	"context"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, labelSelector string) (string, error) {
+	iSets, err := client.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(iSets.Items) == 0 {
+		return "", nil
+	}
+	if len(iSets.Items) == 1 {
+		iSetName := iSets.Items[0].GetName()
+		return iSetName, nil
+	}
+
+	// len(iSets.Items) > 1
+	// delete all installerSets as it cannot be decided which one is the desired one
+	err = client.OperatorV1alpha1().TektonInstallerSets().DeleteCollection(ctx,
+		v1.DeleteOptions{},
+		v1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+	if err != nil {
+		return "", err
+	}
+	return "", v1alpha1.RECONCILE_AGAIN_ERR
+}

--- a/pkg/reconciler/kubernetes/tektoninstallerset/query_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektoninstallerset
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCurrentInstallerSetName(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonPipeline",
+		InstallerSetType, "pipeline",
+	)
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "pipeline")
+}
+
+func TestCurrentInstallerSetNameNoMatching(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonTriggers",
+		InstallerSetType, "triggers",
+	)
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "")
+}
+
+func TestCurrentInstallerSetNameWithDuplicates(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline-1",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+			v1alpha1.TektonInstallerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline-2",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonPipeline",
+		InstallerSetType, "pipeline",
+	)
+
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+	assert.Error(t, err, v1alpha1.RECONCILE_AGAIN_ERR.Error())
+	assert.Equal(t, name, "")
+}

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -52,11 +52,16 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, pipelineVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
 			logger.Errorf("Failed to create pipeline metrics recorder %v", err)
+		}
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
 		}
 
 		c := &Reconciler{
@@ -64,7 +69,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			kubeClientSet:     kubeclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
-			releaseVersion:    releaseVersion,
+			operatorVersion:   operatorVer,
+			pipelineVersion:   pipelineVer,
 			metrics:           metrics,
 		}
 		impl := tektonPipelineReconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -86,7 +86,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, createdByValue),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+				tektoninstallerset.CreatedByKey, createdByValue,
+				tektoninstallerset.InstallerSetType, v1alpha1.PipelineResourceName),
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonPipeline", err)
 		return err
@@ -131,7 +133,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	tp.Status.MarkPreReconcilerComplete()
 
 	// Check if an tekton installer set already exists, if not then create
-	existingInstallerSet, err := r.currentInstallerSetName(ctx)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		tektoninstallerset.CreatedByKey, createdByValue,
+		tektoninstallerset.InstallerSetType, v1alpha1.PipelineResourceName,
+	)
+	existingInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, labelSelector)
 	if err != nil {
 		return err
 	}
@@ -383,36 +389,4 @@ func (m *Recorder) logMetrics(status, version string, logger *zap.SugaredLogger)
 	if err != nil {
 		logger.Warnf("Failed to log the metrics : %v", err)
 	}
-}
-
-func (r *Reconciler) currentInstallerSetName(ctx context.Context) (string, error) {
-	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
-		tektoninstallerset.CreatedByKey, createdByValue,
-		tektoninstallerset.InstallerSetType, v1alpha1.PipelineResourceName,
-	)
-	iSets, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	if err != nil {
-		return "", err
-	}
-	if len(iSets.Items) == 0 {
-		return "", nil
-	}
-	if len(iSets.Items) == 1 {
-		iSetName := iSets.Items[0].GetName()
-		return iSetName, nil
-	}
-
-	// len(iSets.Items) > 1
-	// delete all installerSets as it cannot be decided which one is the desired one
-	err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().DeleteCollection(ctx,
-		metav1.DeleteOptions{},
-		v1.ListOptions{
-			LabelSelector: labelSelector,
-		})
-	if err != nil {
-		return "", err
-	}
-	return "", v1alpha1.RECONCILE_AGAIN_ERR
 }

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -54,11 +54,16 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, triggersVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
 			logger.Errorf("Failed to create trigger metrics recorder %v", err)
+		}
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
 		}
 
 		c := &Reconciler{
@@ -66,7 +71,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:  tektonPipelineinformer.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
-			releaseVersion:    releaseVersion,
+			operatorVersion:   operatorVer,
+			triggersVersion:   triggersVer,
 			metrics:           metrics,
 		}
 		impl := tektonTriggerreconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -62,10 +62,10 @@ type Reconciler struct {
 	metrics *Recorder
 
 	pipelineInformer pipelineinformer.TektonPipelineInformer
-	// releaseVersion describes the current triggers version
-	releaseVersion string
 	// enqueueAfter enqueues a obj after a duration
-	enqueueAfter func(obj interface{}, after time.Duration)
+	enqueueAfter    func(obj interface{}, after time.Duration)
+	triggersVersion string
+	operatorVersion string
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -149,7 +149,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		}
 
 		// If there was no existing installer set, that means its a new install
-		r.metrics.logMetrics(metricsNew, r.releaseVersion, logger)
+		r.metrics.logMetrics(metricsNew, r.triggersVersion, logger)
 
 		return r.updateTektonTriggerStatus(ctx, tt, createdIs)
 	}
@@ -164,8 +164,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 				return err
 			}
 			// if there is version diff then its a call for upgrade
-			if tt.Status.Version != r.releaseVersion {
-				r.metrics.logMetrics(metricsUpgrade, r.releaseVersion, logger)
+			if tt.Status.Version != r.triggersVersion {
+				r.metrics.logMetrics(metricsUpgrade, r.triggersVersion, logger)
 			}
 			return r.updateTektonTriggerStatus(ctx, tt, createdIs)
 		}
@@ -181,7 +181,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	// If any of the thing above is not same the delete the existing TektonInstallerSet
 	// and create a new with expected properties
 
-	if installerSetTargetNamespace != tt.Spec.TargetNamespace || installerSetReleaseVersion != r.releaseVersion {
+	if installerSetTargetNamespace != tt.Spec.TargetNamespace || installerSetReleaseVersion != r.operatorVersion {
 
 		// Delete the existing TektonInstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
@@ -308,7 +308,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 func (r *Reconciler) updateTektonTriggerStatus(ctx context.Context, tt *v1alpha1.TektonTrigger, createdIs *v1alpha1.TektonInstallerSet) error {
 	// update the tt with TektonInstallerSet and releaseVersion
 	tt.Status.SetTektonInstallerSet(createdIs.Name)
-	tt.Status.SetVersion(r.releaseVersion)
+	tt.Status.SetVersion(r.triggersVersion)
 
 	// Update the status with TektonInstallerSet so that any new thread
 	// reconciling with know that TektonInstallerSet is created otherwise
@@ -339,7 +339,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tt *v1alpha1.Tekton
 	}
 
 	// create installer set
-	tis := makeInstallerSet(tt, manifest, specHash, r.releaseVersion)
+	tis := makeInstallerSet(tt, manifest, specHash, r.operatorVersion)
 	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, tis, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -192,12 +192,12 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 }
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	pipeline := comp.(*v1alpha1.TektonPipeline)
-	err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline, postPipelineInstallerSet, postReconcileSelector)
-	if err != nil {
+	if err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline,
+		postPipelineInstallerSet, postReconcileSelector); err != nil {
 		return err
 	}
-	err = deleteInstallerSet(ctx, oe.operatorClientSet, pipeline, postPipelineInstallerSet, postReconcileSelector)
-	if err != nil {
+	if err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline,
+		postPipelineInstallerSet, postReconcileSelector); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stdError "errors"
 	"fmt"
+	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -35,58 +36,72 @@ const createdByValue = "TektonPipeline"
 // and if installer set which already exist is of older version/ or if target namespace is different then it
 // deletes and return false to create a new installer set
 func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVersion string,
-	tp *v1alpha1.TektonPipeline, component string) (bool, error) {
+	tp *v1alpha1.TektonPipeline, ls string) (bool, error) {
 
 	// Check if installer set is already created
-	compInstallerSet, ok := tp.Status.ExtentionInstallerSets[component]
-	if !ok {
+	installerSets, err := oc.OperatorV1alpha1().TektonInstallerSets().
+		List(ctx, metav1.ListOptions{
+			LabelSelector: ls,
+		})
+	if err != nil {
+		return false, err
+	}
+	if len(installerSets.Items) == 0 {
+		// only scenario where this function returns
+		// false, nil
 		return false, nil
 	}
 
-	if compInstallerSet != "" {
-		// if already created then check which version it is
-		ctIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
-			Get(ctx, compInstallerSet, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-
-		// Check release version and target namespace
-		// If anyone of this is not as expected then delete existing
-		// installer set and create a new one
-
-		version, vOk := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]
-		namespace, nOk := ctIs.Annotations[tektoninstallerset.TargetNamespaceKey]
-
-		if vOk && nOk {
-			if version == relVersion && namespace == tp.Spec.TargetNamespace {
-				// if installer set already exist
-				// release version and target namespace is as expected
-				// then ignore and move on
-				return true, nil
-			}
-		}
-
-		// release version/ target namespace doesn't exist or is different from expected
-		// deleted existing InstallerSet and create a new one
-
+	// if the List query returns more than 1 InstallerSets,
+	// then delete all of them as we are expecting only one
+	// If there are more than one then it means the state is
+	// corrupted/unexpected. So to get back to desired state
+	// delete all installerSets that match the labelSelector
+	if len(installerSets.Items) > 1 {
 		err = oc.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, compInstallerSet, metav1.DeleteOptions{})
+			DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: ls,
+			})
+
 		if err != nil {
 			return false, err
+		}
+		return false, v1alpha1.RECONCILE_AGAIN_ERR
+	}
+
+	// if the InstallerSet already exists then check then validate it:
+	// Check release version and target namespace
+	// If anyone of this is not as expected then delete existing
+	// InstallerSet and return false
+
+	version, vOk := installerSets.Items[0].Labels[tektoninstallerset.ReleaseVersionKey]
+	namespace, nOk := installerSets.Items[0].Annotations[tektoninstallerset.TargetNamespaceKey]
+
+	if vOk && nOk {
+		if version == relVersion && namespace == tp.Spec.TargetNamespace {
+			// only scenarion where this function returns
+			// true
+			return true, nil
 		}
 	}
 
-	return false, nil
+	// release version/ target namespace information doesn't exist in InstallerSet
+	// or is different from expected
+	// deleted existing InstallerSet and return false
+
+	err = oc.OperatorV1alpha1().TektonInstallerSets().
+		Delete(ctx, installerSets.Items[0].GetName(), metav1.DeleteOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return false, v1alpha1.RECONCILE_AGAIN_ERR
 }
 
 func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha1.TektonPipeline,
-	manifest mf.Manifest, releaseVersion, component, installerSetPrefix string) error {
+	manifest mf.Manifest, releaseVersion, component string) error {
 
-	is := makeInstallerSet(tp, manifest, installerSetPrefix, releaseVersion)
+	is := makeInstallerSet(tp, manifest, component, releaseVersion)
 
 	createdIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, is, metav1.CreateOptions{})
@@ -110,13 +125,15 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha
 	return stdError.New("ensuring TektonPipeline status update")
 }
 
-func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix, releaseVersion string) *v1alpha1.TektonInstallerSet {
+func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, installerSetType, releaseVersion string) *v1alpha1.TektonInstallerSet {
 	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", prefix),
+			GenerateName: fmt.Sprintf("%s-", strings.ToLower(installerSetType)),
 			Labels: map[string]string{
-				tektoninstallerset.CreatedByKey: createdByValue,
+				tektoninstallerset.CreatedByKey:      createdByValue,
+				tektoninstallerset.ReleaseVersionKey: releaseVersion,
+				tektoninstallerset.InstallerSetType:  installerSetType,
 			},
 			Annotations: map[string]string{
 				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
@@ -130,27 +147,23 @@ func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix,
 	}
 }
 
-func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha1.TektonPipeline, component string) error {
+func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha1.TektonPipeline, component, labelSelector string) error {
 
-	compInstallerSet, ok := ta.Status.ExtentionInstallerSets[component]
-	if !ok {
-		return nil
+	// delete the installer set
+	err := oc.OperatorV1alpha1().TektonInstallerSets().
+		DeleteCollection(ctx, metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+	if err != nil {
+		return err
 	}
 
-	if compInstallerSet != "" {
-		// delete the installer set
-		err := oc.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, ta.Status.ExtentionInstallerSets[component], metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
-		// clear the name of installer set from TektonPipeline status
-		delete(ta.Status.ExtentionInstallerSets, component)
-		_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	// clear the name of installer set from TektonPipeline status
+	delete(ta.Status.ExtentionInstallerSets, component)
+	_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Fix occurrence of duplicate installerSets in pre, post and main
recociler logic of TektonPipeline reconciler

Adds a label based querying to identify InstallerSets instead of
querying by there name

Use Operator version instead of Component versions while deciding whether to recreate deployments and other resources during upgrades

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
fixes duplicate pipeline (pre, post, main)  installerSets occuring in in TektoncdPipeline reconciler. 
```
