### PR TITLE
Fixes make apply error due to variable changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
 
 KO = $(or ${KO_BIN},${KO_BIN},$(BIN)/ko)
 
-PIPELINES_VERSION ?= latest
-TRIGGERS_VERSION ?= latest
-DASHBOARD_VERSION ?= latest
-RESULTS_VERSION ?= v0.3.1 # latest returns an older version hence hard coding to v0.3.1 for now (tektoncd/results#138)
+TEKTON_PIPELINE_VERSION ?= latest
+TEKTON_TRIGGERS_VERSION ?= latest
+TEKTON_DASHBOARD_VERSION ?= latest
+TEKTON_RESULTS_VERSION ?= v0.3.1 # latest returns an older version hence hard coding to v0.3.1 for now (tektoncd/results#138)
 
 $(BIN)/ko: PACKAGE=github.com/google/ko/cmd/ko
 


### PR DESCRIPTION
due to variables got renamed make apply used to return an
error
```
./hack/fetch-releases.sh: line 99: 2: unbound variable
make: *** [Makefile:90: get-releases] Error 1
```
this updates the script.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
