### PR TITLE
Removes obsolete installersets created during upgrades

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/query.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query.go
@@ -22,6 +22,8 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, labelSelector string) (string, error) {
@@ -50,4 +52,41 @@ func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, la
 		return "", err
 	}
 	return "", v1alpha1.RECONCILE_AGAIN_ERR
+}
+
+// CleanUpObsoleteResources cleans up obsolete resources
+// this is required because after TektonInstallerSet were introduced
+// it was observed that during upgrade multiple installerSets were
+// getting created
+// now that we have label based query and we have new labels
+// this cleanup is just to make sure we delete all older installerSets
+// from the cluster
+func CleanUpObsoleteResources(ctx context.Context, client clientset.Interface, createdBy string) error {
+
+	labelSelector := labels.NewSelector()
+	createdReq, _ := labels.NewRequirement(CreatedByKey, selection.Equals, []string{createdBy})
+	if createdReq != nil {
+		labelSelector = labelSelector.Add(*createdReq)
+	}
+
+	list, err := client.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		return err
+	}
+
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	for _, i := range list.Items {
+		// check if installerSet has InstallerSetType label
+		// if it doesn't exist then delete it
+		if _, ok := i.Labels[InstallerSetType]; !ok {
+			err := client.OperatorV1alpha1().TektonInstallerSets().Delete(ctx, i.Name, v1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -120,6 +120,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	// Pass the object through defaulting
 	tp.SetDefaults(ctx)
 
+	if err := tektoninstallerset.CleanUpObsoleteResources(ctx, r.operatorClientSet, createdByValue); err != nil {
+		return err
+	}
+
 	if err := r.targetNamespaceCheck(ctx, tp); err != nil {
 		return err
 	}

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -134,6 +134,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	// Pass the object through defaulting
 	tt.SetDefaults(ctx)
 
+	if err := tektoninstallerset.CleanUpObsoleteResources(ctx, r.operatorClientSet, createdByValue); err != nil {
+		return err
+	}
+
 	if err := r.extension.PreReconcile(ctx, tt); err != nil {
 		tt.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
 		return err


### PR DESCRIPTION
after the introduction of installerSet, it was observed that
multiple installerSet are getting created during upgrades,
this adds logic to remove those installeSet.
as we have now changed labels on installerSets and query them
compared to by their name which we used to save in status.

so this deletes any older installerSet which doesn't have the
new label of type.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
