### PR TITLE
Updates tektonPipeline to make it independent of tektonConfig

### DIFF
--- a/pkg/reconciler/common/targetnamespace.go
+++ b/pkg/reconciler/common/targetnamespace.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CreateTargetNamespace(ctx context.Context, labels map[string]string, obj v1alpha1.TektonComponent, kubeClientSet kubernetes.Interface) error {
+	ownerRef := *metav1.NewControllerRef(obj, obj.GroupVersionKind())
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: obj.GetSpec().GetTargetNamespace(),
+			Labels: map[string]string{
+				"operator.tekton.dev/targetNamespace": "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+	}
+
+	if len(labels) > 0 {
+		for key, value := range labels {
+			namespace.Labels[key] = value
+		}
+	}
+
+	if _, err := kubeClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CreateOperatorVersionConfigMap(manifest mf.Manifest, obj v1alpha1.TektonComponent) error {
+	koDataDir := os.Getenv(KoEnvKey)
+	operatorDir := filepath.Join(koDataDir, "info")
+
+	if err := AppendManifest(&manifest, operatorDir); err != nil {
+		return err
+	}
+
+	manifest, err := manifest.Transform(
+		mf.InjectNamespace(obj.GetSpec().GetTargetNamespace()),
+		mf.InjectOwner(obj),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	if err = manifest.Apply(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/reconciler/common/targetnamespace_test.go
+++ b/pkg/reconciler/common/targetnamespace_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeClient struct {
+	err            error
+	getErr         error
+	createErr      error
+	resourcesExist bool
+	creates        []unstructured.Unstructured
+	deletes        []unstructured.Unstructured
+}
+
+var configMap = namespacedResource("v1", "ConfigMap", "test-ns", "operators-info")
+
+func (f *fakeClient) Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var resource *unstructured.Unstructured
+	if f.resourcesExist {
+		resource = &unstructured.Unstructured{}
+	}
+	return resource, f.getErr
+}
+
+func (f *fakeClient) Create(obj *unstructured.Unstructured, options ...mf.ApplyOption) error {
+	obj.SetAnnotations(nil) // Deleting the extra annotation. Irrelevant for the test.
+	f.creates = append(f.creates, *obj)
+	return f.createErr
+}
+
+func (f *fakeClient) Delete(obj *unstructured.Unstructured, options ...mf.DeleteOption) error {
+	f.deletes = append(f.deletes, *obj)
+	return f.err
+}
+
+func (f *fakeClient) Update(obj *unstructured.Unstructured, options ...mf.ApplyOption) error {
+	return f.err
+}
+
+func TestCreateTargetNamespace(t *testing.T) {
+	targetNamespace := "test-ns"
+	component := &v1alpha1.TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-name",
+		},
+		Spec: v1alpha1.TektonPipelineSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: targetNamespace,
+			},
+		},
+	}
+	fakeClientset := fake.NewSimpleClientset()
+
+	err := CreateTargetNamespace(context.Background(), nil, component, fakeClientset)
+	assert.Equal(t, err, nil)
+
+	ns, err := fakeClientset.CoreV1().Namespaces().Get(context.Background(), targetNamespace, metav1.GetOptions{})
+	assert.Equal(t, err, nil)
+	assert.Equal(t, ns.ObjectMeta.Name, targetNamespace)
+}
+
+func TestTargetNamespaceNotFound(t *testing.T) {
+	component := &v1alpha1.TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-name",
+		},
+		Spec: v1alpha1.TektonPipelineSpec{
+			CommonSpec: v1alpha1.CommonSpec{},
+		},
+	}
+	fakeClientset := fake.NewSimpleClientset()
+
+	err := CreateTargetNamespace(context.Background(), nil, component, fakeClientset)
+	assert.Equal(t, err, nil)
+
+	_, err = fakeClientset.CoreV1().Namespaces().Get(context.Background(), "foo", metav1.GetOptions{})
+	assert.Equal(t, err.Error(), `namespaces "foo" not found`)
+}
+
+func TestOperatorVersionCreateConfigMap(t *testing.T) {
+	os.Setenv(KoEnvKey, "testdata/kodata")
+	defer os.Unsetenv(KoEnvKey)
+
+	targetNamespace := "test-ns"
+	component := &v1alpha1.TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-name",
+		},
+		Spec: v1alpha1.TektonPipelineSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: targetNamespace,
+			},
+		},
+	}
+	fakeClientset := fake.NewSimpleClientset()
+
+	err := CreateTargetNamespace(context.Background(), nil, component, fakeClientset)
+	assert.Equal(t, err, nil)
+
+	var manifest mf.Manifest
+
+	client := &fakeClient{}
+	manifest, err = mf.ManifestFrom(mf.Slice(manifest.Resources()), mf.UseClient(client))
+	assert.Equal(t, err, nil)
+
+	err = CreateOperatorVersionConfigMap(manifest, component)
+	assert.Equal(t, err, nil)
+
+	want := []unstructured.Unstructured{configMap}
+
+	if len(want) != len(client.creates) {
+		t.Fatalf("Unexpected creates: %s", fmt.Sprintf("(-got, +want): %s", cmp.Diff(client.creates, want)))
+	}
+}

--- a/pkg/reconciler/common/testdata/kodata/info/test-create-operator-version-config-map.yaml
+++ b/pkg/reconciler/common/testdata/kodata/info/test-create-operator-version-config-map.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operators-info
+  labels:
+    app.kubernetes.io/instance: default
+data:
+  # Contains operator version which can be queried by external
+  # tools such as CLI.
+  version: 'devel'

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -379,8 +379,15 @@ func (r *Reconciler) targetNamespaceCheck(ctx context.Context, tp *v1alpha1.Tekt
 	ns, err := r.kubeClientSet.CoreV1().Namespaces().Get(ctx, tp.GetSpec().GetTargetNamespace(), metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return err
+			if err := common.CreateTargetNamespace(ctx, labels, tp, r.kubeClientSet); err != nil {
+				return err
+			}
+			if err := common.CreateOperatorVersionConfigMap(r.manifest, tp); err != nil {
+				return err
+			}
+			return nil
 		}
+		return err
 	}
 	for key, value := range labels {
 		ns.Labels[key] = value


### PR DESCRIPTION
# Changes

  - With the addition of operator version config map `operators-info`
    getting created in tektonConfig, the targetNamespace was getting
    created in tektonConfig reconciler, but if `tektonConfig` is not installed
    and `tektonPipeline` is supposed to installed alone then it won't
    be installed as it would miss the targetNamespace. 

 - So this patch checks for the targetNamespace in `tektonPipeline`
   reconciler, if it is not present then it creates the targetNamespace
   and also the operator version config map i.e. makes tektonPipeline
   independent of tektonConfig

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
