### PR TITLE
[cherry-pick] Multiple fixes for 1.6.2 builds for OpenShift

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -18,14 +18,10 @@ package v1alpha1
 
 import "fmt"
 
-var (
-	// RECONCILE_AGAIN_ERR
-	// When we updates spec or status we reconcile again and then proceed so
-	// that we proceed ahead with updated object
-	RECONCILE_AGAIN_ERR = fmt.Errorf("reconcile again and proceed")
-)
-
 const (
+	// operatorVersion
+	VersionEnvKey = "VERSION"
+
 	// Profiles
 	ProfileAll   = "all"
 	ProfileBasic = "basic"
@@ -37,6 +33,16 @@ const (
 
 	ApiFieldAlpha  = "alpha"
 	ApiFieldStable = "stable"
+)
+
+var (
+	// RECONCILE_AGAIN_ERR
+	// When we updates spec or status we reconcile again and then proceed so
+	// that we proceed ahead with updated object
+	RECONCILE_AGAIN_ERR = fmt.Errorf("reconcile again and proceed")
+
+	// VERSION_ENV_NOT_SET_ERR Error when VERSION environment variable is not set
+	VERSION_ENV_NOT_SET_ERR = fmt.Errorf("version environment variable %s is not set or empty", VersionEnvKey)
 )
 
 var (

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -62,3 +62,12 @@ var (
 		PipelineTemplatesParam: defaultParamValue,
 	}
 )
+
+var (
+	PipelineResourceName  = "pipeline"
+	TriggerResourceName   = "trigger"
+	DashboardResourceName = "dashboard"
+	AddonResourceName     = "addon"
+	ConfigResourceName    = "config"
+	ResultResourceName    = "result"
+)

--- a/pkg/apis/operator/v1alpha1/tektondashboard_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_lifecycle.go
@@ -26,102 +26,158 @@ var (
 
 	dashboardCondSet = apis.NewLivingConditionSet(
 		DependenciesInstalled,
-		DeploymentsAvailable,
-		InstallSucceeded,
+		PreReconciler,
+		InstallerSetAvailable,
+		InstallerSetReady,
+		PostReconciler,
 	)
 )
 
 // GroupVersionKind returns SchemeGroupVersion of a TektonDashboard
-func (tp *TektonDashboard) GroupVersionKind() schema.GroupVersionKind {
+func (td *TektonDashboard) GroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(KindTektonDashboard)
+}
+
+func (td *TektonDashboard) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(KindTektonDashboard)
 }
 
 // GetCondition returns the current condition of a given condition type
-func (tps *TektonDashboardStatus) GetCondition(t apis.ConditionType) *apis.Condition {
-	return dashboardCondSet.Manage(tps).GetCondition(t)
+func (tds *TektonDashboardStatus) GetCondition(t apis.ConditionType) *apis.Condition {
+	return dashboardCondSet.Manage(tds).GetCondition(t)
 }
 
 // InitializeConditions initializes conditions of an TektonDashboardStatus
-func (tps *TektonDashboardStatus) InitializeConditions() {
-	dashboardCondSet.Manage(tps).InitializeConditions()
+func (tds *TektonDashboardStatus) InitializeConditions() {
+	dashboardCondSet.Manage(tds).InitializeConditions()
 }
 
 // IsReady looks at the conditions returns true if they are all true.
-func (tps *TektonDashboardStatus) IsReady() bool {
-	return dashboardCondSet.Manage(tps).IsHappy()
+func (tds *TektonDashboardStatus) IsReady() bool {
+	return dashboardCondSet.Manage(tds).IsHappy()
 }
 
-// MarkInstallSucceeded marks the InstallationSucceeded status as true.
-func (tps *TektonDashboardStatus) MarkInstallSucceeded() {
-	dashboardCondSet.Manage(tps).MarkTrue(InstallSucceeded)
-	if tps.GetCondition(DependenciesInstalled).IsUnknown() {
-		// Assume deps are installed if we're not sure
-		tps.MarkDependenciesInstalled()
-	}
+func (tds *TektonDashboardStatus) MarkPreReconcilerComplete() {
+	dashboardCondSet.Manage(tds).MarkTrue(PreReconciler)
 }
 
-// MarkInstallFailed marks the InstallationSucceeded status as false with the given
-// message.
-func (tps *TektonDashboardStatus) MarkInstallFailed(msg string) {
-	dashboardCondSet.Manage(tps).MarkFalse(
-		InstallSucceeded,
-		"Error",
-		"Install failed with message: %s", msg)
+func (tds *TektonDashboardStatus) MarkInstallerSetAvailable() {
+	dashboardCondSet.Manage(tds).MarkTrue(InstallerSetAvailable)
 }
 
-// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
-func (tps *TektonDashboardStatus) MarkDeploymentsAvailable() {
-	dashboardCondSet.Manage(tps).MarkTrue(DeploymentsAvailable)
+func (tds *TektonDashboardStatus) MarkInstallerSetReady() {
+	dashboardCondSet.Manage(tds).MarkTrue(InstallerSetReady)
 }
 
-// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
-// it's waiting for deployments.
-func (tps *TektonDashboardStatus) MarkDeploymentsNotReady() {
-	dashboardCondSet.Manage(tps).MarkFalse(
-		DeploymentsAvailable,
-		"NotReady",
-		"Waiting on deployments")
+func (tds *TektonDashboardStatus) MarkPostReconcilerComplete() {
+	dashboardCondSet.Manage(tds).MarkTrue(PostReconciler)
 }
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.
-func (tps *TektonDashboardStatus) MarkDependenciesInstalled() {
-	dashboardCondSet.Manage(tps).MarkTrue(DependenciesInstalled)
+func (tds *TektonDashboardStatus) MarkDependenciesInstalled() {
+	dashboardCondSet.Manage(tds).MarkTrue(DependenciesInstalled)
+}
+
+func (tds *TektonDashboardStatus) MarkNotReady(msg string) {
+	dashboardCondSet.Manage(tds).MarkFalse(
+		apis.ConditionReady,
+		"Error",
+		"Ready: %s", msg)
+}
+
+func (tds *TektonDashboardStatus) MarkPreReconcilerFailed(msg string) {
+	tds.MarkNotReady("PreReconciliation failed")
+	dashboardCondSet.Manage(tds).MarkFalse(
+		PreReconciler,
+		"Error",
+		"PreReconciliation failed with message: %s", msg)
+}
+
+func (tds *TektonDashboardStatus) MarkInstallerSetNotAvailable(msg string) {
+	tds.MarkNotReady("TektonInstallerSet not ready")
+	dashboardCondSet.Manage(tds).MarkFalse(
+		InstallerSetAvailable,
+		"Error",
+		"Installer set not ready: %s", msg)
+}
+
+func (tds *TektonDashboardStatus) MarkInstallerSetNotReady(msg string) {
+	tds.MarkNotReady("TektonInstallerSet not ready")
+	dashboardCondSet.Manage(tds).MarkFalse(
+		InstallerSetReady,
+		"Error",
+		"Installer set not ready: %s", msg)
+}
+
+func (tds *TektonDashboardStatus) MarkPostReconcilerFailed(msg string) {
+	tds.MarkNotReady("PostReconciliation failed")
+	dashboardCondSet.Manage(tds).MarkFalse(
+		PostReconciler,
+		"Error",
+		"PostReconciliation failed with message: %s", msg)
 }
 
 // MarkDependencyInstalling marks the DependenciesInstalled status as false with the
 // given message.
-func (tps *TektonDashboardStatus) MarkDependencyInstalling(msg string) {
-	dashboardCondSet.Manage(tps).MarkFalse(
+func (tds *TektonDashboardStatus) MarkDependencyInstalling(msg string) {
+	tds.MarkNotReady("Dependencies installing")
+	dashboardCondSet.Manage(tds).MarkFalse(
 		DependenciesInstalled,
-		"Installing",
+		"Error",
 		"Dependency installing: %s", msg)
 }
 
 // MarkDependencyMissing marks the DependenciesInstalled status as false with the
 // given message.
-func (tps *TektonDashboardStatus) MarkDependencyMissing(msg string) {
-	dashboardCondSet.Manage(tps).MarkFalse(
+func (tds *TektonDashboardStatus) MarkDependencyMissing(msg string) {
+	tds.MarkNotReady("Missing Dependencies for TektonDashboard")
+	dashboardCondSet.Manage(tds).MarkFalse(
 		DependenciesInstalled,
 		"Error",
 		"Dependency missing: %s", msg)
 }
 
+func (tds *TektonDashboardStatus) GetTektonInstallerSet() string {
+	return tds.TektonInstallerSet
+}
+
+func (tds *TektonDashboardStatus) SetTektonInstallerSet(installerSet string) {
+	tds.TektonInstallerSet = installerSet
+}
+
 // GetVersion gets the currently installed version of the component.
-func (tps *TektonDashboardStatus) GetVersion() string {
-	return tps.Version
+func (tds *TektonDashboardStatus) GetVersion() string {
+	return tds.Version
 }
 
 // SetVersion sets the currently installed version of the component.
-func (tps *TektonDashboardStatus) SetVersion(version string) {
-	tps.Version = version
+func (tds *TektonDashboardStatus) SetVersion(version string) {
+	tds.Version = version
+}
+
+// MarkInstallSucceeded marks the InstallationSucceeded status as true.
+func (tds *TektonDashboardStatus) MarkInstallSucceeded() {
+	panic("implement me")
+}
+
+// MarkInstallFailed marks the InstallationSucceeded status as false with the given
+// message.
+func (tds *TektonDashboardStatus) MarkInstallFailed(msg string) {
+	panic("implement me")
+}
+
+// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
+func (tds *TektonDashboardStatus) MarkDeploymentsAvailable() {
+	panic("implement me")
+}
+
+// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
+// it's waiting for deployments.
+func (tds *TektonDashboardStatus) MarkDeploymentsNotReady() {
+	panic("implement me")
 }
 
 // GetManifests gets the url links of the manifests.
-func (tps *TektonDashboardStatus) GetManifests() []string {
-	return tps.Manifests
-}
-
-// SetVersion sets the url links of the manifests.
-func (tps *TektonDashboardStatus) SetManifests(manifests []string) {
-	tps.Manifests = manifests
+func (tds *TektonDashboardStatus) GetManifests() []string {
+	panic("implement me")
 }

--- a/pkg/apis/operator/v1alpha1/tektondashboard_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_lifecycle_test.go
@@ -30,7 +30,7 @@ func TestTektonDashboardGroupVersionKind(t *testing.T) {
 		Version: SchemaVersion,
 		Kind:    KindTektonDashboard,
 	}
-	if got := r.GroupVersionKind(); got != want {
+	if got := r.GetGroupVersionKind(); got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
@@ -40,81 +40,85 @@ func TestTektonDashboardHappyPath(t *testing.T) {
 	tt.InitializeConditions()
 
 	apistest.CheckConditionOngoing(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(tt, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(tt, PreReconciler, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetAvailable, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetReady, t)
+	apistest.CheckConditionOngoing(tt, PostReconciler, t)
 
-	// Install succeeds.
-	tt.MarkInstallSucceeded()
-	// Dependencies are assumed successful too.
+	// Dependencies installed
+	tt.MarkDependenciesInstalled()
 	apistest.CheckConditionSucceeded(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
 
-	// Deployments are not available at first.
-	tt.MarkDeploymentsNotReady()
-	apistest.CheckConditionSucceeded(tt, DependenciesInstalled, t)
-	apistest.CheckConditionFailed(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
-	if ready := tt.IsReady(); ready {
-		t.Errorf("tt.IsReady() = %v, want false", ready)
-	}
+	// Pre reconciler completes execution
+	tt.MarkPreReconcilerComplete()
+	apistest.CheckConditionSucceeded(tt, PreReconciler, t)
 
-	// Deployments become ready and we're good.
-	tt.MarkDeploymentsAvailable()
-	apistest.CheckConditionSucceeded(tt, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
+	// Installer set created
+	tt.MarkInstallerSetAvailable()
+	apistest.CheckConditionSucceeded(tt, InstallerSetAvailable, t)
+
+	// InstallerSet is not ready when deployment pods are not up
+	tt.MarkInstallerSetNotReady("waiting for deployments")
+	apistest.CheckConditionFailed(tt, InstallerSetReady, t)
+
+	// InstallerSet and then PostReconciler become ready and we're good.
+	tt.MarkInstallerSetReady()
+	apistest.CheckConditionSucceeded(tt, InstallerSetReady, t)
+
+	tt.MarkPostReconcilerComplete()
+	apistest.CheckConditionSucceeded(tt, PostReconciler, t)
+
 	if ready := tt.IsReady(); !ready {
 		t.Errorf("tt.IsReady() = %v, want true", ready)
 	}
 }
 
 func TestTektonDashboardErrorPath(t *testing.T) {
-	tt := &TektonDashboardStatus{}
-	tt.InitializeConditions()
+	tr := &TektonDashboardStatus{}
+	tr.InitializeConditions()
 
-	apistest.CheckConditionOngoing(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(tt, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(tr, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(tr, PreReconciler, t)
+	apistest.CheckConditionOngoing(tr, InstallerSetAvailable, t)
+	apistest.CheckConditionOngoing(tr, InstallerSetReady, t)
+	apistest.CheckConditionOngoing(tr, PostReconciler, t)
 
-	// Install fails.
-	tt.MarkInstallFailed("test")
-	apistest.CheckConditionOngoing(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionFailed(tt, InstallSucceeded, t)
+	// Dependencies installed
+	tr.MarkDependenciesInstalled()
+	apistest.CheckConditionSucceeded(tr, DependenciesInstalled, t)
 
-	// Dependencies are installing.
-	tt.MarkDependencyInstalling("testing")
-	apistest.CheckConditionFailed(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionFailed(tt, InstallSucceeded, t)
+	// Pre reconciler completes execution
+	tr.MarkPreReconcilerComplete()
+	apistest.CheckConditionSucceeded(tr, PreReconciler, t)
 
-	// Install now succeeds.
-	tt.MarkInstallSucceeded()
-	apistest.CheckConditionFailed(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
-	if ready := tt.IsReady(); ready {
-		t.Errorf("tt.IsReady() = %v, want false", ready)
+	// Installer set created
+	tr.MarkInstallerSetAvailable()
+	apistest.CheckConditionSucceeded(tr, InstallerSetAvailable, t)
+
+	// InstallerSet is not ready when deployment pods are not up
+	tr.MarkInstallerSetNotReady("waiting for deployments")
+	apistest.CheckConditionFailed(tr, InstallerSetReady, t)
+
+	// InstallerSet and then PostReconciler become ready and we're good.
+	tr.MarkInstallerSetReady()
+	apistest.CheckConditionSucceeded(tr, InstallerSetReady, t)
+
+	tr.MarkPostReconcilerComplete()
+	apistest.CheckConditionSucceeded(tr, PostReconciler, t)
+
+	if ready := tr.IsReady(); !ready {
+		t.Errorf("tr.IsReady() = %v, want true", ready)
 	}
 
-	// Deployments become ready
-	tt.MarkDeploymentsAvailable()
-	apistest.CheckConditionFailed(tt, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
-	if ready := tt.IsReady(); ready {
-		t.Errorf("tt.IsReady() = %v, want false", ready)
+	// In further reconciliation deployment might fail and installer
+	// set will change to not ready
+
+	tr.MarkInstallerSetNotReady("webhook not ready")
+	apistest.CheckConditionFailed(tr, InstallerSetReady, t)
+	if ready := tr.IsReady(); ready {
+		t.Errorf("tr.IsReady() = %v, want false", ready)
 	}
 
-	// Finally, dependencies become available.
-	tt.MarkDependenciesInstalled()
-	apistest.CheckConditionSucceeded(tt, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
-	if ready := tt.IsReady(); !ready {
-		t.Errorf("tt.IsReady() = %v, want true", ready)
-	}
 }
 
 func TestTektonDashboardExternalDependency(t *testing.T) {
@@ -124,15 +128,17 @@ func TestTektonDashboardExternalDependency(t *testing.T) {
 	// External marks dependency as failed.
 	tt.MarkDependencyMissing("test")
 
-	// Install succeeds.
-	tt.MarkInstallSucceeded()
 	apistest.CheckConditionFailed(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(tt, PreReconciler, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetAvailable, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetReady, t)
+	apistest.CheckConditionOngoing(tt, PostReconciler, t)
 
 	// Dependencies are now ready.
 	tt.MarkDependenciesInstalled()
 	apistest.CheckConditionSucceeded(tt, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(tt, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(tt, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(tt, PreReconciler, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetAvailable, t)
+	apistest.CheckConditionOngoing(tt, InstallerSetReady, t)
+	apistest.CheckConditionOngoing(tt, PostReconciler, t)
 }

--- a/pkg/apis/operator/v1alpha1/tektondashboard_types.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_types.go
@@ -66,9 +66,9 @@ type TektonDashboardStatus struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// The url links of the manifests, separated by comma
+	// The current installer set name for TektonDashboard
 	// +optional
-	Manifests []string `json:"manifests,omitempty"`
+	TektonInstallerSet string `json:"tektonInstallerSet,omitempty"`
 }
 
 // TektonDashboardsList contains a list of TektonDashboard

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -637,11 +637,6 @@ func (in *TektonDashboardSpec) DeepCopy() *TektonDashboardSpec {
 func (in *TektonDashboardStatus) DeepCopyInto(out *TektonDashboardStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.Manifests != nil {
-		in, out := &in.Manifests, &out.Manifests
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/reconciler/common/deadlockbreaker.go
+++ b/pkg/reconciler/common/deadlockbreaker.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	"github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+)
+
+var webhookNames = map[string]string{
+	v1alpha1.PipelineResourceName: "config.webhook.pipeline.tekton.dev",
+	v1alpha1.TriggerResourceName:  "config.webhook.triggers.tekton.dev",
+}
+
+var webhookServiceNames = map[string]string{
+	v1alpha1.PipelineResourceName: "tekton-pipelines-webhook",
+	v1alpha1.TriggerResourceName:  "tekton-triggers-webhook",
+}
+
+func PreemptDeadlock(ctx context.Context, m *manifestival.Manifest, kc kubernetes.Interface, component string) error {
+
+	// check if there are pod endpoints populated for webhhook service
+	webhookServiceName := webhookServiceNames[component]
+	ok, err := isWebhookEndpointsActive(m, kc, webhookServiceName)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	// if endpoints are empty, set webhook definition rules
+	// to the initial state where the webhook pod can refill the rules when it comes up
+	webhookName := webhookNames[component]
+	err = removeValidatingWebhookRules(m, kc, webhookName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// isWebhookEndpointsActive checks if the there are valid Endpoint resources associated with a webhook service
+func isWebhookEndpointsActive(m *manifestival.Manifest, kc kubernetes.Interface, svcName string) (bool, error) {
+	svcResource := m.Filter(manifestival.ByKind("Service"), manifestival.ByName(svcName))
+	targetNamespace := svcResource.Resources()[0].GetNamespace()
+	endPoint, err := kc.CoreV1().Endpoints(targetNamespace).Get(context.TODO(), svcName, v1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if endPoint.Subsets == nil || len(endPoint.Subsets) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// removeValidatingWebhookRules remove "rules" from config.webhook.** webhook definiton(s)
+func removeValidatingWebhookRules(m *manifestival.Manifest, kc kubernetes.Interface, webhookName string) error {
+	cmValidationWebHookManifest := m.Filter(manifestival.ByName(webhookName))
+	cmValidationWebHookManifest, err := cmValidationWebHookManifest.Transform(removeWebhooks)
+	if err != nil {
+		return err
+	}
+	return cmValidationWebHookManifest.Apply()
+}
+
+// removeWebhooks is a Transformer function which clears our webhooks[...].rules
+func removeWebhooks(u *unstructured.Unstructured) error {
+	unstructured.RemoveNestedField(u.Object, "webhooks")
+	return nil
+}

--- a/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
+++ b/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initcontroller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/zapr"
+	mfc "github.com/manifestival/client-go-client"
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"go.uber.org/zap"
+	"knative.dev/pkg/injection"
+)
+
+type Controller struct {
+	Manifest         *mf.Manifest
+	Logger           *zap.SugaredLogger
+	VersionConfigMap string
+}
+
+func (ctrl Controller) InitController(ctx context.Context) (mf.Manifest, string) {
+
+	mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
+	if err != nil {
+		ctrl.Logger.Fatalw("Error creating client from injected config", zap.Error(err))
+	}
+	mflogger := zapr.NewLogger(ctrl.Logger.Named("manifestival").Desugar())
+
+	manifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+	if err != nil {
+		ctrl.Logger.Fatalw("Error creating initial manifest", zap.Error(err))
+	}
+
+	ctrl.Manifest = &manifest
+	if err := ctrl.fetchSourceManifests(ctx); err != nil {
+		ctrl.Logger.Fatalw("failed to read manifest", err)
+	}
+
+	var releaseVersion string
+	// Read the release version of component
+	releaseVersion, err = common.FetchVersionFromConfigMap(manifest, ctrl.VersionConfigMap)
+	if err != nil {
+		if common.IsFetchVersionError(err) {
+			ctrl.Logger.Warnf("failed to read version information from ConfigMap %s", ctrl.VersionConfigMap, err)
+			releaseVersion = "Unknown"
+		} else {
+			ctrl.Logger.Fatalw("Error while reading ConfigMap", zap.Error(err))
+		}
+	}
+
+	return manifest, releaseVersion
+}
+
+// fetchSourceManifests mutates the passed manifest by appending one
+// appropriate for the passed TektonComponent
+func (ctrl Controller) fetchSourceManifests(ctx context.Context) error {
+	switch {
+	case strings.Contains(ctrl.VersionConfigMap, "pipeline"):
+		var pipeline *v1alpha1.TektonPipeline
+		if err := common.AppendTarget(ctx, ctrl.Manifest, pipeline); err != nil {
+			return err
+		}
+		// add proxy configs to pipeline if any
+		return addProxy(ctrl.Manifest)
+	case strings.Contains(ctrl.VersionConfigMap, "triggers"):
+		var trigger *v1alpha1.TektonTrigger
+		return common.AppendTarget(ctx, ctrl.Manifest, trigger)
+	}
+
+	return nil
+}
+
+func addProxy(manifest *mf.Manifest) error {
+	koDataDir := os.Getenv(common.KoEnvKey)
+	proxyLocation := filepath.Join(koDataDir, "webhook")
+	return common.AppendManifest(manifest, proxyLocation)
+}

--- a/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
+++ b/pkg/reconciler/kubernetes/initcontroller/initcontroller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"go.uber.org/zap"
 	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
 )
 
 type Controller struct {
@@ -39,6 +40,16 @@ type Controller struct {
 
 type PayloadOptions struct {
 	ReadOnly bool
+}
+
+func OperatorVersion(ctx context.Context) (string, error) {
+	logger := logging.FromContext(ctx)
+	operatorVersion, ok := os.LookupEnv(v1alpha1.VersionEnvKey)
+	if !ok || operatorVersion == "" {
+		logger.Errorf(v1alpha1.VERSION_ENV_NOT_SET_ERR.Error())
+		return "", v1alpha1.VERSION_ENV_NOT_SET_ERR
+	}
+	return operatorVersion, nil
 }
 
 func (ctrl Controller) InitController(ctx context.Context, opts PayloadOptions) (mf.Manifest, string) {

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -58,9 +58,14 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		readonlyManifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
+		readonlyManifest, dashboardVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
 
 		fullaccessManifest, _ := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: false})
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
+		}
 
 		c := &Reconciler{
 			kubeClientSet:      kubeClient,
@@ -69,7 +74,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			readonlyManifest:   readonlyManifest,
 			fullaccessManifest: fullaccessManifest,
 			pipelineInformer:   tektonPipelineInformer,
-			releaseVersion:     releaseVersion,
+			dashboardVersion:   dashboardVer,
+			operatorVersion:    operatorVer,
 		}
 		impl := tektonDashboardreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -18,9 +18,8 @@ package tektondashboard
 
 import (
 	"context"
-	"github.com/go-logr/zapr"
-	mfc "github.com/manifestival/client-go-client"
-	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
+
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 
@@ -38,6 +37,8 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+const versionConfigMap = "dashboard-info"
+
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -52,31 +53,14 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		kubeClient := kubeclient.Get(ctx)
 		logger := logging.FromContext(ctx)
 
-		mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
-		if err != nil {
-			logger.Fatalw("Error creating client from injected config", zap.Error(err))
-		}
-		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-
-		readonlyManifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
-		if err != nil {
-			logger.Fatalw("Error creating initial manifest", zap.Error(err))
+		ctrl := initcontroller.Controller{
+			Logger:           logger,
+			VersionConfigMap: versionConfigMap,
 		}
 
-		// Reads the source manifest from kodata while initializing the contoller
-		if err := fetchSourceReadOnlyManifests(ctx, &readonlyManifest); err != nil {
-			logger.Fatalw("failed to read manifest", err)
-		}
+		readonlyManifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: true})
 
-		fullaccessManifest, err := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
-		if err != nil {
-			logger.Fatalw("Error creating initial manifest", zap.Error(err))
-		}
-
-		// Reads the source manifest from kodata while initializing the contoller
-		if err := fetchSourceFullAccessManifests(context.TODO(), &fullaccessManifest); err != nil {
-			logger.Fatalw("failed to read manifest", err)
-		}
+		fullaccessManifest, _ := ctrl.InitController(ctx, initcontroller.PayloadOptions{ReadOnly: false})
 
 		c := &Reconciler{
 			kubeClientSet:      kubeClient,
@@ -85,6 +69,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			readonlyManifest:   readonlyManifest,
 			fullaccessManifest: fullaccessManifest,
 			pipelineInformer:   tektonPipelineInformer,
+			releaseVersion:     releaseVersion,
 		}
 		impl := tektonDashboardreconciler.NewImpl(ctx, c)
 
@@ -102,20 +87,4 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		return impl
 	}
-}
-
-// fetchSourceReadOnlyManifests mutates the passed manifest by appending one
-// appropriate for the passed TektonComponent with readonly value set to true
-func fetchSourceReadOnlyManifests(ctx context.Context, manifest *mf.Manifest) error {
-	var dashboard v1alpha1.TektonDashboard
-	dashboard.Spec.Readonly = true
-	return common.AppendTarget(ctx, manifest, &dashboard)
-}
-
-// fetchSourceFullAccessManifests mutates the passed manifest by appending one
-// appropriate for the passed TektonComponent with readonly value set to false
-func fetchSourceFullAccessManifests(ctx context.Context, manifest *mf.Manifest) error {
-	var dashboard v1alpha1.TektonDashboard
-	dashboard.Spec.Readonly = false
-	return common.AppendTarget(ctx, manifest, &dashboard)
 }

--- a/pkg/reconciler/kubernetes/tektondashboard/controller.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/controller.go
@@ -18,9 +18,9 @@ package tektondashboard
 
 import (
 	"context"
+
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
 
-	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"

--- a/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
@@ -120,8 +120,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, td *v1alpha1.TektonDashb
 
 	logger.Infow("Reconciling TektonDashboards", "status", td.Status)
 
-	r.releaseVersion = common.TargetVersion(td)
-
 	if td.GetName() != watchedResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			watchedResourceName,

--- a/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
@@ -19,6 +19,9 @@ package tektondashboard
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 
 	mf "github.com/manifestival/manifestival"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +32,9 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektondashboardreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektondashboard"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -39,13 +45,18 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// operatorClientSet allows us to configure operator objects
 	operatorClientSet clientset.Interface
-	// manifest is empty, but with a valid client and logger. all
-	// manifests are immutable, and any created during reconcile are
-	// expected to be appended to this one, obviating the passing of
-	// client & logger
-	manifest mf.Manifest
+	// readOnlyManifest has the source manifest of Tekton Dashboard for
+	// a particular version with readonly value as true
+	readonlyManifest mf.Manifest
+	// fullaccessManifest has the source manifest of Tekton Dashboard for
+	// a particular version with readonly value as false
+	fullaccessManifest mf.Manifest
 	// Platform-specific behavior to affect the transform
-	extension common.Extension
+	// enqueueAfter enqueues a obj after a duration
+	enqueueAfter func(obj interface{}, after time.Duration)
+	extension    common.Extension
+
+	releaseVersion string
 
 	pipelineInformer pipelineinformer.TektonPipelineInformer
 }
@@ -56,33 +67,44 @@ var _ tektondashboardreconciler.Finalizer = (*Reconciler)(nil)
 
 var watchedResourceName = "dashboard"
 
+const (
+	// TektonInstallerSet keys
+	lastAppliedHashKey = "operator.tekton.dev/last-applied-hash"
+	createdByKey       = "operator.tekton.dev/created-by"
+	createdByValue     = "TektonDashboard"
+	releaseVersionKey  = "operator.tekton.dev/release-version"
+	targetNamespaceKey = "operator.tekton.dev/target-namespace"
+)
+
 // FinalizeKind removes all resources after deletion of a TektonDashboards.
 func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.TektonDashboard) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
-	// List all TektonDashboards to determine if cluster-scoped resources should be deleted.
-	tps, err := r.operatorClientSet.OperatorV1alpha1().TektonDashboards().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to list all TektonDashboards: %w", err)
+	// Delete CRDs before deleting rest of resources so that any instance
+	// of CRDs which has finalizer set will get deleted before we remove
+	// the controller;s deployment for it
+
+	var manifest mf.Manifest
+	if original.Spec.Readonly {
+		manifest = r.readonlyManifest
+	} else {
+		manifest = r.fullaccessManifest
 	}
 
-	for _, tp := range tps.Items {
-		if tp.GetDeletionTimestamp().IsZero() {
-			// Not deleting all TektonDashboards. Nothing to do here.
-			return nil
-		}
+	if err := manifest.Filter(mf.CRDs).Delete(); err != nil {
+		logger.Error("Failed to deleted CRDs for TektonDashboard")
+		return err
+	}
+
+	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", createdByKey, createdByValue),
+		}); err != nil {
+		logger.Error("Failed to delete installer set created by TektonDashboard", err)
+		return err
 	}
 
 	if err := r.extension.Finalize(ctx, original); err != nil {
-		logger.Error("Failed to finalize platform resources", err)
-	}
-	logger.Info("Deleting cluster-scoped resources")
-	manifest, err := r.installed(ctx, original)
-	if err != nil {
-		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
-		return nil
-	}
-	if err := common.Uninstall(ctx, manifest, nil); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}
 	return nil
@@ -90,47 +112,201 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
-func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonDashboard) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, td *v1alpha1.TektonDashboard) pkgreconciler.Event {
+
 	logger := logging.FromContext(ctx)
-	tt.Status.InitializeConditions()
-	tt.Status.ObservedGeneration = tt.Generation
+	td.Status.InitializeConditions()
+	td.Status.ObservedGeneration = td.Generation
 
-	logger.Infow("Reconciling TektonDashboards", "status", tt.Status)
+	logger.Infow("Reconciling TektonDashboards", "status", td.Status)
 
-	if tt.GetName() != watchedResourceName {
+	r.releaseVersion = common.TargetVersion(td)
+
+	if td.GetName() != watchedResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			watchedResourceName,
-			tt.GetName(),
+			td.GetName(),
 		)
 		logger.Error(msg)
-		tt.GetStatus().MarkInstallFailed(msg)
+		td.GetStatus().MarkInstallFailed(msg)
 		return nil
 	}
 
 	// find the valid tekton-pipeline installation
 	if _, err := common.PipelineReady(r.pipelineInformer); err != nil {
 		if err.Error() == common.PipelineNotReady {
-			tt.Status.MarkDependencyInstalling("tekton-pipelines is still installing")
+			td.Status.MarkDependencyInstalling("tekton-pipelines is still installing")
 			// wait for pipeline status to change
 			return fmt.Errorf(common.PipelineNotReady)
 		}
 		// (tektonpipeline.opeator.tekton.dev instance not available yet)
-		tt.Status.MarkDependencyMissing("tekton-pipelines does not exist")
+		td.Status.MarkDependencyMissing("tekton-pipelines does not exist")
 		return err
 	}
-	tt.Status.MarkDependenciesInstalled()
+	td.Status.MarkDependenciesInstalled()
 
-	if err := r.extension.PreReconcile(ctx, tt); err != nil {
+	if err := r.extension.PreReconcile(ctx, td); err != nil {
+		td.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
 		return err
 	}
-	stages := common.Stages{
-		common.AppendTarget,
-		r.transform,
-		common.Install,
-		common.CheckDeployments,
+
+	// Mark PreReconcile Complete
+	td.Status.MarkPreReconcilerComplete()
+
+	// Check if an tekton installer set already exists, if not then create
+	existingInstallerSet := td.Status.GetTektonInstallerSet()
+	if existingInstallerSet == "" {
+		td.Status.MarkInstallerSetNotAvailable("Dashboard Installer Set Not Available")
+
+		createdIs, err := r.createInstallerSet(ctx, td)
+		if err != nil {
+			return err
+		}
+
+		return r.updateTektonDashboardStatus(ctx, td, createdIs)
 	}
-	manifest := r.manifest.Append()
-	return stages.Execute(ctx, &manifest, tt)
+
+	// If exists, then fetch the TektonInstallerSet
+	installedTIS, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		Get(ctx, existingInstallerSet, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			createdIs, err := r.createInstallerSet(ctx, td)
+			if err != nil {
+				return err
+			}
+			return r.updateTektonDashboardStatus(ctx, td, createdIs)
+		}
+		logger.Error("failed to get InstallerSet: %s", err)
+		return err
+	}
+
+	installerSetTargetNamespace := installedTIS.Annotations[targetNamespaceKey]
+	installerSetReleaseVersion := installedTIS.Annotations[releaseVersionKey]
+
+	// Check if TargetNamespace of existing TektonInstallerSet is same as expected
+	// Check if Release Version in TektonInstallerSet is same as expected
+	// If any of the thing above is not same then delete the existing TektonInstallerSet
+	// and create a new with expected properties
+
+	if installerSetTargetNamespace != td.Spec.TargetNamespace || installerSetReleaseVersion != r.releaseVersion {
+		// Delete the existing TektonInstallerSet
+		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+			Delete(ctx, existingInstallerSet, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error("failed to delete InstallerSet: %s", err)
+			return err
+		}
+
+		// Make sure the TektonInstallerSet is deleted
+		_, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+			Get(ctx, existingInstallerSet, metav1.GetOptions{})
+		if err == nil {
+			td.Status.MarkNotReady("Waiting for previous installer set to get deleted")
+			r.enqueueAfter(td, 10*time.Second)
+			return nil
+		}
+		if !apierrors.IsNotFound(err) {
+			logger.Error("failed to get InstallerSet: %s", err)
+			return err
+		}
+		return nil
+
+	} else {
+		// If target namespace and version are not changed then check if spec
+		// of TektonDashboard is changed by checking hash stored as annotation on
+		// TektonInstallerSet with computing new hash of TektonDashboard Spec
+
+		// Hash of TektonDashboard Spec
+
+		expectedSpecHash, err := hash.Compute(td.Spec)
+		if err != nil {
+			return err
+		}
+
+		// spec hash stored on installerSet
+		lastAppliedHash := installedTIS.GetAnnotations()[lastAppliedHashKey]
+
+		if lastAppliedHash != expectedSpecHash {
+
+			var manifest mf.Manifest
+			if td.Spec.Readonly {
+				manifest = r.readonlyManifest
+			} else {
+				manifest = r.fullaccessManifest
+			}
+
+			if err := r.transform(ctx, &manifest, td); err != nil {
+				logger.Error("manifest transformation failed:  ", err)
+				return err
+			}
+
+			// Update the spec hash
+			current := installedTIS.GetAnnotations()
+			current[lastAppliedHashKey] = expectedSpecHash
+			installedTIS.SetAnnotations(current)
+
+			// Update the manifests
+			installedTIS.Spec.Manifests = manifest.Resources()
+
+			if _, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+				Update(ctx, installedTIS, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+
+			// after updating installer set enqueue after a duration
+			// to allow changes to get deployed
+			r.enqueueAfter(td, 20*time.Second)
+			return nil
+		}
+	}
+
+	// Mark InstallerSetAvailable
+	td.Status.MarkInstallerSetAvailable()
+
+	ready := installedTIS.Status.GetCondition(apis.ConditionReady)
+	if ready == nil {
+		td.Status.MarkInstallerSetNotReady("Waiting for installation")
+		r.enqueueAfter(td, 10*time.Second)
+		return nil
+	}
+
+	if ready.Status == corev1.ConditionUnknown {
+		td.Status.MarkInstallerSetNotReady("Waiting for installation")
+		r.enqueueAfter(td, 10*time.Second)
+		return nil
+	} else if ready.Status == corev1.ConditionFalse {
+		td.Status.MarkInstallerSetNotReady(ready.Message)
+		r.enqueueAfter(td, 10*time.Second)
+		return nil
+	}
+
+	// Mark InstallerSet Ready
+	td.Status.MarkInstallerSetReady()
+
+	if err := r.extension.PostReconcile(ctx, td); err != nil {
+		td.Status.MarkPostReconcilerFailed(fmt.Sprintf("PostReconciliation failed: %s", err.Error()))
+		return err
+	}
+
+	td.Status.MarkPostReconcilerComplete()
+	return nil
+}
+
+func (r *Reconciler) updateTektonDashboardStatus(ctx context.Context, td *v1alpha1.TektonDashboard, createdIs *v1alpha1.TektonInstallerSet) error {
+	// update the td with TektonInstallerSet and releaseVersion
+	td.Status.SetTektonInstallerSet(createdIs.Name)
+	td.Status.SetVersion(r.releaseVersion)
+
+	// Update the status with TektonInstallerSet so that any new thread
+	// reconciling with know that TektonInstallerSet is created otherwise
+	// there will be 2 instance created if we don't update status here
+	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonDashboards().
+		UpdateStatus(ctx, td, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return v1alpha1.RECONCILE_AGAIN_ERR
 }
 
 // transform mutates the passed manifest to one with common, component
@@ -145,11 +321,46 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	return common.Transform(ctx, manifest, instance, extra...)
 }
 
-func (r *Reconciler) installed(ctx context.Context, instance v1alpha1.TektonComponent) (*mf.Manifest, error) {
-	// Create new, empty manifest with valid client and logger
-	installed := r.manifest.Append()
-	// TODO: add ingress, etc
-	stages := common.Stages{common.AppendInstalled, r.transform}
-	err := stages.Execute(ctx, &installed, instance)
-	return &installed, err
+func (r *Reconciler) createInstallerSet(ctx context.Context, td *v1alpha1.TektonDashboard) (*v1alpha1.TektonInstallerSet, error) {
+
+	var manifest mf.Manifest
+	if td.Spec.Readonly {
+		manifest = r.readonlyManifest
+	} else {
+		manifest = r.fullaccessManifest
+	}
+
+	if err := r.transform(ctx, &manifest, td); err != nil {
+		td.Status.MarkNotReady("transformation failed: " + err.Error())
+		return nil, err
+	}
+
+	// create installer set
+	tis := makeInstallerSet(td, manifest, r.releaseVersion)
+	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		Create(ctx, tis, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return createdIs, nil
+}
+
+func makeInstallerSet(td *v1alpha1.TektonDashboard, manifest mf.Manifest, releaseVersion string) *v1alpha1.TektonInstallerSet {
+	ownerRef := *metav1.NewControllerRef(td, td.GetGroupVersionKind())
+	return &v1alpha1.TektonInstallerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", v1alpha1.DashboardResourceName),
+			Labels: map[string]string{
+				createdByKey: createdByValue,
+			},
+			Annotations: map[string]string{
+				releaseVersionKey:  releaseVersion,
+				targetNamespaceKey: td.Spec.TargetNamespace,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.TektonInstallerSetSpec{
+			Manifests: manifest.Resources(),
+		},
+	}
 }

--- a/pkg/reconciler/kubernetes/tektoninstallerset/query.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query.go
@@ -22,6 +22,8 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, labelSelector string) (string, error) {
@@ -50,4 +52,41 @@ func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, la
 		return "", err
 	}
 	return "", v1alpha1.RECONCILE_AGAIN_ERR
+}
+
+// CleanUpObsoleteResources cleans up obsolete resources
+// this is required because after TektonInstallerSet were introduced
+// it was observed that during upgrade multiple installerSets were
+// getting created
+// now that we have label based query and we have new labels
+// this cleanup is just to make sure we delete all older installerSets
+// from the cluster
+func CleanUpObsoleteResources(ctx context.Context, client clientset.Interface, createdBy string) error {
+
+	labelSelector := labels.NewSelector()
+	createdReq, _ := labels.NewRequirement(CreatedByKey, selection.Equals, []string{createdBy})
+	if createdReq != nil {
+		labelSelector = labelSelector.Add(*createdReq)
+	}
+
+	list, err := client.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		return err
+	}
+
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	for _, i := range list.Items {
+		// check if installerSet has InstallerSetType label
+		// if it doesn't exist then delete it
+		if _, ok := i.Labels[InstallerSetType]; !ok {
+			err := client.OperatorV1alpha1().TektonInstallerSets().Delete(ctx, i.Name, v1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/reconciler/kubernetes/tektoninstallerset/query.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektoninstallerset
+
+import (
+	"context"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CurrentInstallerSetName(ctx context.Context, client clientset.Interface, labelSelector string) (string, error) {
+	iSets, err := client.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(iSets.Items) == 0 {
+		return "", nil
+	}
+	if len(iSets.Items) == 1 {
+		iSetName := iSets.Items[0].GetName()
+		return iSetName, nil
+	}
+
+	// len(iSets.Items) > 1
+	// delete all installerSets as it cannot be decided which one is the desired one
+	err = client.OperatorV1alpha1().TektonInstallerSets().DeleteCollection(ctx,
+		v1.DeleteOptions{},
+		v1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+	if err != nil {
+		return "", err
+	}
+	return "", v1alpha1.RECONCILE_AGAIN_ERR
+}

--- a/pkg/reconciler/kubernetes/tektoninstallerset/query_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/query_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektoninstallerset
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCurrentInstallerSetName(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonPipeline",
+		InstallerSetType, "pipeline",
+	)
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "pipeline")
+}
+
+func TestCurrentInstallerSetNameNoMatching(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonTriggers",
+		InstallerSetType, "triggers",
+	)
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "")
+}
+
+func TestCurrentInstallerSetNameWithDuplicates(t *testing.T) {
+
+	iSets := v1alpha1.TektonInstallerSetList{
+		Items: []v1alpha1.TektonInstallerSet{
+			v1alpha1.TektonInstallerSet{},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline-1",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+			v1alpha1.TektonInstallerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipeline-2",
+					Labels: map[string]string{
+						CreatedByKey:     "TektonPipeline",
+						InstallerSetType: "pipeline",
+					},
+				},
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(&iSets)
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		CreatedByKey, "TektonPipeline",
+		InstallerSetType, "pipeline",
+	)
+
+	name, err := CurrentInstallerSetName(context.TODO(), client, labelSelector)
+	assert.Error(t, err, v1alpha1.RECONCILE_AGAIN_ERR.Error())
+	assert.Equal(t, name, "")
+}

--- a/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/transformer.go
@@ -25,7 +25,10 @@ import (
 func injectOwner(owner []v1.OwnerReference) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		kind := u.GetKind()
-		if kind == "CustomResourceDefinition" {
+		if kind == "CustomResourceDefinition" ||
+			kind == "ValidatingWebhookConfiguration" ||
+			kind == "MutatingWebhookConfiguration" ||
+			kind == "Namespace" {
 			return nil
 		}
 		u.SetOwnerReferences(owner)
@@ -33,12 +36,14 @@ func injectOwner(owner []v1.OwnerReference) mf.Transformer {
 	}
 }
 
-func injectOwnerForCRDs(owner []v1.OwnerReference) mf.Transformer {
+func injectOwnerForCRDsAndNamespace(owner []v1.OwnerReference) mf.Transformer {
 	if len(owner) == 0 {
 		return func(u *unstructured.Unstructured) error { return nil }
 	}
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "CustomResourceDefinition" {
+		kind := u.GetKind()
+		if kind != "CustomResourceDefinition" &&
+			kind != "Namespace" {
 			return nil
 		}
 		u.SetOwnerReferences(owner)

--- a/pkg/reconciler/kubernetes/tektoninstallerset/transformers_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/transformers_test.go
@@ -39,7 +39,7 @@ func TestInjectOwner_CRDs(t *testing.T) {
 		BlockOwnerDeletion: ptr.Bool(true),
 	}}
 
-	manifest, err := sourceManifest.Transform(injectOwnerForCRDs(owners))
+	manifest, err := sourceManifest.Transform(injectOwnerForCRDsAndNamespace(owners))
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}
@@ -75,7 +75,7 @@ func TestInjectOwner_NonCRDs(t *testing.T) {
 	}}
 
 	// Must not add owner as resource is non-crd
-	manifest, err := sourceManifest.Transform(injectOwnerForCRDs(owners))
+	manifest, err := sourceManifest.Transform(injectOwnerForCRDsAndNamespace(owners))
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -52,11 +52,16 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, pipelineVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
 			logger.Errorf("Failed to create pipeline metrics recorder %v", err)
+		}
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
 		}
 
 		c := &Reconciler{
@@ -64,7 +69,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			operatorClientSet: operatorclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
-			releaseVersion:    releaseVersion,
+			operatorVersion:   operatorVer,
+			pipelineVersion:   pipelineVer,
 			metrics:           metrics,
 		}
 		impl := tektonPipelineReconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
 	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -59,6 +60,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		}
 
 		c := &Reconciler{
+			kubeClientSet:     kubeclient.Get(ctx),
 			operatorClientSet: operatorclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,

--- a/pkg/reconciler/kubernetes/tektonpipeline/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/controller.go
@@ -51,7 +51,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx)
+		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -257,8 +257,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 		return nil
 	} else if ready.Status == corev1.ConditionFalse {
 		tp.Status.MarkInstallerSetNotReady(ready.Message)
+		manifest := r.manifest
+		if err := r.transform(ctx, &manifest, tp); err != nil {
+			logger.Error("manifest transformation failed:  ", err)
+			return err
+		}
+		err = common.PreemptDeadlock(ctx, &manifest, r.kubeClientSet, v1alpha1.PipelineResourceName)
 		r.enqueueAfter(tp, 10*time.Second)
-		return nil
+		return err
 	}
 
 	// Mark InstallerSet Ready

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -61,11 +61,11 @@ type Reconciler struct {
 	extension common.Extension
 	// enqueueAfter enqueues a obj after a duration
 	enqueueAfter func(obj interface{}, after time.Duration)
-	// releaseVersion describes the current pipelines version
-	releaseVersion string
 	// metrics handles metrics for pipeline install
-	metrics       *Recorder
-	kubeClientSet kubernetes.Interface
+	metrics         *Recorder
+	kubeClientSet   kubernetes.Interface
+	operatorVersion string
+	pipelineVersion string
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -147,7 +147,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 			return err
 		}
 		// If there was no existing installer set, that means its a new install
-		r.metrics.logMetrics(metricsNew, r.releaseVersion, logger)
+		r.metrics.logMetrics(metricsNew, r.pipelineVersion, logger)
 
 		return r.updateTektonPipelineStatus(ctx, tp, createdIs)
 	}
@@ -162,8 +162,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 				return err
 			}
 			// if there is version diff then its a call for upgrade
-			if tp.Status.Version != r.releaseVersion {
-				r.metrics.logMetrics(metricsUpgrade, r.releaseVersion, logger)
+			if tp.Status.Version != r.pipelineVersion {
+				r.metrics.logMetrics(metricsUpgrade, r.pipelineVersion, logger)
 			}
 			return r.updateTektonPipelineStatus(ctx, tp, createdIs)
 		}
@@ -172,14 +172,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	}
 
 	installerSetTargetNamespace := installedTIS.Annotations[tektoninstallerset.TargetNamespaceKey]
-	installerSetReleaseVersion := installedTIS.Annotations[tektoninstallerset.ReleaseVersionKey]
+	installerSetReleaseVersion := installedTIS.Labels[tektoninstallerset.ReleaseVersionKey]
 
 	// Check if TargetNamespace of existing TektonInstallerSet is same as expected
 	// Check if Release Version in TektonInstallerSet is same as expected
 	// If any of the thing above is not same then delete the existing TektonInstallerSet
 	// and create a new with expected properties
 
-	if installerSetTargetNamespace != tp.Spec.TargetNamespace || installerSetReleaseVersion != r.releaseVersion {
+	if installerSetTargetNamespace != tp.Spec.TargetNamespace || installerSetReleaseVersion != r.operatorVersion {
 		// Delete the existing TektonInstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Delete(ctx, existingInstallerSet, metav1.DeleteOptions{})
@@ -291,7 +291,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 func (r *Reconciler) updateTektonPipelineStatus(ctx context.Context, tp *v1alpha1.TektonPipeline, createdIs *v1alpha1.TektonInstallerSet) error {
 	// update the tp with TektonInstallerSet and releaseVersion
 	tp.Status.SetTektonInstallerSet(createdIs.Name)
-	tp.Status.SetVersion(r.releaseVersion)
+	tp.Status.SetVersion(r.pipelineVersion)
 
 	// Update the status with TektonInstallerSet so that any new thread
 	// reconciling with know that TektonInstallerSet is created otherwise
@@ -339,10 +339,9 @@ func (r *Reconciler) makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.M
 			Labels: map[string]string{
 				tektoninstallerset.CreatedByKey:      createdByValue,
 				tektoninstallerset.InstallerSetType:  v1alpha1.PipelineResourceName,
-				tektoninstallerset.ReleaseVersionKey: r.releaseVersion,
+				tektoninstallerset.ReleaseVersionKey: r.operatorVersion,
 			},
 			Annotations: map[string]string{
-				tektoninstallerset.ReleaseVersionKey:  r.releaseVersion,
 				tektoninstallerset.TargetNamespaceKey: tp.Spec.TargetNamespace,
 				tektoninstallerset.LastAppliedHashKey: tpSpecHash,
 			},

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -33,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -63,7 +64,8 @@ type Reconciler struct {
 	// releaseVersion describes the current pipelines version
 	releaseVersion string
 	// metrics handles metrics for pipeline install
-	metrics *Recorder
+	metrics       *Recorder
+	kubeClientSet kubernetes.Interface
 }
 
 // Check that our Reconciler implements controller.Reconciler

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -125,7 +125,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	tp.Status.MarkPreReconcilerComplete()
 
 	// Check if an tekton installer set already exists, if not then create
-	existingInstallerSet := tp.Status.GetTektonInstallerSet()
+	existingInstallerSet, err := r.currentInstallerSetName(ctx)
+	if err != nil {
+		return err
+	}
 	if existingInstallerSet == "" {
 		createdIs, err := r.createInstallerSet(ctx, tp)
 		if err != nil {
@@ -301,7 +304,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tp *v1alpha1.Tekton
 	}
 
 	// create installer set
-	tis := makeInstallerSet(tp, manifest, specHash, r.releaseVersion)
+	tis := r.makeInstallerSet(tp, manifest, specHash)
 	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, tis, metav1.CreateOptions{})
 	if err != nil {
@@ -310,16 +313,18 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tp *v1alpha1.Tekton
 	return createdIs, nil
 }
 
-func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, tpSpecHash, releaseVersion string) *v1alpha1.TektonInstallerSet {
+func (r *Reconciler) makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, tpSpecHash string) *v1alpha1.TektonInstallerSet {
 	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", common.PipelineResourceName),
 			Labels: map[string]string{
-				tektoninstallerset.CreatedByKey: createdByValue,
+				tektoninstallerset.CreatedByKey:      createdByValue,
+				tektoninstallerset.InstallerSetType:  v1alpha1.PipelineResourceName,
+				tektoninstallerset.ReleaseVersionKey: r.releaseVersion,
 			},
 			Annotations: map[string]string{
-				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
+				tektoninstallerset.ReleaseVersionKey:  r.releaseVersion,
 				tektoninstallerset.TargetNamespaceKey: tp.Spec.TargetNamespace,
 				tektoninstallerset.LastAppliedHashKey: tpSpecHash,
 			},
@@ -357,4 +362,36 @@ func (m *Recorder) logMetrics(status, version string, logger *zap.SugaredLogger)
 	if err != nil {
 		logger.Warnf("Failed to log the metrics : %v", err)
 	}
+}
+
+func (r *Reconciler) currentInstallerSetName(ctx context.Context) (string, error) {
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		tektoninstallerset.CreatedByKey, createdByValue,
+		tektoninstallerset.InstallerSetType, v1alpha1.PipelineResourceName,
+	)
+	iSets, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(iSets.Items) == 0 {
+		return "", nil
+	}
+	if len(iSets.Items) == 1 {
+		iSetName := iSets.Items[0].GetName()
+		return iSetName, nil
+	}
+
+	// len(iSets.Items) > 1
+	// delete all installerSets as it cannot be decided which one is the desired one
+	err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().DeleteCollection(ctx,
+		metav1.DeleteOptions{},
+		v1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+	if err != nil {
+		return "", err
+	}
+	return "", v1alpha1.RECONCILE_AGAIN_ERR
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -118,6 +118,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	// Pass the object through defaulting
 	tp.SetDefaults(ctx)
 
+	if err := tektoninstallerset.CleanUpObsoleteResources(ctx, r.operatorClientSet, createdByValue); err != nil {
+		return err
+	}
+
 	if err := r.extension.PreReconcile(ctx, tp); err != nil {
 		tp.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
 		return err

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/initcontroller"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
@@ -62,6 +63,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		}
 
 		c := &Reconciler{
+			kubeClientSet:     kubeclient.Get(ctx),
 			operatorClientSet: operatorclient.Get(ctx),
 			pipelineInformer:  tektonPipelineinformer.Get(ctx),
 			extension:         generator(ctx),

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -55,11 +55,16 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
+		manifest, triggersVer := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {
 			logger.Errorf("Failed to create trigger metrics recorder %v", err)
+		}
+
+		operatorVer, err := initcontroller.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
 		}
 
 		c := &Reconciler{
@@ -68,7 +73,8 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:  tektonPipelineinformer.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
-			releaseVersion:    releaseVersion,
+			operatorVersion:   operatorVer,
+			triggersVersion:   triggersVer,
 			metrics:           metrics,
 		}
 		impl := tektonTriggerreconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/kubernetes/tektontrigger/controller.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/controller.go
@@ -54,7 +54,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			VersionConfigMap: versionConfigMap,
 		}
 
-		manifest, releaseVersion := ctrl.InitController(ctx)
+		manifest, releaseVersion := ctrl.InitController(ctx, initcontroller.PayloadOptions{})
 
 		metrics, err := NewRecorder()
 		if err != nil {

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -133,6 +133,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	// Pass the object through defaulting
 	tt.SetDefaults(ctx)
 
+	if err := tektoninstallerset.CleanUpObsoleteResources(ctx, r.operatorClientSet, createdByValue); err != nil {
+		return err
+	}
+
 	if err := r.extension.PreReconcile(ctx, tt); err != nil {
 		tt.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
 		return err

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -65,6 +66,7 @@ type Reconciler struct {
 	releaseVersion string
 	// enqueueAfter enqueues a obj after a duration
 	enqueueAfter func(obj interface{}, after time.Duration)
+	kubeClientSet   kubernetes.Interface
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -279,8 +281,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 		return nil
 	} else if ready.Status == corev1.ConditionFalse {
 		tt.Status.MarkInstallerSetNotReady(ready.Message)
+		manifest := r.manifest
+		if err := r.transform(ctx, &manifest, tt); err != nil {
+			logger.Error("manifest transformation failed:  ", err)
+			return err
+		}
+		err = common.PreemptDeadlock(ctx, &manifest, r.kubeClientSet, v1alpha1.TriggerResourceName)
 		r.enqueueAfter(tt, 10*time.Second)
-		return nil
+		return err
 	}
 
 	// Mark InstallerSet Ready

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -85,7 +85,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", tektoninstallerset.CreatedByKey, createdByValue),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+				tektoninstallerset.CreatedByKey, createdByValue,
+				tektoninstallerset.InstallerSetType, v1alpha1.TriggerResourceName),
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonTrigger", err)
 		return err
@@ -140,7 +142,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	tt.Status.MarkPreReconcilerComplete()
 
 	// Check if an tekton installer set already exists, if not then create
-	existingInstallerSet := tt.Status.GetTektonInstallerSet()
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
+		tektoninstallerset.CreatedByKey, createdByValue,
+		tektoninstallerset.InstallerSetType, v1alpha1.TriggerResourceName,
+	)
+	existingInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, labelSelector)
+	if err != nil {
+		return err
+	}
 	if existingInstallerSet == "" {
 		createdIs, err := r.createInstallerSet(ctx, tt)
 		if err != nil {
@@ -173,7 +182,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigg
 	}
 
 	installerSetTargetNamespace := installedTIS.Annotations[tektoninstallerset.TargetNamespaceKey]
-	installerSetReleaseVersion := installedTIS.Annotations[tektoninstallerset.ReleaseVersionKey]
+	installerSetReleaseVersion := installedTIS.Labels[tektoninstallerset.ReleaseVersionKey]
 
 	// Check if TargetNamespace of existing TektonInstallerSet is same as expected
 	// Check if Release Version in TektonInstallerSet is same as expected
@@ -357,10 +366,11 @@ func makeInstallerSet(tt *v1alpha1.TektonTrigger, manifest mf.Manifest, ttSpecHa
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", common.TriggerResourceName),
 			Labels: map[string]string{
-				tektoninstallerset.CreatedByKey: createdByValue,
+				tektoninstallerset.CreatedByKey:      createdByValue,
+				tektoninstallerset.ReleaseVersionKey: releaseVersion,
+				tektoninstallerset.InstallerSetType:  v1alpha1.TriggerResourceName,
 			},
 			Annotations: map[string]string{
-				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
 				tektoninstallerset.TargetNamespaceKey: tt.Spec.TargetNamespace,
 				tektoninstallerset.LastAppliedHashKey: ttSpecHash,
 			},

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -148,6 +148,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	// Pass the object through defaulting
 	ta.SetDefaults(ctx)
 
+	if err := tektoninstallerset.CleanUpObsoleteResources(ctx, r.operatorClientSet, CreatedByValue); err != nil {
+		return err
+	}
+
 	// validate the params
 	ptVal, _ := findValue(ta.Spec.Params, v1alpha1.PipelineTemplatesParam)
 	ctVal, _ := findValue(ta.Spec.Params, v1alpha1.ClusterTasksParam)

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -57,7 +57,7 @@ var (
 		tektoninstallerset.CreatedByKey, createdByValue,
 	)
 	postReconcileSelector = fmt.Sprintf("%s=%s,%s=%s",
-		tektoninstallerset.InstallerSetType, prePipelineInstallerSet,
+		tektoninstallerset.InstallerSetType, postPipelineInstallerSet,
 		tektoninstallerset.CreatedByKey, createdByValue,
 	)
 )
@@ -192,12 +192,12 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 }
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	pipeline := comp.(*v1alpha1.TektonPipeline)
-	err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline, postPipelineInstallerSet, postReconcileSelector)
-	if err != nil {
+	if err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline,
+		postPipelineInstallerSet, postReconcileSelector); err != nil {
 		return err
 	}
-	err = deleteInstallerSet(ctx, oe.operatorClientSet, pipeline, postPipelineInstallerSet, postReconcileSelector)
-	if err != nil {
+	if err := deleteInstallerSet(ctx, oe.operatorClientSet, pipeline,
+		prePipelineInstallerSet, preReconcileSelector); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stdError "errors"
 	"fmt"
+	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -37,58 +38,72 @@ const (
 // and if installer set which already exist is of older version/ or if target namespace is different then it
 // deletes and return false to create a new installer set
 func checkIfInstallerSetExist(ctx context.Context, oc clientset.Interface, relVersion string,
-	tp *v1alpha1.TektonPipeline, component string) (bool, error) {
+	tp *v1alpha1.TektonPipeline, ls string) (bool, error) {
 
 	// Check if installer set is already created
-	compInstallerSet, ok := tp.Status.ExtentionInstallerSets[component]
-	if !ok {
+	installerSets, err := oc.OperatorV1alpha1().TektonInstallerSets().
+		List(ctx, metav1.ListOptions{
+			LabelSelector: ls,
+		})
+	if err != nil {
+		return false, err
+	}
+	if len(installerSets.Items) == 0 {
+		// only scenario where this function returns
+		// false, nil
 		return false, nil
 	}
 
-	if compInstallerSet != "" {
-		// if already created then check which version it is
-		ctIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
-			Get(ctx, compInstallerSet, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-
-		// Check release version and target namespace
-		// If anyone of this is not as expected then delete existing
-		// installer set and create a new one
-
-		version, vOk := ctIs.Annotations[tektoninstallerset.ReleaseVersionKey]
-		namespace, nOk := ctIs.Annotations[tektoninstallerset.TargetNamespaceKey]
-
-		if vOk && nOk {
-			if version == relVersion && namespace == tp.Spec.TargetNamespace {
-				// if installer set already exist
-				// release version and target namespace is as expected
-				// then ignore and move on
-				return true, nil
-			}
-		}
-
-		// release version/ target namespace doesn't exist or is different from expected
-		// deleted existing InstallerSet and create a new one
-
+	// if the List query returns more than 1 InstallerSets,
+	// then delete all of them as we are expecting only one
+	// If there are more than one then it means the state is
+	// corrupted/unexpected. So to get back to desired state
+	// delete all installerSets that match the labelSelector
+	if len(installerSets.Items) > 1 {
 		err = oc.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, compInstallerSet, metav1.DeleteOptions{})
+			DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: ls,
+			})
+
 		if err != nil {
 			return false, err
+		}
+		return false, v1alpha1.RECONCILE_AGAIN_ERR
+	}
+
+	// if the InstallerSet already exists then check then validate it:
+	// Check release version and target namespace
+	// If anyone of this is not as expected then delete existing
+	// InstallerSet and return false
+
+	version, vOk := installerSets.Items[0].Labels[tektoninstallerset.ReleaseVersionKey]
+	namespace, nOk := installerSets.Items[0].Annotations[tektoninstallerset.TargetNamespaceKey]
+
+	if vOk && nOk {
+		if version == relVersion && namespace == tp.Spec.TargetNamespace {
+			// only scenarion where this function returns
+			// true
+			return true, nil
 		}
 	}
 
-	return false, nil
+	// release version/ target namespace information doesn't exist in InstallerSet
+	// or is different from expected
+	// deleted existing InstallerSet and return false
+
+	err = oc.OperatorV1alpha1().TektonInstallerSets().
+		Delete(ctx, installerSets.Items[0].GetName(), metav1.DeleteOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return false, v1alpha1.RECONCILE_AGAIN_ERR
 }
 
 func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha1.TektonPipeline,
-	manifest mf.Manifest, releaseVersion, component, installerSetPrefix string) error {
+	manifest mf.Manifest, releaseVersion, component string) error {
 
-	is := makeInstallerSet(tp, manifest, installerSetPrefix, releaseVersion)
+	is := makeInstallerSet(tp, manifest, component, releaseVersion)
 
 	createdIs, err := oc.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, is, metav1.CreateOptions{})
@@ -112,13 +127,15 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha
 	return stdError.New("ensuring TektonPipeline status update")
 }
 
-func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix, releaseVersion string) *v1alpha1.TektonInstallerSet {
+func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, installerSetType, releaseVersion string) *v1alpha1.TektonInstallerSet {
 	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", prefix),
+			GenerateName: fmt.Sprintf("%s-", strings.ToLower(installerSetType)),
 			Labels: map[string]string{
-				tektoninstallerset.CreatedByKey: createdByValue,
+				tektoninstallerset.CreatedByKey:      createdByValue,
+				tektoninstallerset.ReleaseVersionKey: releaseVersion,
+				tektoninstallerset.InstallerSetType:  installerSetType,
 			},
 			Annotations: map[string]string{
 				tektoninstallerset.ReleaseVersionKey:  releaseVersion,
@@ -132,27 +149,23 @@ func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, prefix,
 	}
 }
 
-func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha1.TektonPipeline, component string) error {
+func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha1.TektonPipeline, component, labelSelector string) error {
 
-	compInstallerSet, ok := ta.Status.ExtentionInstallerSets[component]
-	if !ok {
-		return nil
+	// delete the installer set
+	err := oc.OperatorV1alpha1().TektonInstallerSets().
+		DeleteCollection(ctx, metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+	if err != nil {
+		return err
 	}
 
-	if compInstallerSet != "" {
-		// delete the installer set
-		err := oc.OperatorV1alpha1().TektonInstallerSets().
-			Delete(ctx, ta.Status.ExtentionInstallerSets[component], metav1.DeleteOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
-		// clear the name of installer set from TektonPipeline status
-		delete(ta.Status.ExtentionInstallerSets, component)
-		_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	// clear the name of installer set from TektonPipeline status
+	delete(ta.Status.ExtentionInstallerSets, component)
+	_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
 	}
 
 	return nil

--- a/pkg/reconciler/shared/hash/hash.go
+++ b/pkg/reconciler/shared/hash/hash.go
@@ -1,0 +1,19 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+)
+
+// ComputeHashOf generates an unique hash/string for the
+// object pass to it.
+func Compute(obj interface{}) (string, error) {
+	h := sha256.New()
+	d, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+	h.Write(d)
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/pkg/reconciler/shared/hash/hash_test.go
+++ b/pkg/reconciler/shared/hash/hash_test.go
@@ -1,0 +1,49 @@
+package hash
+
+import (
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"testing"
+)
+
+func TestCompute(t *testing.T) {
+	tp := &v1alpha1.TektonPipeline{
+		Spec: v1alpha1.TektonPipelineSpec{
+			CommonSpec: v1alpha1.CommonSpec{TargetNamespace: "tekton"},
+			Config: v1alpha1.Config{
+				NodeSelector: map[string]string{
+					"abc": "xyz",
+				},
+			},
+		},
+	}
+
+	hash, err := Compute(tp.Spec)
+	if err != nil {
+		t.Fatal("unexpected error while computing hash of obj")
+	}
+
+	// Again, calculate the hash without changing object
+
+	hash2, err := Compute(tp.Spec)
+	if err != nil {
+		t.Fatal("unexpected error while computing hash of obj")
+	}
+
+	if hash != hash2 {
+		t.Fatal("hash changed without changing the object")
+	}
+
+	// Now, change the object
+
+	tp.Spec.TargetNamespace = "changed"
+
+	hash3, err := Compute(tp.Spec)
+	if err != nil {
+		t.Fatal("unexpected error while computing hash of obj")
+	}
+
+	// Hash should be changed now
+	if hash == hash3 {
+		t.Fatal("hash not changed after changing the object")
+	}
+}

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -50,20 +50,20 @@ var _ tektonConfigreconciler.Finalizer = (*Reconciler)(nil)
 func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.TektonConfig) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
+	if err := r.extension.Finalize(ctx, original); err != nil {
+		logger.Error("Failed to finalize platform resources", err)
+	}
+
 	if original.Spec.Profile == v1alpha1.ProfileLite {
 		return pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName)
 	} else {
 		// TektonPipeline and TektonTrigger is common for profile type basic and all
-		if err := pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), common.PipelineResourceName); err != nil {
-			return err
-		}
 		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName); err != nil {
 			return err
 		}
-	}
-
-	if err := r.extension.Finalize(ctx, original); err != nil {
-		logger.Error("Failed to finalize platform resources", err)
+		if err := pipeline.TektonPipelineCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -61,7 +61,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 		if err := trigger.TektonTriggerCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), common.TriggerResourceName); err != nil {
 			return err
 		}
-		if err := pipeline.TektonPipelineCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName); err != nil {
+		if err := pipeline.TektonPipelineCRDelete(r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
# Changes

### Cherry-picked commints

#### Multiple installerSet getting created for pipelines
- [x]  [Fix duplicate InstallerSets in Pipeline Reconciler
](https://github.com/tektoncd/operator/commit/d8d9b7b156f3b5c190df5f7efcfae8f5c75f06ad)
- [x]  [Add label based InstallerSet querying in triggers
](https://github.com/tektoncd/operator/commit/ffda58a047980aa2fae8fab7201d34eed608d615)

#### Fixes Webhook service missing and tekton resources create/delete/update failing
- [x]  [Fix upgrade deadlock in Pipeline and Triggers
](https://github.com/tektoncd/operator/commit/b0c67638ab0f5612caab5633977d09b2a740df27)

#### Operator should compare operator version not component version to trigger deployment recreation
- [x]  [Use Operator version not Component version
](https://github.com/tektoncd/operator/commit/c676a1982cb75bbf2716279ad3d27f242354743d)

#### other relevant fixes
- [x]  [Skips Namespace deletion on installlerSet deletion
](https://github.com/tektoncd/operator/commit/17f208754d4a9f0ea4958a8aa9e9d03ab5a99362)
- [x]  [Removes obsolete installersets created during upgrades
](https://github.com/tektoncd/operator/commit/236f666df95c421024e2fdf5a89c5c88613bc924)
- [x]  [[OpenShift] removes obsolete installerSets created during Upgrade
](https://github.com/tektoncd/operator/commit/41c7f080922ffb7433eb6304c12baf07ad0b4d79)
- [x]  [[OpenShift] fixes post pipelines installerSet creation
](https://github.com/tektoncd/operator/commit/959795423e9fd19d6d13c66514d3926fe7bfb882)

#### picked for dependencies 
- [x] [Refactor tekton pipeline and tekton trigger controller
](https://github.com/tektoncd/operator/commit/9967839593f9fa83fe640ea081227ba30c673898)
- [x]  [Refactor dashboard by using Tekton Installer set
](https://github.com/tektoncd/operator/commit/a930f31fdc64c45ebac7b6a72f7aee0cc777f404)
- [x]  [Fetches the manifest for Tekton Dashboard through init Controller
](https://github.com/tektoncd/operator/commit/e37aa26ed3db9b58dd3f1777ff8ae775cfe604d8)



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
