### PR TITLE
[OpenShift] Fix e2e test failure

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -300,13 +300,14 @@ func (r *Reconciler) checkComponentStatus(ctx context.Context, labelSelector str
 		return err
 	}
 
-	ready := installerSets.Items[0].Status.GetCondition(apis.ConditionReady)
-	if ready == nil || ready.Status == corev1.ConditionUnknown {
-		return fmt.Errorf("InstallerSet %s: waiting for installation", installerSets.Items[0].Name)
-	} else if ready.Status == corev1.ConditionFalse {
-		return fmt.Errorf("InstallerSet %s: ", ready.Message)
+	if len(installerSets.Items) > 0 {
+		ready := installerSets.Items[0].Status.GetCondition(apis.ConditionReady)
+		if ready == nil || ready.Status == corev1.ConditionUnknown {
+			return fmt.Errorf("InstallerSet %s: waiting for installation", installerSets.Items[0].Name)
+		} else if ready.Status == corev1.ConditionFalse {
+			return fmt.Errorf("InstallerSet %s: ", ready.Message)
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Changes
This fixes failure of e2e tests on Openshift platform

**Reason:** When we update tektonconfig for addons param then operator pod was crashing because we were accessing installerSets without checking len.

verified by running e2e locally
https://gist.github.com/savitaashture/45073a116b6420b7f4dae2f0d4dde6c4
  
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```