### PR TITLE
[OpenShift] Fix e2e tests

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -300,7 +300,8 @@ func (r *Reconciler) checkComponentStatus(ctx context.Context, labelSelector str
 		return err
 	}
 
-	if len(installerSets.Items) > 0 {
+	// To make sure there won't be duplicate installersets.
+	if len(installerSets.Items) == 1 {
 		ready := installerSets.Items[0].Status.GetCondition(apis.ConditionReady)
 		if ready == nil || ready.Status == corev1.ConditionUnknown {
 			return fmt.Errorf("InstallerSet %s: waiting for installation", installerSets.Items[0].Name)

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -304,8 +304,8 @@ func runAddonTest(t *testing.T, clients *utils.Clients, tc *v1alpha1.TektonConfi
 		}
 
 		// there must be 5 installerSet created for addons
-		if len(addonsIS.Items) != 5 {
-			t.Fatalf("expected 5 installerSets for Addon but got %v", len(addonsIS.Items))
+		if len(addonsIS.Items) != 6 {
+			t.Fatalf("expected 6 installerSets for Addon but got %v", len(addonsIS.Items))
 		}
 
 		// Now, disable clusterTasks and pipelineTemplates through TektonConfig

--- a/test/e2e/openshift/tektonaddondeployment_test.go
+++ b/test/e2e/openshift/tektonaddondeployment_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package openshift
 
 import (
-	"fmt"
 	"os"
 	"testing"
 


### PR DESCRIPTION
# Changes
1. Updated check verification for number of installersets because new installerset `VersionedClusterTask` added as part of this PR https://github.com/tektoncd/operator/pull/599
2. Instead of checking `>0` updated check to `==1` to make sure there won't be duplication.
3. Removed unused `fmt`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```