### PR TITLE
[cherry-pick] Fix TektonPipeline Ready check

### DIFF
--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	informer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -58,11 +57,8 @@ func PipelineReady(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPi
 		}
 		return nil, err
 	}
-
-	if len(ppln.Status.Conditions) != 0 {
-		if ppln.Status.Conditions[0].Status != corev1.ConditionTrue {
-			return nil, fmt.Errorf(PipelineNotReady)
-		}
+	if !ppln.Status.IsReady() {
+		return nil, fmt.Errorf(PipelineNotReady)
 	}
 	return ppln, nil
 }
@@ -80,11 +76,8 @@ func TriggerReady(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrig
 		}
 		return nil, err
 	}
-
-	if len(trigger.Status.Conditions) != 0 {
-		if trigger.Status.Conditions[0].Status != corev1.ConditionTrue {
-			return nil, fmt.Errorf(TriggerNotReady)
-		}
+	if !trigger.Status.IsReady() {
+		return nil, fmt.Errorf(TriggerNotReady)
 	}
 	return trigger, nil
 }


### PR DESCRIPTION
Cherry pick of https://github.com/tektoncd/operator/pull/607

Currently, the availability (creation) of an TektonInstallerSet for
TektonPipeline is considered to be the Ready condition for
TektonPipeline. This is because the 'ready check' checks the condition
item [0] and that item correspond to 'InstallerSet' available. The
correct check should depend on condition `Ready` which is set to True
when all other conditions are True.

This patch ensures that the TektonPipeline Ready check checks the true
'Ready' condition.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>