### PR TITLE
Fix flaky test behavior

### DIFF
--- a/pkg/reconciler/common/labels_test.go
+++ b/pkg/reconciler/common/labels_test.go
@@ -35,11 +35,10 @@ func TestLabelSelector(t *testing.T) {
 		name: "non empty label selector",
 		ls: metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"createdByKey":     "createdByValue",
 				"installerSetType": "pipelineResourceName",
 			},
 		},
-		want: "createdByKey=createdByValue,installerSetType=pipelineResourceName",
+		want: "installerSetType=pipelineResourceName",
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			got, _ := LabelSelector(c.ls)


### PR DESCRIPTION
# Changes
1. Golang maps are unordered and as part of this test we are checking output so there is 50% of chance for this test failure.
2. The intend of test is to verify string output for the given labelselector so removed second map value.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```