### PR TITLE
Improve TekktonInstallerSet Reconciler

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -71,15 +71,44 @@ type installer struct {
 	Manifest mf.Manifest
 }
 
-func (i *installer) EnsureCRDs() error {
-	if err := i.Manifest.Filter(mf.Any(mf.CRDs)).Apply(); err != nil {
+func ensureResources(mani *mf.Manifest) error {
+	freshCreate := true
+	// check if all resources in a given set of resources exists
+	ok, err := allResourcesExists(mani)
+	if err != nil {
+		if !apierrs.IsNotFound(err) {
+			return err
+		}
+	}
+	// if error == NotFound error or !ok
+	// then Apply all resources
+	// if ok, that means the reosource already exists
+	// but this reconcile could be an modification eg: concig-defaults change
+	// set freshCreate flag to false, and then Apply all
+	// so that we can skip (break) RECONCILE_AGAIN loop path
+	if ok {
+		freshCreate = false
+	}
+
+	if err := mani.Apply(); err != nil {
 		return err
+	}
+	// on err == nil after Apply() return RECONCILE_AGAIN
+	// if freshCreate == true return RECONCILE_AGAIN
+	// this ensures freshly created resources are in place before proceeding to next stages of reconciler
+	if freshCreate {
+		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 	return nil
 }
 
+func (i *installer) EnsureCRDs() error {
+	resourceList := i.Manifest.Filter(mf.Any(mf.CRDs))
+	return ensureResources(&resourceList)
+}
+
 func (i *installer) EnsureClusterScopedResources() error {
-	if err := i.Manifest.Filter(
+	resourceList := i.Manifest.Filter(
 		mf.Any(
 			namespacePred,
 			clusterRolePred,
@@ -92,14 +121,12 @@ func (i *installer) EnsureClusterScopedResources() error {
 			consoleQuickStartPred,
 			ConsoleYAMLSamplePred,
 			securityContextConstraints,
-		)).Apply(); err != nil {
-		return err
-	}
-	return nil
+		))
+	return ensureResources(&resourceList)
 }
 
 func (i *installer) EnsureNamespaceScopedResources() error {
-	if err := i.Manifest.Filter(
+	resourceList := i.Manifest.Filter(
 		mf.Any(
 			serviceAccountPred,
 			clusterRoleBindingPred,
@@ -114,10 +141,10 @@ func (i *installer) EnsureNamespaceScopedResources() error {
 			eventListenerPred,
 			triggerBindingPred,
 			triggerTemplatePred,
-		)).Apply(); err != nil {
-		return err
-	}
-	return nil
+			servicePred,
+			routePred,
+		))
+	return ensureResources(&resourceList)
 }
 
 func (i *installer) EnsureDeploymentResources() error {
@@ -128,13 +155,6 @@ func (i *installer) EnsureDeploymentResources() error {
 		}
 	}
 
-	if err := i.Manifest.Filter(
-		mf.Any(
-			servicePred,
-			routePred,
-		)).Apply(); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -202,7 +222,11 @@ func (i *installer) updateDeployment(existing *unstructured.Unstructured, existi
 	}
 	existing.SetUnstructuredContent(unstrObj)
 
-	return i.Manifest.Client.Update(existing)
+	err = i.Manifest.Client.Update(existing)
+	if err != nil {
+		return v1alpha1.RECONCILE_AGAIN_ERR
+	}
+	return err
 }
 
 func (i *installer) ensureDeployment(expected *unstructured.Unstructured) error {
@@ -213,7 +237,11 @@ func (i *installer) ensureDeployment(expected *unstructured.Unstructured) error 
 
 		// If deployment doesn't exist, then create new
 		if apierrs.IsNotFound(err) {
-			return i.createDeployment(expected)
+			errInner := i.createDeployment(expected)
+			if errInner == nil {
+				return v1alpha1.RECONCILE_AGAIN_ERR
+			}
+			return errInner
 		}
 		return err
 	}
@@ -347,4 +375,26 @@ func isDeploymentAvailable(d *appsv1.Deployment) bool {
 		}
 	}
 	return false
+}
+
+func allResourcesExists(m *mf.Manifest) (bool, error) {
+	c := m.Client
+	for _, item := range m.Resources() {
+		ok, err := resourceExists(c, &item)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func resourceExists(c mf.Client, u *unstructured.Unstructured) (bool, error) {
+	_, err := c.Get(u)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -57,7 +57,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, installerSet *v1alpha1.Te
 	// Delete all resources except CRDs and Namespace as they are own by owner of
 	// TektonInstallerSet
 	// They will be deleted when the component CR is deleted
-	err = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs))).Delete()
+	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs)))
+	err = deleteManifests.Delete(mf.PropagationPolicy(v1.DeletePropagationForeground))
 	if err != nil {
 		logger.Error("failed to delete resources")
 		return err
@@ -107,7 +108,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureCRDs()
 	if err != nil {
 		installerSet.Status.MarkCRDsInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for CRD condition
@@ -117,7 +118,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureClusterScopedResources()
 	if err != nil {
 		installerSet.Status.MarkClustersScopedInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for ClustersScope Condition
@@ -127,7 +128,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureNamespaceScopedResources()
 	if err != nil {
 		installerSet.Status.MarkNamespaceScopedInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for NamespaceScope Condition
@@ -137,7 +138,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureDeploymentResources()
 	if err != nil {
 		installerSet.Status.MarkDeploymentsAvailableFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for Deployment Resources
@@ -178,4 +179,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	installerSet.Status.MarkAllDeploymentsReady()
 
 	return nil
+}
+
+func (r *Reconciler) handleError(err error, installerSet *v1alpha1.TektonInstallerSet) error {
+	if err == v1alpha1.RECONCILE_AGAIN_ERR {
+		r.enqueueAfter(installerSet, 10*time.Second)
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
Add explicit check to ensure that resources are present on cluster
after an manifestival.Apply() call

Add DeletePropagation policy 'Foreground' to TektonInstallerSet
finalizer logic

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```