### PR TITLE
[cherry-pick] 0.50.x Improve TekktonInstallerSet Reconciler

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	"github.com/manifestival/manifestival/fake"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +57,7 @@ type fakeClient struct {
 	getErr         error
 	createErr      error
 	resourcesExist bool
+	gets           []unstructured.Unstructured
 	creates        []unstructured.Unstructured
 	deletes        []unstructured.Unstructured
 }
@@ -62,7 +65,12 @@ type fakeClient struct {
 func (f *fakeClient) Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	var resource *unstructured.Unstructured
 	if f.resourcesExist {
-		resource = &unstructured.Unstructured{}
+		for _, item := range f.gets {
+			if obj.GetKind() == item.GetKind() && obj.GetName() == item.GetName() {
+				return &item, nil
+			}
+		}
+
 	}
 	return resource, f.getErr
 }
@@ -98,7 +106,7 @@ func clusterScopedResource(apiVersion, kind, name string) unstructured.Unstructu
 }
 
 func TestInstaller(t *testing.T) {
-
+	crd.SetDeletionTimestamp(&metav1.Time{})
 	in := []unstructured.Unstructured{namespace, podSecurityPolicy, deployment, clusterRole, role,
 		roleBinding, clusterRoleBinding, serviceAccount, crd, validatingWebhook, mutatingWebhook, configMap, service, hpa, secret}
 
@@ -141,7 +149,7 @@ func TestInstaller(t *testing.T) {
 	client.creates = []unstructured.Unstructured{}
 
 	want = []unstructured.Unstructured{serviceAccount, clusterRoleBinding, role,
-		roleBinding, configMap, secret, hpa}
+		roleBinding, configMap, secret, hpa, service}
 
 	err = i.EnsureNamespaceScopedResources()
 	if err != nil {
@@ -160,17 +168,20 @@ func TestInstaller(t *testing.T) {
 		Resource: "Deployment",
 	}, "test-deployment")
 
-	want = []unstructured.Unstructured{deployment, service}
-
 	err = i.EnsureDeploymentResources()
-	if err != nil {
-		t.Fatal("Unexpected Error while installing resources: ", err)
-	}
+	assert.Error(t, err, v1alpha1.RECONCILE_AGAIN_ERR.Error())
 
+	want = []unstructured.Unstructured{deployment}
 	if len(want) != len(client.creates) {
 		t.Fatalf("Unexpected creates: %s", fmt.Sprintf("(-got, +want): %s", cmp.Diff(client.creates, want)))
 	}
 
+	client.resourcesExist = true
+	client.gets = []unstructured.Unstructured{deployment}
+	err = i.EnsureDeploymentResources()
+	if err != nil {
+		t.Fatal("Unexpected Error while installing resources: ", err)
+	}
 }
 
 var (

--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -57,7 +57,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, installerSet *v1alpha1.Te
 	// Delete all resources except CRDs and Namespace as they are own by owner of
 	// TektonInstallerSet
 	// They will be deleted when the component CR is deleted
-	err = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs))).Delete()
+	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs)))
+	err = deleteManifests.Delete(mf.PropagationPolicy(v1.DeletePropagationForeground))
 	if err != nil {
 		logger.Error("failed to delete resources")
 		return err
@@ -107,7 +108,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureCRDs()
 	if err != nil {
 		installerSet.Status.MarkCRDsInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for CRD condition
@@ -117,7 +118,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureClusterScopedResources()
 	if err != nil {
 		installerSet.Status.MarkClustersScopedInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for ClustersScope Condition
@@ -127,7 +128,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureNamespaceScopedResources()
 	if err != nil {
 		installerSet.Status.MarkNamespaceScopedInstallationFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for NamespaceScope Condition
@@ -137,7 +138,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	err = installer.EnsureDeploymentResources()
 	if err != nil {
 		installerSet.Status.MarkDeploymentsAvailableFailed(err.Error())
-		return err
+		return r.handleError(err, installerSet)
 	}
 
 	// Update Status for Deployment Resources
@@ -178,4 +179,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	installerSet.Status.MarkAllDeploymentsReady()
 
 	return nil
+}
+
+func (r *Reconciler) handleError(err error, installerSet *v1alpha1.TektonInstallerSet) error {
+	if err == v1alpha1.RECONCILE_AGAIN_ERR {
+		r.enqueueAfter(installerSet, 10*time.Second)
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
Add explicit check to ensure that resources are present on cluster
after an manifestival.Apply() call

Add DeletePropagation policy 'Foreground' to TektonInstallerSet
finalizer logic

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit d4032a11eeba71cf71d98a80480583fde760f384)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```