### PR TITLE
Refactors the mechanism for creating and updating TektonPipeline CR and TektonTrigger CR

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
@@ -20,83 +20,44 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
-	operatorv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/pkg/test/logging"
 )
 
-func CreatePipelineCR(ctx context.Context, instance v1alpha1.TektonComponent, client operatorv1alpha1.OperatorV1alpha1Interface) error {
-	configInstance := instance.(*v1alpha1.TektonConfig)
-	if _, err := ensureTektonPipelineExists(ctx, client.TektonPipelines(), configInstance); err != nil {
-		return errors.New(err.Error())
-	}
-	if _, err := waitForTektonPipelineState(ctx, client.TektonPipelines(), v1alpha1.PipelineResourceName,
-		isTektonPipelineReady); err != nil {
-		log.Println("TektonPipeline is not in ready state: ", err)
-		return err
-	}
-	return nil
-}
-
-func ensureTektonPipelineExists(ctx context.Context, clients op.TektonPipelineInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonPipeline, error) {
+func EnsureTektonPipelineExists(ctx context.Context, clients op.TektonPipelineInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonPipeline, error) {
 	tpCR, err := GetPipeline(ctx, clients, v1alpha1.PipelineResourceName)
-	if err == nil {
-		// if the pipeline spec is changed then update the instance
-		updated := false
 
-		if config.Spec.TargetNamespace != tpCR.Spec.TargetNamespace {
-			tpCR.Spec.TargetNamespace = config.Spec.TargetNamespace
-			updated = true
+	if err != nil {
+		if !apierrs.IsNotFound(err) {
+			return nil, err
 		}
-
-		if !reflect.DeepEqual(tpCR.Spec.Pipeline, config.Spec.Pipeline) {
-			tpCR.Spec.Pipeline = config.Spec.Pipeline
-			updated = true
+		_, err = CreatePipeline(ctx, clients, config)
+		if err != nil {
+			return nil, err
 		}
-
-		if !reflect.DeepEqual(tpCR.Spec.Config, config.Spec.Config) {
-			tpCR.Spec.Config = config.Spec.Config
-			updated = true
-		}
-
-		if tpCR.ObjectMeta.OwnerReferences == nil {
-			ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
-			tpCR.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
-			updated = true
-		}
-
-		if updated {
-			return clients.Update(ctx, tpCR, metav1.UpdateOptions{})
-		}
-
-		return tpCR, err
+		return nil, v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
-	if apierrs.IsNotFound(err) {
-		tpCR = &v1alpha1.TektonPipeline{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: v1alpha1.PipelineResourceName,
-			},
-			Spec: v1alpha1.TektonPipelineSpec{
-				CommonSpec: v1alpha1.CommonSpec{
-					TargetNamespace: config.Spec.TargetNamespace,
-				},
-				Pipeline: config.Spec.Pipeline,
-				Config:   config.Spec.Config,
-			},
-		}
-
-		return clients.Create(ctx, tpCR, metav1.CreateOptions{})
+	tpCR, err = UpdatePipeline(ctx, tpCR, config, clients)
+	if err != nil {
+		return nil, err
 	}
+
+	ok, err := isTektonPipelineReady(tpCR, err)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, v1alpha1.RECONCILE_AGAIN_ERR
+	}
+
 	return tpCR, err
 }
 
@@ -104,24 +65,59 @@ func GetPipeline(ctx context.Context, clients op.TektonPipelineInterface, name s
 	return clients.Get(ctx, name, metav1.GetOptions{})
 }
 
-// WaitForTektonPipelineState polls the status of the TektonPipeline called name
-// from client every `interval` until `inState` returns `true` indicating it
-// is done, returns an error or timeout.
-func waitForTektonPipelineState(ctx context.Context, clients op.TektonPipelineInterface, name string,
-	inState func(s *v1alpha1.TektonPipeline, err error) (bool, error)) (*v1alpha1.TektonPipeline, error) {
-	span := logging.GetEmitableSpan(ctx, fmt.Sprintf("WaitForTektonPipelineState/%s/%s", name, "TektonPipelineIsReady"))
-	defer span.End()
-
-	var lastState *v1alpha1.TektonPipeline
-	waitErr := wait.PollImmediate(common.Interval, common.Timeout, func() (bool, error) {
-		lastState, err := clients.Get(ctx, name, metav1.GetOptions{})
-		return inState(lastState, err)
-	})
-
-	if waitErr != nil {
-		return lastState, fmt.Errorf("tektonpipeline %s is not in desired state, got: %+v: %w: For more info Please check TektonPipeline CR status", name, lastState, waitErr)
+func CreatePipeline(ctx context.Context, clients op.TektonPipelineInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonPipeline, error) {
+	tpCR := &v1alpha1.TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v1alpha1.PipelineResourceName,
+		},
+		Spec: v1alpha1.TektonPipelineSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: config.Spec.TargetNamespace,
+			},
+			Pipeline: config.Spec.Pipeline,
+			Config:   config.Spec.Config,
+		},
 	}
-	return lastState, nil
+	_, err := clients.Create(ctx, tpCR, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return tpCR, err
+}
+
+func UpdatePipeline(ctx context.Context, tpCR *v1alpha1.TektonPipeline, config *v1alpha1.TektonConfig, clients op.TektonPipelineInterface) (*v1alpha1.TektonPipeline, error) {
+	// if the pipeline spec is changed then update the instance
+	updated := false
+
+	if config.Spec.TargetNamespace != tpCR.Spec.TargetNamespace {
+		tpCR.Spec.TargetNamespace = config.Spec.TargetNamespace
+		updated = true
+	}
+
+	if !reflect.DeepEqual(tpCR.Spec.Pipeline, config.Spec.Pipeline) {
+		tpCR.Spec.Pipeline = config.Spec.Pipeline
+		updated = true
+	}
+
+	if !reflect.DeepEqual(tpCR.Spec.Config, config.Spec.Config) {
+		tpCR.Spec.Config = config.Spec.Config
+		updated = true
+	}
+
+	if tpCR.ObjectMeta.OwnerReferences == nil {
+		ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
+		tpCR.ObjectMeta.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		updated = true
+	}
+
+	if updated {
+		_, err := clients.Update(ctx, tpCR, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return nil, v1alpha1.RECONCILE_AGAIN_ERR
+	}
+	return tpCR, nil
 }
 
 // IsTektonPipelineReady will check the status conditions of the TektonPipeline and return true if the TektonPipeline is ready.

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
@@ -29,8 +29,8 @@ func TestTektonPipelineCreateAndDeleteCR(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
 	tConfig := GetTektonConfig()
-	err := CreatePipelineCR(ctx, tConfig, c.OperatorV1alpha1())
-	util.AssertNotEqual(t, err, nil)
+	_, err := EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err.Error(), "reconcile again and proceed")
 	err = TektonPipelineCRDelete(ctx, c.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
 	util.AssertEqual(t, err, nil)
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -131,7 +131,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 
 	// Create TektonTrigger CR if the profile is all or basic
 	if tc.Spec.Profile == v1alpha1.ProfileAll || tc.Spec.Profile == v1alpha1.ProfileBasic {
-		if err := trigger.CreateTriggerCR(ctx, tc, r.operatorClientSet.OperatorV1alpha1()); err != nil {
+		if _, err := trigger.EnsureTektonTriggerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), tc); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
 			r.enqueueAfter(tc, 10*time.Second)
 			return nil

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -22,19 +22,15 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
-	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 	ts "knative.dev/pkg/reconciler/testing"
 )
 
 func TestTektonTriggerCreateAndDeleteCR(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	tConfig := pipeline.GetTektonConfig()
-	err := CreateTriggerCR(ctx, tConfig, c.OperatorV1alpha1())
-	util.AssertNotEqual(t, err, nil)
-	// recheck triggers creation
-	err = CreateTriggerCR(ctx, tConfig, c.OperatorV1alpha1())
-	util.AssertNotEqual(t, err, nil)
+	tConfig := GetTektonConfig()
+	_, err := EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err.Error(), "reconcile again and proceed")
 	err = TektonTriggerCRDelete(ctx, c.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName)
 	util.AssertEqual(t, err, nil)
 }


### PR DESCRIPTION
# Changes

## Refactoring the TektonPipeline CR
  
- This patch now checks first if there is TektonPipeline CR
    already present, if yes then it checks if there are any
    changes in the instance, if yes then it makes the changes
    and updates the CR, if not then it creates a new CR

 - This patch also removes the polling state mechanism for
    tekton Pipeline CR

---

## Refactoring the TektonTrigger CR

  - This patch now checks first if there is TektonTrigger CR
         already present, if yes then it checks if there are any
         changes in the instance, if yes then it makes the changes
         and updates the CR, if not then it creates a new CR
    
  - This patch also removes the polling state mechanism for
     tekton Trigger CR

---
Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
