### PR TITLE
Fixes operator pod restart on changing addon params

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -202,16 +202,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 			ta.Status.MarkInstallerSetNotReady(msg)
 			return r.ensureClusterTasks(ctx, ta)
 		}
+
+		if err := r.checkComponentStatus(ctx, clusterTaskLabelSelector); err != nil {
+			ta.Status.MarkInstallerSetNotReady(err.Error())
+			return nil
+		}
+
 	} else {
 		// if disabled then delete the installer Set if exist
 		if err := r.deleteInstallerSet(ctx, clusterTaskLabelSelector); err != nil {
 			return err
 		}
-	}
-
-	if err := r.checkComponentStatus(ctx, clusterTaskLabelSelector); err != nil {
-		ta.Status.MarkInstallerSetNotReady(err.Error())
-		return nil
 	}
 
 	// If clusterTasks are enabled then create an InstallerSet
@@ -284,16 +285,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 			ta.Status.MarkInstallerSetNotReady(msg)
 			return r.ensurePipelineTemplates(ctx, ta)
 		}
+
+		if err := r.checkComponentStatus(ctx, pipelineTemplateLSLabelSelector); err != nil {
+			ta.Status.MarkInstallerSetNotReady(err.Error())
+			return nil
+		}
+
 	} else {
 		// if disabled then delete the installer Set if exist
 		if err := r.deleteInstallerSet(ctx, pipelineTemplateLSLabelSelector); err != nil {
 			return err
 		}
-	}
-
-	if err := r.checkComponentStatus(ctx, pipelineTemplateLSLabelSelector); err != nil {
-		ta.Status.MarkInstallerSetNotReady(err.Error())
-		return nil
 	}
 
 	// Ensure Triggers resources


### PR DESCRIPTION
after successfull installation, changing addon params is breaking
the code and pods keep restarting.
this fixes it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
