### PR TITLE
[OpenShift] Fix RBAC bugs

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -73,7 +73,7 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		// then disable auto creation of RBAC resources by deleting installerSet
 		if v.Name == rbacParamName && v.Value == "false" {
 			createRBACResource = false
-			if err := deleteInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, componentName); err != nil {
+			if err := deleteInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, componentNameRBAC); err != nil {
 				return err
 			}
 			// remove openshift-pipelines.tekton.dev/namespace-reconcile-version label from namespaces while deleting RBAC resources.
@@ -83,10 +83,16 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		}
 	}
 
+	// TODO: Remove this after v0.55.0 release, by following a depreciation notice
+	// --------------------
+	if err := r.cleanUpRBACNameChange(ctx); err != nil {
+		return err
+	}
+	// --------------------
+
 	if createRBACResource {
 		return r.createResources(ctx)
 	}
-
 	return nil
 }
 

--- a/pkg/reconciler/shared/tektonconfig/controller.go
+++ b/pkg/reconciler/shared/tektonconfig/controller.go
@@ -35,6 +35,7 @@ import (
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	tektonChainsinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonchains"
 	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
+	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonTriggerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektontrigger"
 	tektonConfigreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonconfig"
@@ -95,6 +96,11 @@ func NewExtensibleController(generator common.ExtensionGenerator) injection.Cont
 		})
 
 		tektonChainsinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
+			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+		})
+
+		tektonInstallerinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})

--- a/test/e2e/common/00_tektonconfigdeployment_test.go
+++ b/test/e2e/common/00_tektonconfigdeployment_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonpipeline"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
+	tconfig "github.com/tektoncd/operator/pkg/reconciler/openshift/tektonconfig"
 	"github.com/tektoncd/operator/test/client"
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
@@ -440,7 +441,7 @@ func runRbacTest(t *testing.T, clients *utils.Clients) {
 	})
 
 	pipelinesSCCRoleBinding := "pipelines-scc-rolebinding"
-	editRoleBinding := "edit"
+	editRoleBinding := tconfig.PipelineRoleBinding
 
 	// Test whether the roleBindings are created
 	t.Run("verify-rolebindings", func(t *testing.T) {


### PR DESCRIPTION

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

- Rename rolebinding created by RBAC reconciler to
  'openshift-pipelines-edit' (was 'edit' earlier)

- Add mechanism to ensure that missing RBAC resources are recreated if
  the RBAC installerSet is recreated during an upgrade.
  - this ensures that RBAC in the version label user 
    namespaces are removed during an upgrade and the presence of RBAC
resources are re-verified

- Make TektonConfig reconciler listen to TektonInstallerSet events so
  that it can recreate RBAC InstallerSet if it is deleted manually from
a cluster

- Add a mechanism to remove ownerReference and 'pipeline' sa subject
  from 'edit' rolebinding in namespaces
  - This ensures that operator upgrades won't delete/reset 'edit'
    rolebinding in usernamespaces.
  - This mechanism will delete the edit role binding if the only subject is `pipeline` serviceaccount.
    


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Name of rolebinding which binds ClusterRole edit to 'pipeline' ServiceAccount in usernamespaces is now 'openshift-pipelines-edit' instead of 'edit'.
```