### PR TITLE
Updates Hub Db deployment in case of Openshift

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -64,6 +64,8 @@ spec:
               key: DEFAULT_TARGET_NAMESPACE
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
+        - name: IMAGE_HUB_DB
+          value: registry.redhat.io/rhel8/postgresql-13:1-18
 #          - name: IMAGE_ADDONS_TKN_CLI_SERVE
 #            value: docker.io/rupali/serve-tkn:v2
 #          - name: IMAGE_ADDONS_PARAM_TKN_IMAGE

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -41,6 +41,7 @@ const (
 	TriggersImagePrefix           = "IMAGE_TRIGGERS_"
 	AddonsImagePrefix             = "IMAGE_ADDONS_"
 	ChainsImagePrefix             = "IMAGE_CHAINS_"
+	HubDbImagePrefix              = "IMAGE_HUB_"
 
 	ArgPrefix   = "arg_"
 	ParamPrefix = "param_"

--- a/pkg/reconciler/openshift/tektonhub/extension_test.go
+++ b/pkg/reconciler/openshift/tektonhub/extension_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonhub
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestUpdateDbDeployment(t *testing.T) {
+	testData := path.Join("testdata", "update-db-deployment.yaml")
+
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(UpdateDbDeployment())
+	assert.NilError(t, err)
+
+	d := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, d)
+	assert.NilError(t, err)
+
+	env := d.Spec.Template.Spec.Containers[0].Env
+	assert.Equal(t, env[0].Name, "POSTGRESQL_DATABASE")
+
+	mountPath := d.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+	assert.Equal(t, mountPath, "/var/lib/pgsql/data")
+
+	cmd := d.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command
+	assert.Equal(t, strings.Contains(cmd[2], "POSTGRESQL_USER"), true)
+}

--- a/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
+++ b/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
@@ -1,0 +1,75 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+  labels:
+    app: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - name: db
+          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: db
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: [bash, -c, "psql -w -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c 'SELECT 1'"]
+            initialDelaySeconds: 15
+            timeoutSeconds: 2
+            periodSeconds: 15
+          livenessProbe:
+            exec:
+              command: [bash, -c, "psql -w -U ${POSTGRES_USER} -d ${POSTGRES_DB} -c 'SELECT 1'"]
+            initialDelaySeconds: 45
+            timeoutSeconds: 2
+            periodSeconds: 15
+      volumes:
+        - name: db
+          persistentVolumeClaim:
+            claimName: db
+      restartPolicy: Always


### PR DESCRIPTION
# Changes

-   This patch adds a transformer which updates the db deployment,
    in case of openshift to use productized postgres images and also
    replace a few env and commands for readiness and liveness probes
    
 Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
