### PR TITLE
Disabling removed feature flags in Pipleines v0.33.0

### DIFF
--- a/docs/TektonPipeline.md
+++ b/docs/TektonPipeline.md
@@ -46,21 +46,6 @@ them as per their need.
     See more in the workspace documentation about [Affinity Assistant](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline)
     or more info [here](https://github.com/tektoncd/pipeline/pull/2630).
 
-
-- `disable-home-env-overwrite` (Default: `true`)
-
-    Setting this flag to "false" will allow Tekton to override your Task container's $HOME environment variable.
-
-    See more info [here](https://github.com/tektoncd/pipeline/issues/2013).
-
-
-- `disable-working-directory-overwrite` (Default: `true`)
-
-    Setting this flag to "false" will allow Tekton to override your Task container's working directory.
-
-    See more info [here](https://github.com/tektoncd/pipeline/issues/1836).
-
-
 - `disable-creds-init` (Default: `false`)
 
     Setting this flag to "true" will prevent Tekton scanning attached service accounts and injecting any credentials it

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -34,12 +34,15 @@ func (tp *TektonPipeline) SetDefaults(ctx context.Context) {
 }
 
 func (p *PipelineProperties) setDefaults() {
-	if p.DisableHomeEnvOverwrite == nil {
-		p.DisableHomeEnvOverwrite = ptr.Bool(true)
+	// Disabling this for now and will be removed in next release
+	// disabling will hide this from users in TektonConfig/TektonPipeline
+	if p.DisableHomeEnvOverwrite != nil {
+		p.DisableHomeEnvOverwrite = nil
 	}
-	if p.DisableWorkingDirectoryOverwrite == nil {
-		p.DisableWorkingDirectoryOverwrite = ptr.Bool(true)
+	if p.DisableWorkingDirectoryOverwrite != nil {
+		p.DisableWorkingDirectoryOverwrite = nil
 	}
+
 	if p.DisableCredsInit == nil {
 		p.DisableCredsInit = ptr.Bool(false)
 	}

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
@@ -41,8 +41,8 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 	}
 
 	properties := PipelineProperties{
-		DisableHomeEnvOverwrite:                  ptr.Bool(true),
-		DisableWorkingDirectoryOverwrite:         ptr.Bool(true),
+		DisableHomeEnvOverwrite:                  nil,
+		DisableWorkingDirectoryOverwrite:         nil,
 		DisableCredsInit:                         ptr.Bool(false),
 		RunningInEnvironmentWithInjectedSidecars: ptr.Bool(true),
 		RequireGitSshSecretKnownHosts:            ptr.Bool(false),

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -85,9 +85,13 @@ type Pipeline struct {
 
 // PipelineProperties defines customizable flags for Pipeline Component.
 type PipelineProperties struct {
-	DisableAffinityAssistant                 *bool  `json:"disable-affinity-assistant,omitempty"`
-	DisableHomeEnvOverwrite                  *bool  `json:"disable-home-env-overwrite,omitempty"`
-	DisableWorkingDirectoryOverwrite         *bool  `json:"disable-working-directory-overwrite,omitempty"`
+	DisableAffinityAssistant *bool `json:"disable-affinity-assistant,omitempty"`
+
+	// DEPRECATED:  (Removed in Pipelines v0.33.0): to be removed in next release
+	DisableHomeEnvOverwrite *bool `json:"disable-home-env-overwrite,omitempty"`
+	// DEPRECATED: (Removed in Pipelines v0.33.0): to be removed in next release
+	DisableWorkingDirectoryOverwrite *bool `json:"disable-working-directory-overwrite,omitempty"`
+
 	DisableCredsInit                         *bool  `json:"disable-creds-init,omitempty"`
 	RunningInEnvironmentWithInjectedSidecars *bool  `json:"running-in-environment-with-injected-sidecars,omitempty"`
 	RequireGitSshSecretKnownHosts            *bool  `json:"require-git-ssh-secret-known-hosts,omitempty"`


### PR DESCRIPTION
This disables the flags in TektonPipeline for now, so
that in next operator release we can remove them
and upgrades can be smooth.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
