### PR TITLE
[OpenShift] Fixes addon if operator target ns is not openshift-pipelines

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/extension.go
+++ b/pkg/reconciler/openshift/tektonaddon/extension.go
@@ -203,6 +203,10 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 		if err := applyAddons(&tknservecliManifest, "05-tkncliserve"); err != nil {
 			return err
 		}
+		if err := addonTransform(ctx, &tknservecliManifest, addon); err != nil {
+			return err
+		}
+
 		routeHost, err := getRouteHost(&tknservecliManifest)
 		if err != nil {
 			return err


### PR DESCRIPTION
operator looks for tkncliserve route in openshif-pipelines ns and not
in target namespace. so addon fails if targetnamespace is different
from openshift-pipelines. this fixes it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
