### PR TITLE
change cmd/ko to ko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ TEKTON_RESULTS_VERSION ?= v0.4.0 # latest returns an older version hence hard co
 PAC_VERSION ?= 0.5.3
 TEKTON_HUB_VERSION ?= v1.6.0 # latest doesn't returns any version hence hard coding to v1.6.0 for now
 
-$(BIN)/ko: PACKAGE=github.com/google/ko/cmd/ko
+$(BIN)/ko: PACKAGE=github.com/google/ko
 
 KUSTOMIZE = $(or ${KUSTOMIZE_BIN},${KUSTOMIZE_BIN},$(BIN)/kustomize)
 $(BIN)/kustomize: | $(BIN) ; $(info $(M) getting kustomize)


### PR DESCRIPTION
With this pr https://github.com/google/ko/pull/628 getting merged
operator Make apply is gives below error

```:cat: building github.com/google/ko/cmd/ko…
cannot find package "github.com/google/ko/cmd/ko" in any of:
	/usr/local/go/src/github.com/google/ko/cmd/ko (from $GOROOT)
	/tmp/tmp.rXMejzqfMj/src/github.com/google/ko/cmd/ko (from $GOPATH)
make: *** [Makefile:26: /home/pradeepkumar/go/src/github.com/tektoncd/operator/.bin/ko] Error 1
```

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
