### PR TITLE
Mount CA bundles in Tekton components as well

### DIFF
--- a/pkg/reconciler/common/certificates.go
+++ b/pkg/reconciler/common/certificates.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// user-provided and system CA certificates
+	TrustedCAConfigMapName   = "config-trusted-cabundle"
+	TrustedCAConfigMapVolume = "config-trusted-cabundle-volume"
+	TrustedCAKey             = "ca-bundle.crt"
+
+	// service serving certificates (required to talk to the internal registry)
+	ServiceCAConfigMapName   = "config-service-cabundle"
+	ServiceCAConfigMapVolume = "config-service-cabundle-volume"
+	ServiceCAKey             = "service-ca.crt"
+)
+
+// newVolumeWithConfigMap creates a new volume with the given ConfigMap
+func newVolumeWithConfigMap(volumeName, configMapName, configMapKey, configMapPath string) corev1.Volume {
+	return corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  configMapKey,
+						Path: configMapPath,
+					},
+				},
+			},
+		},
+	}
+}
+
+// AddCABundleConfigMapsToVolumes adds the config-trusted-cabundle and config-service-cabundle
+// ConfigMaps to the given list of volumes and removes duplicates, if any
+func AddCABundleConfigMapsToVolumes(volumes []corev1.Volume) []corev1.Volume {
+	// If CA bundle volumes already exists in the pod's volumes, then remove it
+	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
+		for i, v := range volumes {
+			if v.Name == volumeName {
+				volumes = append(volumes[:i], volumes[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return append(
+		volumes,
+		newVolumeWithConfigMap(TrustedCAConfigMapVolume, TrustedCAConfigMapName, TrustedCAKey, TrustedCAKey),
+		newVolumeWithConfigMap(ServiceCAConfigMapVolume, ServiceCAConfigMapName, ServiceCAKey, ServiceCAKey),
+	)
+}
+
+// AddCABundlesToContainerVolumes adds the CA bundles to the container via VolumeMounts.
+// SSL_CERT_DIR environment variable is also set if it does not exist already.
+func AddCABundlesToContainerVolumes(c *corev1.Container) {
+	volumeMounts := c.VolumeMounts
+
+	// If volume mounts for CA bundles already exist then remove them
+	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
+		for i, vm := range volumeMounts {
+			if vm.Name == volumeName {
+				volumeMounts = append(volumeMounts[:i], volumeMounts[i+1:]...)
+				break
+			}
+		}
+	}
+
+	// We will mount the certs at /tekton-custom-certs so we don't override the existing certs
+	sslCertDir := "/tekton-custom-certs"
+	certEnvAvailable := false
+
+	for _, env := range c.Env {
+		// If SSL_CERT_DIR env var already exists, then we don't mess with
+		// it and simply carry it forward as it is
+		if env.Name == "SSL_CERT_DIR" {
+			sslCertDir = env.Value
+			certEnvAvailable = true
+			break
+		}
+	}
+
+	if !certEnvAvailable {
+		// Here, we need to set the default value for SSL_CERT_DIR.
+		// Keep in mind that if SSL_CERT_DIR is set, then it overrides the
+		// system default, i.e. the system default directories will "NOT"
+		// be scanned for certificates. This is risky and we don't want to
+		// do this because users mount certificates at these locations or
+		// build images with certificates "in" them and expect certificates
+		// to get picked up, and rightfully so since this is the documented
+		// way of achieving this.
+		// So, let's keep the system wide default locations in place and
+		// "append" our custom location to those.
+		//
+		// certDirectories copied from
+		// https://golang.org/src/crypto/x509/root_linux.go
+		var certDirectories = []string{
+			// Ordering is important here - we will be using the "first"
+			// element in SSL_CERT_DIR to do the volume mounts.
+			sslCertDir,                     // /tekton-custom-certs
+			"/etc/ssl/certs",               // SLES10/SLES11, https://golang.org/issue/12139
+			"/etc/pki/tls/certs",           // Fedora/RHEL
+			"/system/etc/security/cacerts", // Android
+		}
+
+		// SSL_CERT_DIR accepts a colon separated list of directories
+		sslCertDir = strings.Join(certDirectories, ":")
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  "SSL_CERT_DIR",
+			Value: sslCertDir,
+		})
+	}
+
+	// Let's mount the certificates now.
+	volumeMounts = append(volumeMounts,
+		corev1.VolumeMount{
+			Name: TrustedCAConfigMapVolume,
+			// We only want the first entry in SSL_CERT_DIR for the mount
+			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], TrustedCAKey),
+			SubPath:   TrustedCAKey,
+			ReadOnly:  true,
+		},
+		corev1.VolumeMount{
+			Name: ServiceCAConfigMapVolume,
+			// We only want the first entry in SSL_CERT_DIR for the mount
+			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], ServiceCAKey),
+			SubPath:   ServiceCAKey,
+			ReadOnly:  true,
+		},
+	)
+	c.VolumeMounts = volumeMounts
+}

--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -18,26 +18,12 @@ package common
 
 import (
 	"encoding/json"
-	"path/filepath"
-	"strings"
 
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-)
-
-const (
-	// user-provided and system CA certificates
-	trustedCAConfigMapName   = "config-trusted-cabundle"
-	trustedCAConfigMapVolume = "config-trusted-cabundle-volume"
-	trustedCAKey             = "ca-bundle.crt"
-
-	// service serving certificates (required to talk to the internal registry)
-	serviceCAConfigMapName   = "config-service-cabundle"
-	serviceCAConfigMapVolume = "config-service-cabundle-volume"
-	serviceCAKey             = "service-ca.crt"
 )
 
 // ApplyCABundles is a transformer that add the trustedCA volume, mount and
@@ -53,94 +39,14 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 		return err
 	}
 
-	volumes := deployment.Spec.Template.Spec.Volumes
-
-	// If CA bundle volumes already exists in the PodSpec, then remove it
-	for _, volumeName := range []string{trustedCAConfigMapVolume, serviceCAConfigMapVolume} {
-		for i, v := range volumes {
-			if v.Name == volumeName {
-				volumes = append(volumes[:i], volumes[i+1:]...)
-				break
-			}
-		}
-	}
-
 	// Let's add the trusted and service CA bundle ConfigMaps as a volume in
 	// the PodSpec which will later be mounted to add certs in the pod.
-	volumes = append(volumes,
-		// Add trusted CA bundle
-		corev1.Volume{
-			Name: trustedCAConfigMapVolume,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: trustedCAConfigMapName},
-					Items: []corev1.KeyToPath{
-						{
-							Key:  trustedCAKey,
-							Path: trustedCAKey,
-						},
-					},
-				},
-			},
-		},
-		// Add service serving certificates bundle
-		corev1.Volume{
-			Name: serviceCAConfigMapVolume,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: serviceCAConfigMapName},
-					Items: []corev1.KeyToPath{
-						{
-							Key:  serviceCAKey,
-							Path: serviceCAKey,
-						},
-					},
-				},
-			},
-		})
-	deployment.Spec.Template.Spec.Volumes = volumes
+	deployment.Spec.Template.Spec.Volumes = common.AddCABundleConfigMapsToVolumes(deployment.Spec.Template.Spec.Volumes)
 
 	// Now that the injected certificates have been added as a volume, let's
 	// mount them via volumeMounts in the containers
 	for i, c := range deployment.Spec.Template.Spec.Containers {
-		volumeMounts := c.VolumeMounts
-
-		// If volume mounts for injected certificates already exist then remove them
-		for _, volumeName := range []string{trustedCAConfigMapVolume, serviceCAConfigMapVolume} {
-			for i, vm := range volumeMounts {
-				if vm.Name == volumeName {
-					volumeMounts = append(volumeMounts[:i], volumeMounts[i+1:]...)
-					break
-				}
-			}
-		}
-
-		// We will mount the certs at this location so we don't override the existing certs
-		sslCertDir := "/tekton-custom-certs"
-		for _, env := range c.Env {
-			if env.Name == "SSL_CERT_DIR" {
-				sslCertDir = env.Value
-			}
-		}
-
-		// Let's mount the certificates now.
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name: trustedCAConfigMapVolume,
-				// We only want the first entry in SSL_CERT_DIR for the mount
-				MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], trustedCAKey),
-				SubPath:   trustedCAKey,
-				ReadOnly:  true,
-			},
-			corev1.VolumeMount{
-				Name: serviceCAConfigMapVolume,
-				// We only want the first entry in SSL_CERT_DIR for the mount
-				MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], serviceCAKey),
-				SubPath:   serviceCAKey,
-				ReadOnly:  true,
-			},
-		)
-		c.VolumeMounts = volumeMounts
+		common.AddCABundlesToContainerVolumes(&c)
 		deployment.Spec.Template.Spec.Containers[i] = c
 	}
 

--- a/pkg/reconciler/proxy/proxy_test.go
+++ b/pkg/reconciler/proxy/proxy_test.go
@@ -35,14 +35,20 @@ func TestUpdateVolume(t *testing.T) {
 			},
 		},
 	}
-	podUpdated := updateVolume(pod, "testv", "testcm", "testkey")
-	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 1)
+	podUpdated := updateVolume(pod)
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].Env), 1)
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Name, "SSL_CERT_DIR")
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Value, "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts")
-	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "testv")
-	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "testcm")
-	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 1)
-	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].Name, "testv")
-	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].SubPath, "testkey")
+
+	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 2)
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "config-trusted-cabundle-volume")
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "config-trusted-cabundle")
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[1].Name, "config-service-cabundle-volume")
+	assert.DeepEqual(t, podUpdated.Spec.Volumes[1].ConfigMap.Name, "config-service-cabundle")
+
+	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 2)
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].Name, "config-trusted-cabundle-volume")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].SubPath, "ca-bundle.crt")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[1].Name, "config-service-cabundle-volume")
+	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[1].SubPath, "service-ca.crt")
 }


### PR DESCRIPTION
# Changes

Prior to this commit, the CA bundles were:
- mounted inside containers
- exposed via VolumeMounts and SSL_CERT_DIR
only in TaskRun pods via `pkg/reconciler/proxy/proxy.go` but were not
exposed in Tekton components controllers like pipelines, triggers and
chains via `pkg/reconciler/openshift/common/cabundle.go`.

This meant that these Tekton components could not talk to internal
OpenShift services or to hosts for which users added certificates to the
cluster via CA bundles.

One case where this is a problem is when the Chains controller wants to
pull images from the internal OpenShift registry to sign and then push
the signatures, attestations back to it since it does not have access to
the Service CA Bundle.

This commit abstracts away the exposure of certificates via Volumes,
VolumeMounts and SSL_CERT_DIR in `pkg/reconciler/common/certificates.go`
and makes this behavior the same for both TaskRuns and controllers which
want to mount these certificates.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

```release-note
NONE
```