### PR TITLE
Add config owner reference while creating components

### DIFF
--- a/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard.go
@@ -81,9 +81,12 @@ func ensureTektonDashboardExists(ctx context.Context, clients op.TektonDashboard
 	}
 
 	if apierrs.IsNotFound(err) {
+		ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
+
 		tdCR = &v1alpha1.TektonDashboard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: v1alpha1.DashboardResourceName,
+				Name:            v1alpha1.DashboardResourceName,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
 			},
 			Spec: v1alpha1.TektonDashboardSpec{
 				CommonSpec: v1alpha1.CommonSpec{

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
@@ -66,9 +66,12 @@ func GetPipeline(ctx context.Context, clients op.TektonPipelineInterface, name s
 }
 
 func CreatePipeline(ctx context.Context, clients op.TektonPipelineInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonPipeline, error) {
+	ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
+
 	tpCR := &v1alpha1.TektonPipeline{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: v1alpha1.PipelineResourceName,
+			Name:            v1alpha1.PipelineResourceName,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: v1alpha1.TektonPipelineSpec{
 			CommonSpec: v1alpha1.CommonSpec{

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
@@ -66,9 +66,12 @@ func GetTrigger(ctx context.Context, clients op.TektonTriggerInterface, name str
 }
 
 func CreateTrigger(ctx context.Context, clients op.TektonTriggerInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonTrigger, error) {
+	ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
+
 	ttCR := &v1alpha1.TektonTrigger{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: v1alpha1.TriggerResourceName,
+			Name:            v1alpha1.TriggerResourceName,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: v1alpha1.TektonTriggerSpec{
 			CommonSpec: v1alpha1.CommonSpec{


### PR DESCRIPTION
we add owner reference while checking if components fields
are changed in tektonconfig and if owner is missing then we use
to update the component.
this adds owner while creating the component.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
