### PR TITLE
Option to disable community tasks

### DIFF
--- a/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
@@ -25,6 +25,8 @@ spec:
       value: "true"
     - name: pipelineTemplates
       value: "true"
+    - name: communityClusterTasks
+      value: "true"
   params:
   - name: createRbacResource
     value: "true"

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -30,6 +30,7 @@ const (
 	// Addon Params
 	ClusterTasksParam      = "clusterTasks"
 	PipelineTemplatesParam = "pipelineTemplates"
+	CommunityClusterTasks  = "communityClusterTasks"
 
 	// Hub Params
 	EnableDevconsoleIntegrationParam = "enable-devconsole-integration"
@@ -83,6 +84,7 @@ var (
 	AddonParams = map[string]ParamValue{
 		ClusterTasksParam:      defaultParamValue,
 		PipelineTemplatesParam: defaultParamValue,
+		CommunityClusterTasks:  defaultParamValue,
 	}
 
 	HubParams = map[string]ParamValue{

--- a/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
@@ -39,7 +39,7 @@ func Test_AddonSetDefaults_DefaultParamsWithValues(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 2, len(ta.Spec.Params))
+	assert.Equal(t, 3, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[ClusterTasksParam]
@@ -70,7 +70,7 @@ func Test_AddonSetDefaults_ClusterTaskIsFalse(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 2, len(ta.Spec.Params))
+	assert.Equal(t, 3, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[PipelineTemplatesParam]

--- a/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
@@ -64,6 +64,9 @@ func validateAddonParams(params []Param, pathToParams string) *apis.FieldError {
 	if (paramsMap[ClusterTasksParam] == "false") && (paramsMap[PipelineTemplatesParam] == "true") {
 		errs = errs.Also(apis.ErrGeneric("pipelineTemplates cannot be true if clusterTask is false", pathToParams))
 	}
+	if (paramsMap[ClusterTasksParam] == "false") && (paramsMap[CommunityClusterTasks] == "true") {
+		errs = errs.Also(apis.ErrGeneric("communityClusterTasks cannot be true if clusterTask is false", pathToParams))
+	}
 
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -87,7 +87,7 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 	}
 
 	tc.SetDefaults(context.TODO())
-	if len(tc.Spec.Addon.Params) != 2 {
+	if len(tc.Spec.Addon.Params) != 3 {
 		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
 	}
 }

--- a/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
+++ b/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonaddon
+
+import (
+	"context"
+	"fmt"
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	"strings"
+	"time"
+)
+
+var communityClusterTaskLS = metav1.LabelSelector{
+	MatchLabels: map[string]string{
+		v1alpha1.InstallerSetType: CommunityClusterTaskInstallerSet,
+	},
+}
+
+// retryWaitTime holds value until the pod lives.
+// ones the pod restart resets the value back to ""
+// this is useful if the pod is not restarted and community task urls are not reachable
+// we see comparable less forbidden events
+var (
+	layout        = "2006-01-02 15:04:05"
+	retryWaitTime = ""
+)
+
+var communityResourceURLs = []string{
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.4/jib-maven.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.3/helm-upgrade-from-source.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-cli/0.3/git-cli.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/pull-request/0.1/pull-request.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/main/task/argocd-task-sync-and-wait/0.2/argocd-task-sync-and-wait.yaml",
+}
+
+func (r *Reconciler) EnsureCommunityClusterTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+
+	communityClusterTaskLabelSelector, err := common.LabelSelector(communityClusterTaskLS)
+	if err != nil {
+		return err
+	}
+
+	if enable == "true" {
+
+		exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, r.operatorVersion, communityClusterTaskLabelSelector)
+		if err != nil {
+			return err
+		}
+
+		if !exist {
+			msg := fmt.Sprintf("%s being created/upgraded", CommunityClusterTaskInstallerSet)
+			ta.Status.MarkInstallerSetNotReady(msg)
+			return r.ensureCommunityClusterTasks(ctx, ta)
+		}
+
+		if err := r.checkComponentStatus(ctx, communityClusterTaskLabelSelector); err != nil {
+			ta.Status.MarkInstallerSetNotReady(err.Error())
+			return nil
+		}
+
+	} else {
+		// if disabled then delete the installer Set if exist
+		if err := r.deleteInstallerSet(ctx, communityClusterTaskLabelSelector); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// installerset for communityclustertask
+func (r *Reconciler) ensureCommunityClusterTasks(ctx context.Context, ta *v1alpha1.TektonAddon) error {
+
+	if SkipCommunityTaskFetch(retryWaitTime) {
+		return nil
+	}
+
+	communityClusterTaskManifest := mf.Manifest{}
+	if err := r.appendCommunityTarget(ctx, &communityClusterTaskManifest, ta); err != nil {
+		retryWaitTime = time.Now().Add(15 * time.Minute).Format(layout)
+
+		// Continue if failed to resolve community task URL.
+		// (Ex: on disconnected cluster community tasks won't be reachable because of proxy).
+		logging.FromContext(ctx).Error("Failed to get community task: Skipping community tasks installation  ", err)
+		r.enqueueAfter(r, 10*time.Second)
+		return nil
+	}
+
+	if err := r.communityTransform(ctx, &communityClusterTaskManifest, ta); err != nil {
+		return err
+	}
+
+	communityClusterTaskManifest = communityClusterTaskManifest.Append(communityClusterTaskManifest)
+
+	if err := createInstallerSet(ctx, r.operatorClientSet, ta, communityClusterTaskManifest, r.operatorVersion, CommunityClusterTaskInstallerSet, "addon-communityclustertasks"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// appendCommunityTarget mutates the passed manifest by appending one
+// appropriate for the passed TektonComponent
+func (r *Reconciler) appendCommunityTarget(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
+	urls := strings.Join(communityResourceURLs, ",")
+	m, err := mf.ManifestFrom(mf.Path(urls))
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}
+
+// communityTransform mutates the passed manifest to one with common component
+// and platform transformations applied
+func (r *Reconciler) communityTransform(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) error {
+	instance := comp.(*v1alpha1.TektonAddon)
+	extra := []mf.Transformer{
+		replaceKind("Task", "ClusterTask"),
+		injectLabel(labelProviderType, providerTypeCommunity, overwrite, "ClusterTask"),
+	}
+	extra = append(extra, r.extension.Transformers(instance)...)
+	return common.Transform(ctx, manifest, instance, extra...)
+}
+
+// SkipCommunityTaskFetch skips community task fetch until retryWaitTime has passed
+// if there is no value int retryWaitTime that means no error occurred prior to the call
+// if there is some value that means error has occurred earlier and must try after 15 minutes
+func SkipCommunityTaskFetch(until string) bool {
+	skip := false
+	if until != "" {
+		t, err := time.Parse(layout, until)
+		if err != nil {
+			return false
+		}
+		if t.After(time.Now()) {
+			skip = true
+		}
+	}
+	return skip
+}

--- a/pkg/reconciler/openshift/tektonaddon/const.go
+++ b/pkg/reconciler/openshift/tektonaddon/const.go
@@ -18,6 +18,7 @@ package tektonaddon
 
 const (
 	ClusterTaskInstallerSet            = "ClusterTask"
+	CommunityClusterTaskInstallerSet   = "CommunityClusterTask"
 	VersionedClusterTaskInstallerSet   = "VersionedClusterTask"
 	PipelinesTemplateInstallerSet      = "PipelinesTemplate"
 	TriggersResourcesInstallerSet      = "TriggersResources"

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -152,6 +152,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	// validate the params
 	ptVal, _ := findValue(ta.Spec.Params, v1alpha1.PipelineTemplatesParam)
 	ctVal, _ := findValue(ta.Spec.Params, v1alpha1.ClusterTasksParam)
+	cctVal, _ := findValue(ta.Spec.Params, v1alpha1.CommunityClusterTasks)
 
 	if ptVal == "true" && ctVal == "false" {
 		ta.Status.MarkNotReady("pipelineTemplates cannot be true if clusterTask is false")
@@ -170,6 +171,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	}
 
 	if err := r.EnsureVersionedClusterTask(ctx, ctVal, ta); err != nil {
+		return err
+	}
+
+	if err := r.EnsureCommunityClusterTask(ctx, cctVal, ta); err != nil {
 		return err
 	}
 

--- a/test/resources/tektonaddons.go
+++ b/test/resources/tektonaddons.go
@@ -96,6 +96,7 @@ func AssertTektonAddonCRReadyStatus(t *testing.T, clients *utils.Clients, names 
 
 // AssertTektonInstallerSets verifies if the TektonInstallerSets are created.
 func AssertTektonInstallerSets(t *testing.T, clients *utils.Clients) {
+	assertInstallerSets(t, clients, tektonaddon.CommunityClusterTaskInstallerSet)
 	assertInstallerSets(t, clients, tektonaddon.ClusterTaskInstallerSet)
 	assertInstallerSets(t, clients, tektonaddon.VersionedClusterTaskInstallerSet)
 	assertInstallerSets(t, clients, tektonaddon.PipelinesTemplateInstallerSet)

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -77,6 +77,10 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 							Name:  "clusterTasks",
 							Value: "true",
 						},
+						{
+							Name:  "communityClusterTasks",
+							Value: "true",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
this adds an option to disable installaion of
community cluster tasks.

If community task fetch urls are not reachable, it retries
after 15 minutes of fixed time.
This helps to reduce error logs.

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->


Our communitytasks are tasks maintained in tektoncd/catalog, and when the user is in air-gapped 
environment the urls's to fetch them are un-reachable. This leads to huge forbidden error logs.

With this pr user gets an option to disable community tasks from getting installed.
Also if the community tasks are not disabled, and the urls are not reachable. After first error operator 
do not try to fetch the urls for 15 minutes.

By default community tasks installation is enabled.
<i>`communityClusterTasks: true`</i>
```
spec:
  profile: all
  targetNamespace: openshift-pipelines
  addon:
    params:
    - name: clusterTasks
      value: "true"
    - name: pipelineTemplates
      value: "true"
    - name: communityClusterTasks
      value: "true"
```
Note: community tasks cannot be true if clustertasks is false.
```release-note
[openshift] add an option to remove to disable community tasks from getting installed.

```