### PR TITLE
Add chains image env for openshift

### DIFF
--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -153,7 +153,13 @@ image-substitutions:
     containerTargets:
     - deploymentName: tekton-operator-webhook
       containerName: tekton-operator-webhook
-
+- image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel8@
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator
+        envKeys:
+          - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
 # add thrid party images which are not replaced by operator
 # but pulled directly by tasks here
 defaultRelatedImages: []


### PR DESCRIPTION
This will add the env in config.yaml for generating csv
on OpenShift so that the redhat build image can refelect
in csv and replaced during installation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
