### PR TITLE
Add hub image env for openshift

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -64,8 +64,8 @@ spec:
               key: DEFAULT_TARGET_NAMESPACE
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
-        - name: IMAGE_HUB_DB
-          value: registry.redhat.io/rhel8/postgresql-13:1-18
+        - name: IMAGE_HUB_TEKTON_HUB_DB
+          value: registry.redhat.io/rhel8/postgresql-13@sha256:6032adb3eac903ee8aa61f296ca9aaa57f5709e5673504b609222e042823f195
 #          - name: IMAGE_ADDONS_TKN_CLI_SERVE
 #            value: docker.io/rupali/serve-tkn:v2
 #          - name: IMAGE_ADDONS_PARAM_TKN_IMAGE

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -160,6 +160,35 @@ image-substitutions:
         containerName: openshift-pipelines-operator
         envKeys:
           - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
+- image: registry.redhat.io/rhel8/postgresql-13@sha256:6032adb3eac903ee8aa61f296ca9aaa57f5709e5673504b609222e042823f195
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator
+        envKeys:
+          - IMAGE_HUB_TEKTON_HUB_DB
+- image: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel8@
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator
+        envKeys:
+          - IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
+- image: registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel8@
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator
+        envKeys:
+          - IMAGE_HUB_TEKTON_HUB_API
+- image: registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel8@
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator
+        envKeys:
+          - IMAGE_HUB_TEKTON_HUB_UI
+
 # add thrid party images which are not replaced by operator
 # but pulled directly by tasks here
 defaultRelatedImages: []

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -41,7 +41,7 @@ const (
 	TriggersImagePrefix           = "IMAGE_TRIGGERS_"
 	AddonsImagePrefix             = "IMAGE_ADDONS_"
 	ChainsImagePrefix             = "IMAGE_CHAINS_"
-	HubDbImagePrefix              = "IMAGE_HUB_"
+	HubImagePrefix                = "IMAGE_HUB_"
 
 	ArgPrefix   = "arg_"
 	ParamPrefix = "param_"

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -440,7 +440,7 @@ func (r *Reconciler) setupAndCreateInstallerSet(ctx context.Context, manifestLoc
 
 	manifest = manifest.Filter(mf.Not(mf.Any(mf.ByKind("Secret"), mf.ByKind("Namespace"), mf.ByKind("ConfigMap"))))
 
-	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.HubDbImagePrefix))
+	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.HubImagePrefix))
 	trans := r.extension.Transformers(th)
 	extra := []mf.Transformer{
 		mf.InjectOwner(th),


### PR DESCRIPTION
This will add hub imahe env for db-migration, ui and api
in csv generation config and also add the hub db env in config.yaml
and fix the env name in operator.yaml

Also fixed the image value by putting a specific sha

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```