### PR TITLE
Fixes the db name in transformer in case of openshift

### DIFF
--- a/pkg/reconciler/openshift/tektonhub/extension.go
+++ b/pkg/reconciler/openshift/tektonhub/extension.go
@@ -56,6 +56,7 @@ var replaceVal = map[string]string{
 }
 
 var (
+	db  string = fmt.Sprintf("%s-%s", hubprefix, "db")
 	api string = fmt.Sprintf("%s-%s", hubprefix, "api")
 	ui  string = fmt.Sprintf("%s-%s", hubprefix, "ui")
 )
@@ -227,7 +228,7 @@ func UpdateDbDeployment() mf.Transformer {
 			return err
 		}
 
-		if d.Name == "db" {
+		if d.Name == db {
 			env := d.Spec.Template.Spec.Containers[0].Env
 
 			replaceEnv(env)

--- a/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
+++ b/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
@@ -15,21 +15,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: db
+  name: tekton-hub-db
   labels:
-    app: db
+    app: tekton-hub-db
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: db
+      app: tekton-hub-db
   template:
     metadata:
       labels:
-        app: db
+        app: tekton-hub-db
     spec:
       containers:
-        - name: db
+        - name: tekton-hub-db
           image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
           imagePullPolicy: IfNotPresent
           ports:
@@ -39,22 +39,22 @@ spec:
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: tekton-hub-db
                   key: POSTGRES_DB
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: tekton-hub-db
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: tekton-hub-db
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           volumeMounts:
-            - name: db
+            - name: tekton-hub-db
               mountPath: /var/lib/postgresql/data
           readinessProbe:
             exec:
@@ -69,7 +69,7 @@ spec:
             timeoutSeconds: 2
             periodSeconds: 15
       volumes:
-        - name: db
+        - name: tekton-hub-db
           persistentVolumeClaim:
-            claimName: db
+            claimName: tekton-hub-db
       restartPolicy: Always


### PR DESCRIPTION
As we are adding `tekton-hub` as prefix so in the transformer
we need to check with name as `tekton-hub-db` instead of db,
so this patch changes check with name as `tekton-hub-db`

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```