### PR TITLE
Update Hub docs to add additional info to get all resources

### DIFF
--- a/docs/TektonHub.md
+++ b/docs/TektonHub.md
@@ -2,34 +2,66 @@
 
 TektonHub custom resource allows user to install and manage [Tekton Hub][hub].
 
-TektonHub is an optional component and currently cannot be installed through TektonConfig. It has to be installed seperately. It is available for both Kubernetes and OpenShift platform.
+TektonHub is an optional component and currently cannot be installed through TektonConfig. It has to be installed
+seperately. It is available for both Kubernetes and OpenShift platform.
 
 To install Tekton Hub on your cluster follow steps as given below:
 
-1.  Create the secrets for the API before we install Tekton Hub. By default,
-    Tekton Hub expects this secret to have the following properties:
+1. Update the [config.yaml](https://raw.githubusercontent.com/tektoncd/hub/master/config.yaml) to add one user with all
+   the scopes such as
+    - refresh a catalog
+    - refresh config file
+    - create an agent token
 
-    - namespace: TargetNamespace defined in TektonHub CR at the time of applying. If
-      nothing is specified then based on platform create the secrets. `openshift-pipelines` in case
-      of OpenShift, `tekton-pipelines` in case of Kubernetes.
+   **NOTE**:- You can maintain [config.yaml](https://raw.githubusercontent.com/tektoncd/hub/master/config.yaml) in any
+   repo but make sure it is accessible to the Hub API server or you can either fork the project [Tekton Hub][hub]
+
+   For example:
+    ```
+   scopes:
+   - name: agent:create
+     users: [foo]        <<< Where `foo` is your Github Handle
+   - name: catalog:refresh
+     users: [foo]
+   - name: config:refresh
+     users: [foo]
+      ```
+
+   **NOTE**:-
+    - With the `catalog:refresh` scope user will be able to refresh the catalog and all the resources in db. For more
+      details refere to [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#add-resources-in-db)
+    - With the `agent:create` scope user can setup a cronjob which will refresh your db after an interval if there are
+      any changes in your catalog. For more details
+      refer [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#setup-catalog-refresh-cronjob-optional)
+    - With the `config:refresh` scope user can get additional scopes. For more details
+      refer [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#setup-catalog-refresh-cronjob-optional)
+
+- Commit the changes and push the changes to your fork
+
+
+2. Create the secrets for the API before we install Tekton Hub. By default, Tekton Hub expects this secret to have the
+   following properties:
+
+    - namespace: TargetNamespace defined in TektonHub CR at the time of applying. If nothing is specified then based on
+      platform create the secrets. `openshift-pipelines` in case of OpenShift, `tekton-pipelines` in case of Kubernetes.
     - name: `api`
     - contains the fields:
 
-      - `GH_CLIENT_ID=<github-client-id>`
-      - `GH_CLIENT_SECRET=<github-client-secret>`
-      - `GL_CLIENT_ID=<gitlab-client-id>`
-      - `GL_CLIENT_SECRET=<gitlab-client-secret>`
-      - `BB_CLIENT_ID=<bitbucket-client-id>`
-      - `BB_CLIENT_SECRET=<bitbucket-client-secret>`
-      - `JWT_SIGNING_KEY=<jwt-signing-key>`
-      - `ACCESS_JWT_EXPIRES_IN=<time(eg 30d)>`
-      - `REFRESH_JWT_EXPIRES_IN=<time(eg 30d)>`
-      - `GHE_URL=<github enterprise url(leave it blank if not using github enterprise>`
-      - `GLE_URL=<gitlab enterprise url(leave it blank if not using gitlab enterprise>`
+        - `GH_CLIENT_ID=<github-client-id>`
+        - `GH_CLIENT_SECRET=<github-client-secret>`
+        - `GL_CLIENT_ID=<gitlab-client-id>`
+        - `GL_CLIENT_SECRET=<gitlab-client-secret>`
+        - `BB_CLIENT_ID=<bitbucket-client-id>`
+        - `BB_CLIENT_SECRET=<bitbucket-client-secret>`
+        - `JWT_SIGNING_KEY=<jwt-signing-key>`
+        - `ACCESS_JWT_EXPIRES_IN=<time(eg 30d)>`
+        - `REFRESH_JWT_EXPIRES_IN=<time(eg 30d)>`
+        - `GHE_URL=<github enterprise url(leave it blank if not using github enterprise>`
+        - `GLE_URL=<gitlab enterprise url(leave it blank if not using gitlab enterprise>`
 
-    > _Note 1_: For more details please refer to [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#create-git-oauth-applications)
+   > _Note 1_: For more details please refer to [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#create-git-oauth-applications)
 
-1.  Once the secrets are created now we need to understand how TektonHub CR looks.
+3. Once the secrets are created now we need to understand how TektonHub CR looks.
 
     ```yaml
     apiVersion: operator.tekton.dev/v1alpha1
@@ -41,22 +73,22 @@ To install Tekton Hub on your cluster follow steps as given below:
       # <namespace> in which you want to install Tekton Hub. Leave it blank if in case you want to install
       # in default installation namespace ie `openshift-pipelines` in case of OpenShift and `tekton-pipelines` in case of Kubernetes
       api:
-        hubConfigUrl: https://raw.githubusercontent.com/tektoncd/hub/main/config.yaml
+        hubConfigUrl: https://raw.githubusercontent.com/tektoncd/hub/main/config.yaml # 👈 MUST: Change the file URL here to point to your fork
     ```
 
-    ### API
+   ### API
 
-    The following field helps to configure the API deployment. Provided fields are:
+   The following field helps to configure the API deployment. Provided fields are:
 
     - `hubConfigUrl`: The place of Tekton Hub config url as shown above.
 
-1.  After configuring the TektonHub spec you can install Tekton Hub by running the command
+4. After configuring the TektonHub spec you can install Tekton Hub by running the command
 
     ```sh
     kubectl apply -f <name>.yaml
     ```
 
-1.  Check the status of installation using following command
+5. Check the status of installation using following command
 
     ```sh
     $ kubectl get tektonhub.operator.tekton.dev


### PR DESCRIPTION
When Hub CR is created and once Hub is up and running, user
wont't see any resource on Hub UI because Hub Db doesn't have
any resources

Hence this patch adds and points to the docs regarding how user
can add the resources in Db

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
