### PR TITLE
Fixes the value for `REDIRECT_URI` in the Hub UI configMap

### DIFF
--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -425,7 +425,7 @@ func createUiConfigMap(name, namespace string, th *v1alpha1.TektonHub) *corev1.C
 			"API_URL":       th.Status.ApiRouteUrl,
 			"AUTH_BASE_URL": th.Status.AuthRouteUrl,
 			"API_VERSION":   "v1",
-			"REDIRECT_URI":  "https://" + th.Status.UiRouteUrl,
+			"REDIRECT_URI":  th.Status.UiRouteUrl,
 		},
 	}
 }


### PR DESCRIPTION
Currently `REDIREC_URI` was set as `https://` + `UI status URL`,
but while creating the ui routes in the pre-reconciler,
`https://` is already added,

This patch fixes the value by just setting the value as the UI status URL

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
