### PR TITLE
Creates the operator version configMap in the operator namespace

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -29,3 +29,4 @@ resources:
 - operator.yaml
 - tekton_config_role.yaml
 - tekton_config_role_binding.yaml
+- operator-config.yaml

--- a/config/base/operator-config.yaml
+++ b/config/base/operator-config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-operator-info
+  labels:
+    app.kubernetes.io/instance: default
+data:
+  # Contains operator version which can be queried by external
+  # tools such as CLI.
+  version: 'devel'

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -372,9 +372,6 @@ func (r *Reconciler) targetNamespaceCheck(ctx context.Context, tp *v1alpha1.Tekt
 			if err := common.CreateTargetNamespace(ctx, labels, tp, r.kubeClientSet); err != nil {
 				return err
 			}
-			if err := common.CreateOperatorVersionConfigMap(r.manifest, tp); err != nil {
-				return err
-			}
 			return nil
 		}
 		return err

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -104,10 +104,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 		return err
 	}
 
-	if err := common.CreateOperatorVersionConfigMap(r.manifest, tc); err != nil {
-		return err
-	}
-
 	if err := r.extension.PreReconcile(ctx, tc); err != nil {
 		if err == v1alpha1.RECONCILE_AGAIN_ERR {
 			r.enqueueAfter(tc, 10*time.Second)


### PR DESCRIPTION
Initially the operator version configMap was created in the targetNs,
assuming that it will be easier for users and tools to find version
information

But this is confusing as most of our users expect the configMap to be
in the namespace where the operator is installed, hence this patch
creates the configMap in the namespace where the operator is installed

Fixes: #670 

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
