### PR TITLE
adds missing provider lablels in the clustertasks

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/clustertTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTask.go
@@ -77,6 +77,7 @@ func (r *Reconciler) ensureClusterTasks(ctx context.Context, ta *v1alpha1.Tekton
 	// Run transformers
 	tfs := []mf.Transformer{
 		replaceKind(KindTask, KindClusterTask),
+		injectLabel(labelProviderType, providerTypeRedHat, overwrite, "ClusterTask"),
 	}
 	if err := r.addonTransform(ctx, &clusterTaskManifest, ta, tfs...); err != nil {
 		return err

--- a/pkg/reconciler/openshift/tektonaddon/clustertTaskVersioned.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTaskVersioned.go
@@ -90,6 +90,7 @@ func (r *Reconciler) ensureVersionedClusterTasks(ctx context.Context, ta *v1alph
 	// Run transformers
 	tfs := []mf.Transformer{
 		replaceKind(KindTask, KindClusterTask),
+		injectLabel(labelProviderType, providerTypeRedHat, overwrite, "ClusterTask"),
 		setVersionedNames(r.operatorVersion),
 	}
 	if err := r.addonTransform(ctx, &clusterTaskManifest, ta, tfs...); err != nil {


### PR DESCRIPTION
this adds missing label `operator.tekton.dev/provider-type` to all
the redhat provided cluster tasks

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
