### PR TITLE
Refactor TektonResults to use TektonInstallerSets

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonresult_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_lifecycle.go
@@ -25,13 +25,17 @@ var (
 	_              TektonComponentStatus = (*TektonResultStatus)(nil)
 	resultsCondSet                       = apis.NewLivingConditionSet(
 		DependenciesInstalled,
-		DeploymentsAvailable,
-		InstallSucceeded,
+		InstallerSetAvailable,
+		InstallerSetReady,
 	)
 )
 
 // GroupVersionKind returns SchemeGroupVersion of a TektonResult
 func (tr *TektonResult) GroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(KindTektonResult)
+}
+
+func (tr *TektonResult) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(KindTektonResult)
 }
 
@@ -50,36 +54,35 @@ func (trs *TektonResultStatus) IsReady() bool {
 	return resultsCondSet.Manage(trs).IsHappy()
 }
 
-// MarkInstallSucceeded marks the InstallationSucceeded status as true.
-func (trs *TektonResultStatus) MarkInstallSucceeded() {
-	resultsCondSet.Manage(trs).MarkTrue(InstallSucceeded)
-	if trs.GetCondition(DependenciesInstalled).IsUnknown() {
-		// Assume deps are installed if we're not sure
-		trs.MarkDependenciesInstalled()
-	}
-}
-
-// MarkInstallFailed marks the InstallationSucceeded status as false with the given
-// message.
-func (trs *TektonResultStatus) MarkInstallFailed(msg string) {
+func (trs *TektonResultStatus) MarkNotReady(msg string) {
 	resultsCondSet.Manage(trs).MarkFalse(
-		InstallSucceeded,
+		apis.ConditionReady,
 		"Error",
-		"Install failed with message: %s", msg)
+		"Ready: %s", msg)
 }
 
-// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
-func (trs *TektonResultStatus) MarkDeploymentsAvailable() {
-	resultsCondSet.Manage(trs).MarkTrue(DeploymentsAvailable)
+func (trs *TektonResultStatus) MarkInstallerSetAvailable() {
+	resultsCondSet.Manage(trs).MarkTrue(InstallerSetAvailable)
 }
 
-// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
-// it's waiting for deployments.
-func (trs *TektonResultStatus) MarkDeploymentsNotReady() {
+func (trs *TektonResultStatus) MarkInstallerSetNotAvailable(msg string) {
+	trs.MarkNotReady("TektonInstallerSet not ready")
 	resultsCondSet.Manage(trs).MarkFalse(
-		DeploymentsAvailable,
-		"NotReady",
-		"Waiting on deployments")
+		InstallerSetAvailable,
+		"Error",
+		"Installer set not ready: %s", msg)
+}
+
+func (trs *TektonResultStatus) MarkInstallerSetReady() {
+	resultsCondSet.Manage(trs).MarkTrue(InstallerSetReady)
+}
+
+func (trs *TektonResultStatus) MarkInstallerSetNotReady(msg string) {
+	trs.MarkNotReady("TektonInstallerSet not ready")
+	resultsCondSet.Manage(trs).MarkFalse(
+		InstallerSetReady,
+		"Error",
+		"Installer set not ready: %s", msg)
 }
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.
@@ -105,6 +108,14 @@ func (trs *TektonResultStatus) MarkDependencyMissing(msg string) {
 		"Dependency missing: %s", msg)
 }
 
+func (trs *TektonResultStatus) GetTektonInstallerSet() string {
+	return trs.TektonInstallerSet
+}
+
+func (trs *TektonResultStatus) SetTektonInstallerSet(installerSet string) {
+	trs.TektonInstallerSet = installerSet
+}
+
 // GetVersion gets the currently installed version of the component.
 func (trs *TektonResultStatus) GetVersion() string {
 	return trs.Version
@@ -115,12 +126,29 @@ func (trs *TektonResultStatus) SetVersion(version string) {
 	trs.Version = version
 }
 
-// GetManifests gets the url links of the manifests.
-func (trs *TektonResultStatus) GetManifests() []string {
-	return trs.Manifests
+// MarkInstallSucceeded marks the InstallationSucceeded status as true.
+func (trs *TektonResultStatus) MarkInstallSucceeded() {
+	panic("implement me")
 }
 
-// SetManifests sets the url links of the manifests.
-func (trs *TektonResultStatus) SetManifests(manifests []string) {
-	trs.Manifests = manifests
+// MarkInstallFailed marks the InstallationSucceeded status as false with the given
+// message.
+func (trs *TektonResultStatus) MarkInstallFailed(msg string) {
+	panic("implement me")
+}
+
+// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
+func (trs *TektonResultStatus) MarkDeploymentsAvailable() {
+	panic("implement me")
+}
+
+// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
+// it's waiting for deployments.
+func (trs *TektonResultStatus) MarkDeploymentsNotReady() {
+	panic("implement me")
+}
+
+// GetManifests gets the url links of the manifests.
+func (trs *TektonResultStatus) GetManifests() []string {
+	panic("Implement me")
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -62,9 +62,9 @@ type TektonResultStatus struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
-	// The url links of the manifests, separated by comma
+	// The current installer set name for TektonResult
 	// +optional
-	Manifests []string `json:"manifests,omitempty"`
+	TektonInstallerSet string `json:"tektonInstallerSet,omitempty"`
 }
 
 // TektonResultsList contains a list of TektonResult

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1199,11 +1199,6 @@ func (in *TektonResultSpec) DeepCopy() *TektonResultSpec {
 func (in *TektonResultStatus) DeepCopyInto(out *TektonResultStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.Manifests != nil {
-		in, out := &in.Manifests, &out.Manifests
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -46,6 +46,7 @@ var (
 	jobPred                            = mf.ByKind("Job")
 	secretPred                         = mf.ByKind("Secret")
 	deploymentPred                     = mf.ByKind("Deployment")
+	statefulSetPred                    = mf.ByKind("StatefulSet")
 	servicePred                        = mf.ByKind("Service")
 	serviceAccountPred                 = mf.ByKind("ServiceAccount")
 	cronJobPred                        = mf.ByKind("CronJob")
@@ -151,6 +152,7 @@ func (i *installer) EnsureNamespaceScopedResources() error {
 			triggerTemplatePred,
 			servicePred,
 			routePred,
+			statefulSetPred,
 		))
 	return ensureResources(&resourceList)
 }

--- a/pkg/reconciler/kubernetes/tektonresult/controller.go
+++ b/pkg/reconciler/kubernetes/tektonresult/controller.go
@@ -24,6 +24,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
+	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineInformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonResultInformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonresult"
 	tektonResultReconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonresult"
@@ -31,7 +32,6 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	deploymentInformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -59,21 +59,31 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating initial manifest", zap.Error(err))
 		}
 
+		operatorVer, err := common.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		if err := common.AppendTarget(ctx, &manifest, &v1alpha1.TektonResult{}); err != nil {
+			logger.Fatalw("Error fetching manifests", zap.Error(err))
+		}
+
 		c := &Reconciler{
 			kubeClientSet:     kubeclient.Get(ctx),
 			operatorClientSet: operatorclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
 			pipelineInformer:  tektonPipelineInformer.Get(ctx),
+			operatorVersion:   operatorVer,
 		}
 		impl := tektonResultReconciler.NewImpl(ctx, c)
 
-		logger.Info("Setting up event handlers")
+		logger.Info("Setting up event handlers for tekton-results")
 
 		tektonResultInformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-		deploymentInformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("TektonResult")),
+		tektonInstallerinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: controller.FilterController(&v1alpha1.TektonResult{}),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 

--- a/pkg/reconciler/kubernetes/tektonresult/installerset.go
+++ b/pkg/reconciler/kubernetes/tektonresult/installerset.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonresult
+
+import (
+	"context"
+	"fmt"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.TektonResult) (*v1alpha1.TektonInstallerSet, error) {
+
+	if err := r.transform(ctx, &r.manifest, tr); err != nil {
+		tr.Status.MarkNotReady("transformation failed: " + err.Error())
+		return nil, err
+	}
+
+	// compute the hash of tektonresult spec and store as an annotation
+	// in further reconciliation we compute hash of td spec and check with
+	// annotation, if they are same then we skip updating the object
+	// otherwise we update the manifest
+	specHash, err := hash.Compute(tr.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// create installer set
+	tis := r.makeInstallerSet(tr, r.manifest, specHash)
+	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		Create(ctx, tis, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return createdIs, nil
+}
+
+func (r *Reconciler) makeInstallerSet(tr *v1alpha1.TektonResult, manifest mf.Manifest, trSpecHash string) *v1alpha1.TektonInstallerSet {
+	ownerRef := *metav1.NewControllerRef(tr, tr.GetGroupVersionKind())
+	return &v1alpha1.TektonInstallerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", v1alpha1.ResultResourceName),
+			Labels: map[string]string{
+				v1alpha1.CreatedByKey:      createdByValue,
+				v1alpha1.InstallerSetType:  v1alpha1.ResultResourceName,
+				v1alpha1.ReleaseVersionKey: r.operatorVersion,
+			},
+			Annotations: map[string]string{
+				v1alpha1.TargetNamespaceKey: tr.Spec.TargetNamespace,
+				v1alpha1.LastAppliedHashKey: trSpecHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.TektonInstallerSetSpec{
+			Manifests: manifest.Resources(),
+		},
+	}
+}


### PR DESCRIPTION
# Changes

Since Tekton Operator is using TektonInstallerSets for reconciling all the
components shipped by it except for TektonResults, hence this PR
addresses that.

closes #548 

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
refactoring tektonresults to use the tektoninstallersets
```