### PR TITLE
Remove redundant 'UpdateStatus()' calls

### DIFF
--- a/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
@@ -304,16 +304,7 @@ func (r *Reconciler) updateTektonDashboardStatus(ctx context.Context, td *v1alph
 	// update the td with TektonInstallerSet and releaseVersion
 	td.Status.SetTektonInstallerSet(createdIs.Name)
 	td.Status.SetVersion(r.dashboardVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonDashboards().
-		UpdateStatus(ctx, td, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return v1alpha1.RECONCILE_AGAIN_ERR
+	return nil
 }
 
 // transform mutates the passed manifest to one with common, component

--- a/pkg/reconciler/kubernetes/tektonhub/installerset.go
+++ b/pkg/reconciler/kubernetes/tektonhub/installerset.go
@@ -72,13 +72,6 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, th *v1alpha
 	// Update the status of addon with created installerSet name
 	th.Status.HubInstallerSet[component] = createdIs.Name
 	th.Status.SetVersion(releaseVersion)
-
-	_, err = oc.OperatorV1alpha1().TektonHubs().
-		UpdateStatus(ctx, th, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -18,7 +18,6 @@ package tektonpipeline
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"time"
 
@@ -312,16 +311,7 @@ func (r *Reconciler) updateTektonPipelineStatus(ctx context.Context, tp *v1alpha
 	// update the tp with TektonInstallerSet and releaseVersion
 	tp.Status.SetTektonInstallerSet(createdIs.Name)
 	tp.Status.SetVersion(r.pipelineVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonPipelines().
-		UpdateStatus(ctx, tp, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring Reconcile TektonPipeline status update")
+	return nil
 }
 
 func (r *Reconciler) createInstallerSet(ctx context.Context, tp *v1alpha1.TektonPipeline) (*v1alpha1.TektonInstallerSet, error) {

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -18,7 +18,6 @@ package tektontrigger
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"time"
 
@@ -346,16 +345,7 @@ func (r *Reconciler) updateTektonTriggerStatus(ctx context.Context, tt *v1alpha1
 	// update the tt with TektonInstallerSet and releaseVersion
 	tt.Status.SetTektonInstallerSet(createdIs.Name)
 	tt.Status.SetVersion(r.triggersVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonTriggers().
-		UpdateStatus(ctx, tt, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring Reconcile TektonTrigger status update")
+	return nil
 }
 
 func (r *Reconciler) createInstallerSet(ctx context.Context, tt *v1alpha1.TektonTrigger) (*v1alpha1.TektonInstallerSet, error) {

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -18,14 +18,12 @@ package tektonpipeline
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -112,16 +110,9 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha
 		tp.Status.ExtentionInstallerSets = map[string]string{}
 	}
 
-	// Update the status of pipeline with created installerSet name
+	//// Update the status of pipeline with created installerSet name
 	tp.Status.ExtentionInstallerSets[component] = createdIs.Name
-
-	_, err = oc.OperatorV1alpha1().TektonPipelines().
-		UpdateStatus(ctx, tp, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring TektonPipeline status update")
+	return nil
 }
 
 func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, installerSetType, releaseVersion string) *v1alpha1.TektonInstallerSet {
@@ -160,10 +151,5 @@ func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha
 
 	// clear the name of installer set from TektonPipeline status
 	delete(ta.Status.ExtentionInstallerSets, component)
-	_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	return nil
 }


### PR DESCRIPTION
Remove redundant UpdateStatus calls as UpdateStaus api call is carried
out by knative/pkg generated code at the end of each reconcile loop

The removal of these explicit call has no functional effect on the
exising behavior

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```