### PR TITLE
'is not' should not be used for int comparison

### DIFF
--- a/operatorhub/tools/bundle.py
+++ b/operatorhub/tools/bundle.py
@@ -305,6 +305,6 @@ if __name__ == "__main__":
     divider("BundleGen")
     config = buildConfig()
     return_code = generate_bundle(config)
-    if return_code is not 0:
+    if return_code != 0:
         exit(return_code)
     newCSVmods(config)


### PR DESCRIPTION
# Changes

'is not' should not be used for int comparison
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
