### PR TITLE
Use CI image `ko` instead of trying to install it

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -40,7 +40,7 @@ function install_operator_resources() {
 
   echo ">> Deploying Tekton Operator Resources"
 
-  make TARGET=${TARGET:-kubernetes} apply || fail_test "Tekton Operator installation failed"
+  make KO_BIN=$(which ko) KUSTOMIZE_BIN=$(which kustomize) TARGET=${TARGET:-kubernetes} apply || fail_test "Tekton Operator installation failed"
 
   OPERATOR_NAMESPACE="tekton-operator"
   [[ "${TARGET}" == "openshift" ]] && OPERATOR_NAMESPACE="openshift-operators"


### PR DESCRIPTION

# Changes

Use CI image ko instead of trying to install it, as it's already present in the image.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
