### PR TITLE
Freeze ko version to v0.9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,13 @@ export GO111MODULE=on
 $(BIN):
 	@mkdir -p $@
 $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
-	$Q tmp=$$(mktemp -d); \
-	   env GO111MODULE=off GOPATH=$$tmp GOBIN=$(BIN) $(GO) get $(PACKAGE) \
+	$Q tmp=$$(mktemp -d); cd $$tmp; \
+  		env GO111MODULE=on GOPATH=$$tmp GOBIN=$(BIN) $(GO) get $(PACKAGE) \
 		|| ret=$$?; \
-	   rm -rf $$tmp ; exit $$ret
+  		env GO111MODULE=on GOPATH=$$tmp GOBIN=$(BIN) $(GO) clean -modcache \
+        || ret=$$?; \
+		cd - ; \
+	  	rm -rf $$tmp ; exit $$ret
 
 KO = $(or ${KO_BIN},${KO_BIN},$(BIN)/ko)
 
@@ -38,7 +41,9 @@ PAC_VERSION ?= 0.5.4
 TEKTON_HUB_VERSION ?= v1.7.0 # latest doesn't returns any version hence hard coding to v1.7.0 for now
 TEKTON_CHAINS_VERSION ?= latest
 
-$(BIN)/ko: PACKAGE=github.com/google/ko
+# TODO: after updating go version to 1.17 uncommnent the line below to install latest version of ko
+# $(BIN)/ko: PACKAGE=github.com/google/ko
+$(BIN)/ko: PACKAGE=github.com/google/ko@v0.9.3
 
 KUSTOMIZE = $(or ${KUSTOMIZE_BIN},${KUSTOMIZE_BIN},$(BIN)/kustomize)
 $(BIN)/kustomize: | $(BIN) ; $(info $(M) getting kustomize)


### PR DESCRIPTION
Freeze ko version to v0.9.3 as latest version fails to build on
go 1.16.13

Use `GO111MODULE=on` as `@version` syntax in go get will not work in
non GO mod

`go: can only use path@version syntax with 'go get' and 'go install' in
module-aware mode`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->
```release-note
NONE
```