### PR TITLE
[Cherry-pick] Removes security context for Hub Api deployment in case of openshift

### DIFF
--- a/pkg/reconciler/openshift/common/testdata/test-remove-fs-group-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fs-group-expected.yaml
@@ -1,0 +1,51 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-hub-api
+  labels:
+    app: tekton-hub-api
+spec:
+  selector:
+    matchLabels:
+      app: tekton-hub-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-hub-api
+    spec:
+      volumes:
+      - name: catalog-source
+        persistentVolumeClaim:
+          claimName: tekton-hub-api
+      - name: ssh-creds
+        secret:
+          secretName: tekton-hub-api-ssh-crds
+          optional: true
+      securityContext:
+        fsGroup: 101
+      containers:
+        - name: tekton-hub-api
+          image: quay.io/tekton-hub/api
+          volumeMounts:
+          - name: catalog-source
+            mountPath: "/tmp/catalog"
+          - name: ssh-creds
+            mountPath: "/home/hub/.ssh"
+          ports:
+            - containerPort: 8000
+            - containerPort: 4200

--- a/pkg/reconciler/openshift/common/testdata/test-remove-fs-group.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fs-group.yaml
@@ -1,0 +1,49 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-hub-api
+  labels:
+    app: tekton-hub-api
+spec:
+  selector:
+    matchLabels:
+      app: tekton-hub-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-hub-api
+    spec:
+      volumes:
+      - name: catalog-source
+        persistentVolumeClaim:
+          claimName: tekton-hub-api
+      - name: ssh-creds
+        secret:
+          secretName: tekton-hub-api-ssh-crds
+          optional: true
+      containers:
+        - name: tekton-hub-api
+          image: quay.io/tekton-hub/api
+          volumeMounts:
+          - name: catalog-source
+            mountPath: "/tmp/catalog"
+          - name: ssh-creds
+            mountPath: "/home/hub/.ssh"
+          ports:
+            - containerPort: 8000
+            - containerPort: 4200

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -84,3 +84,34 @@ func RemoveRunAsGroup() mf.Transformer {
 		return nil
 	}
 }
+
+// RemoveFsGroup will remove FsGroup in a deployment
+func RemoveFsGroup(obj string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Deployment" {
+			return nil
+		}
+
+		d := &appsv1.Deployment{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, d)
+		if err != nil {
+			return err
+		}
+
+		if d.Name == obj {
+			if d.Spec.Template.Spec.SecurityContext != nil {
+				d.Spec.Template.Spec.SecurityContext = nil
+			}
+
+			unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+			if err != nil {
+				return err
+			}
+			u.SetUnstructuredContent(unstrObj)
+
+			return nil
+		}
+
+		return nil
+	}
+}

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -118,3 +118,32 @@ func TestUpdateDeploymentsInterceptor(t *testing.T) {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
 	}
 }
+
+func TestRemoveFsGroup(t *testing.T) {
+	testData := path.Join("testdata", "test-remove-fs-group.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-remove-fs-group-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := expectedManifest.Transform(RemoveFsGroup("tekton-hub-api"))
+	assert.NilError(t, err)
+
+	got := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, got)
+	if err != nil {
+		t.Errorf("failed to load deployment yaml")
+	}
+
+	expected := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, expected)
+	if err != nil {
+		t.Errorf("failed to load deployment yaml")
+	}
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
+	}
+}

--- a/pkg/reconciler/openshift/tektonhub/extension.go
+++ b/pkg/reconciler/openshift/tektonhub/extension.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	openshiftCommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -88,7 +89,7 @@ type openshiftExtension struct {
 }
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{UpdateDbDeployment()}
+	return []mf.Transformer{UpdateDbDeployment(), openshiftCommon.RemoveFsGroup(api)}
 }
 
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {


### PR DESCRIPTION
With Hub v1.7.1 release SecurityContext of fsGroup with id 101 is added,
because the pod didn't have permissions to create a new directory,
but this SecurityContext is not supported by Openshift

Hence this patch removes the SecurityContext using a transformer as
the pod has the permissions already to create a directory

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
