### PR TITLE
Set release and version labels in operator resources to v0.55.1

### DIFF
--- a/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
+++ b/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
@@ -86,8 +86,8 @@ metadata:
   name: tekton-operator-proxy-webhook
   namespace: tekton-pipelines
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   replicas: 1
   selector:
@@ -129,8 +129,8 @@ metadata:
   name: tekton-operator-proxy-webhook
   namespace: tekton-pipelines
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   ports:
     - name: https-webhook

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -86,8 +86,8 @@ metadata:
   name: tekton-operator-proxy-webhook
   namespace: tekton-pipelines
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   replicas: 1
   selector:
@@ -128,8 +128,8 @@ metadata:
   name: tekton-operator-proxy-webhook
   namespace: tekton-pipelines
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   ports:
     - name: https-webhook

--- a/config/base/300-operator_v1alpha1_chain_crd.yaml
+++ b/config/base/300-operator_v1alpha1_chain_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonchains.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_config_crd.yaml
+++ b/config/base/300-operator_v1alpha1_config_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonconfigs.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_hub_crd.yaml
+++ b/config/base/300-operator_v1alpha1_hub_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonhubs.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_installer_set_crd.yaml
+++ b/config/base/300-operator_v1alpha1_installer_set_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektoninstallersets.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_pipeline_crd.yaml
+++ b/config/base/300-operator_v1alpha1_pipeline_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonpipelines.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_trigger_crd.yaml
+++ b/config/base/300-operator_v1alpha1_trigger_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektontriggers.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/operator.yaml
+++ b/config/base/operator.yaml
@@ -17,6 +17,6 @@ kind: Deployment
 metadata:
   name: tekton-operator
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec: {}

--- a/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
+++ b/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektondashboards.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/kubernetes/base/300-operator_v1alpha1_result_crd.yaml
+++ b/config/kubernetes/base/300-operator_v1alpha1_result_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonresults.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/kubernetes/base/operator.yaml
+++ b/config/kubernetes/base/operator.yaml
@@ -50,7 +50,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/operator
         - name: VERSION
-          value: "devel"
+          value: v0.55.1
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
         - name: AUTOINSTALL_COMPONENTS

--- a/config/kubernetes/base/operator_service.yaml
+++ b/config/kubernetes/base/operator_service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    version: "devel"
+    version: v0.55.1
     app: tekton-pipelines-controller
   name: tekton-operator
 spec:

--- a/config/kubernetes/base/webhook.yaml
+++ b/config/kubernetes/base/webhook.yaml
@@ -17,8 +17,8 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   replicas: 1
   selector:

--- a/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
+++ b/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonaddons.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   group: operator.tekton.dev
   names:

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -51,7 +51,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/operator
         - name: VERSION
-          value: "devel"
+          value: v0.55.1
         - name: AUTOINSTALL_COMPONENTS
           valueFrom:
             configMapKeyRef:

--- a/config/openshift/base/operator_service.yaml
+++ b/config/openshift/base/operator_service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    version: "devel"
+    version: v0.55.1
     name: openshift-pipelines-operator
   name: tekton-operator
 spec:

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -17,8 +17,8 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec:
   replicas: 1
   selector:

--- a/config/webhooks/webhook-service.yaml
+++ b/config/webhooks/webhook-service.yaml
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
     name: tekton-operator-webhook
     app: tekton-operator
 spec:

--- a/config/webhooks/webhook.yaml
+++ b/config/webhooks/webhook.yaml
@@ -17,6 +17,6 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: v0.55.1
+    operator.tekton.dev/release: v0.55.1
 spec: {}

--- a/hack/release-common.sh
+++ b/hack/release-common.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -u
+
+function set_version_label() {
+  local operator_version="v${1}"
+
+  shift
+  local operator_platforms=${*:-"kubernetes openshift"}
+
+  echo ${operator_platforms}
+  printf "%-20s: %s\n" "Platforms" "${operator_platforms}"
+  printf "%-20s: %s\n" "Operator version" "${operator_version}"
+  echo '---------------------'
+  for platform in ${operator_platforms}; do
+    echo updating version labels for platform: ${platform}, version: ${operator_version}
+    sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' config/base/*.yaml
+    sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' config/webhooks/*.yaml
+    sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' config/${platform}/base/*.yaml
+    sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' config/${platform}/overlays/default/*.yaml
+    sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' cmd/${platform}/operator/kodata/webhook/*.yaml
+    sed -i 's/\(value\): "devel"/\1: '${operator_version}'/g' config/${platform}/base/operator.yaml
+  done
+}

--- a/hack/release-setup-branch.sh
+++ b/hack/release-setup-branch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -u
+
+source ./hack/release-common.sh
+
+OPERATOR_RELEASE_VERSION=${1}
+set_version_label ${OPERATOR_RELEASE_VERSION}


### PR DESCRIPTION
# Changes
- Repalace all version and release labels with 'v0.55.1'
- Add a script to replace verion labels during a release
- Add a script to replace all version and release related labels to the
    release version

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```