### PR TITLE
[openshift] Use label selectors to find RBAC instalelr set name

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -50,7 +50,17 @@ const (
 	namespaceVersionLabel    = "openshift-pipelines.tekton.dev/namespace-reconcile-version"
 	createdByValue           = "RBAC"
 	componentNameRBAC        = "rhosp-rbac"
+	rbacInstallerSetType     = "rhosp-rbac"
 	rbacParamName            = "createRbacResource"
+)
+
+var (
+	rbacInstallerSetSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			v1alpha1.CreatedByKey:     createdByValue,
+			v1alpha1.InstallerSetType: componentNameRBAC,
+		},
+	}
 )
 
 // Namespace Regex to ignore the namespace for creating rbac resources.
@@ -105,9 +115,7 @@ func (r *rbac) EnsureRBACInstallerSet(ctx context.Context) (*v1alpha1.TektonInst
 		return nil, err
 	}
 
-	err = createInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, map[string]string{
-		v1alpha1.CreatedByKey: createdByValue,
-	}, r.version, componentNameRBAC, "rbac-resources")
+	err = createInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, r.version, componentNameRBAC, "rbac-resources")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use labelselector based list query to find the existing RBAC installerset
name, instead of looking it up from a map in tektonconfig.status.

Kubernetes being "optimistically consistent", we cannot guarantee that
the value in tektonconfig.status will be updated within a predictable
time or that whether/when the update might pass or fail.

List queries based on label selectors is more reliable

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```