### PR TITLE
[openshift] Add an explicit login function in 'sha' fetch script

### DIFF
--- a/hack/openshift/update-image-sha.sh
+++ b/hack/openshift/update-image-sha.sh
@@ -51,6 +51,10 @@ declare -A IMAGES=(
   ["ubi-minimal"]="registry.redhat.io/ubi8/ubi-minimal"
 )
 
+registry_login() {
+  podman login --username=${USERNAME} --password=${PASSWORD} registry.redhat.io
+}
+
 find_latest_versions() {
   local image_registry=${1:-""}
   local latest_version=""
@@ -74,7 +78,7 @@ update_image_sha() {
 
 
 main() {
-
+  registry_login
   for image in ${!IMAGES[@]}; do
     latest_version=$(find_latest_versions ${IMAGES[$image]})
     echo latest_version=$latest_version


### PR DESCRIPTION
Add an explicit login function to the script to ensure valid credentials
for accessing redhat.io.

This doesn't add any change in script invocation as we already have to
pass redhat.io registry username and password for manifeset-tool

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```