### PR TITLE
Update tkn, pac ConsoleCLIDownload links to 0.23.1

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/04-consolecli/console_cli_download_tkn.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/04-consolecli/console_cli_download_tkn.yaml
@@ -5,14 +5,3 @@ metadata:
 spec:
   description: The OpenShift Pipeline client `tkn` is a CLI tool that allows you to manage OpenShift Pipeline resources.
   displayName: tkn - OpenShift Pipeline Command Line Interface (CLI)
-  links:
-    - href: https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-amd64-0.17.2.tar.gz
-      text: Download tkn for Linux
-    - href: https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-macos-amd64-0.17.2.tar.gz
-      text: Download tkn for Mac
-    - href: https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-windows-amd64-0.17.2.zip
-      text: Download tkn for Windows
-    - href: https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-ppc64le-0.17.2.tar.gz
-      text: Download tkn for IBM Power
-    - href: https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-s390x-0.17.2.tar.gz
-      text: Download tkn for IBM Z

--- a/pkg/reconciler/openshift/tektonaddon/extension.go
+++ b/pkg/reconciler/openshift/tektonaddon/extension.go
@@ -249,6 +249,8 @@ func addonTransform(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.Te
 }
 
 func consoleCLITransform(ctx context.Context, manifest *mf.Manifest, baseURL string) error {
+	tknVersion := "0.23.1"
+
 	if baseURL == "" {
 		return fmt.Errorf("route url should not be empty")
 	}
@@ -256,7 +258,7 @@ func consoleCLITransform(ctx context.Context, manifest *mf.Manifest, baseURL str
 	logger.Debug("Transforming manifest")
 
 	transformers := []mf.Transformer{
-		replaceURLCCD(baseURL),
+		replaceURLCCD(baseURL, tknVersion),
 	}
 
 	transformManifest, err := manifest.Transform(transformers...)

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
@@ -6,13 +6,23 @@ spec:
   description: The OpenShift Pipeline client `tkn` is a CLI tool that allows you to manage OpenShift Pipeline resources.
   displayName: tkn - OpenShift Pipeline Command Line Interface (CLI)
   links:
-    - href: https://testserver.com/tkn/tkn-linux-amd64-0.21.0.tar.gz
+    - href: https://testserver.com/tkn/tkn-linux-amd64-1.2.3.tar.gz
       text: Download tkn for Linux
-    - href: https://testserver.com/tkn/tkn-linux-ppc64le-0.21.0.tar.gz
+    - href: https://testserver.com/tkn/tkn-pac-linux-amd64-1.2.3.tar.gz
+      text: Download tkn-pac for Linux
+    - href: https://testserver.com/tkn/tkn-linux-ppc64le-1.2.3.tar.gz
       text: Download tkn for IBM Power
-    - href: https://testserver.com/tkn/tkn-linux-s390x-0.21.0.tar.gz
+    - href: https://testserver.com/tkn/tkn-pac-linux-ppc64le-1.2.3.tar.gz
+      text: Download tkn-pac for IBM Power
+    - href: https://testserver.com/tkn/tkn-linux-s390x-1.2.3.tar.gz
       text: Download tkn for IBM Z
-    - href: https://testserver.com/tkn/tkn-macos-amd64-0.21.0.tar.gz
+    - href: https://testserver.com/tkn/tkn-pac-linux-s390x-1.2.3.tar.gz
+      text: Download tkn-pac for IBM Z
+    - href: https://testserver.com/tkn/tkn-macos-amd64-1.2.3.tar.gz
       text: Download tkn for Mac
-    - href: https://testserver.com/tkn/tkn-windows-amd64-0.21.0.zip
+    - href: https://testserver.com/tkn/tkn-pac-macos-amd64-1.2.3.tar.gz
+      text: Download tkn-pac for Mac
+    - href: https://testserver.com/tkn/tkn-windows-amd64-1.2.3.zip
       text: Download tkn for Windows
+    - href: https://testserver.com/tkn/tkn-pac-windows-amd64-1.2.3.zip
+      text: Download tkn-pac for Windows

--- a/pkg/reconciler/openshift/tektonaddon/transformer_test.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer_test.go
@@ -42,7 +42,7 @@ func TestUpdateConsoleCLIDownload(t *testing.T) {
 	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 
-	newManifest, err := manifest.Transform(replaceURLCCD("testserver.com"))
+	newManifest, err := manifest.Transform(replaceURLCCD("testserver.com", "1.2.3"))
 	assert.NilError(t, err)
 
 	got := &console.ConsoleCLIDownload{}


### PR DESCRIPTION
This commit updates the link that ConsoleCLIDownload exposes to 0.23.1
and introduces `tkn-pac` binaries to the list as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```