### PR TITLE
[openshift] Fix upgrade: Tektonconfig staying in Ready: False

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -52,7 +52,7 @@ const (
 	createdByValue             = "RBAC"
 	componentNameRBAC          = "rhosp-rbac"
 	rbacInstallerSetType       = "rhosp-rbac"
-	rbacInstalelrSetNamePrefix = "rhosp-rbac-"
+	rbacInstallerSetNamePrefix = "rhosp-rbac-"
 	rbacParamName              = "createRbacResource"
 )
 
@@ -707,8 +707,6 @@ func (r *rbac) removeAndUpdate(slice []metav1.OwnerReference, s int) []metav1.Ow
 	ownerRef = append(ownerRef, r.ownerRef)
 	return ownerRef
 }
-
-//func (r *rbac) ensureRbacInstallerSetIsDeleted(ctx context.Context)
 
 // TODO: Remove this after v0.55.0 release, by following a depreciation notice
 // --------------------


### PR DESCRIPTION
# Changes
Replace metada.name with metadata.generateName in rbac installerSet creation

Add a mechanism to remove constant name based rbac installer set before an upgrade

Fix rbac disable not working bug
    - Make the delete rbac installerSet logic use labelSelctor based `DeleteCollection` instead of constant name based `Delete`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```