### PR TITLE
[openshift] Fix Versioned ClusterTask names

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/clustertTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTask.go
@@ -91,10 +91,20 @@ func (r *Reconciler) ensureClusterTasks(ctx context.Context, ta *v1alpha1.Tekton
 	return nil
 }
 
-// To get the version in the format as in clustertask name i.e. 1-6
-func getFormattedVersion(version string) string {
-	version = strings.TrimPrefix(getPatchVersionTrimmed(version), "v")
-	return strings.Replace(version, ".", "-", -1)
+func formattedVersionMajorMinorX(version, x string) string {
+	ver := getPatchVersionTrimmed(version)
+	ver = fmt.Sprintf("%s.%s", ver, x)
+	return formattedVersionSnake(ver)
+}
+
+func formattedVersionMajorMinor(version string) string {
+	ver := getPatchVersionTrimmed(version)
+	return formattedVersionSnake(ver)
+}
+
+func formattedVersionSnake(version string) string {
+	ver := strings.TrimPrefix(version, "v")
+	return strings.Replace(ver, ".", "-", -1)
 }
 
 // To get the minor major version for label i.e. v1.6

--- a/pkg/reconciler/openshift/tektonaddon/const.go
+++ b/pkg/reconciler/openshift/tektonaddon/const.go
@@ -20,6 +20,7 @@ const (
 	ClusterTaskInstallerSet            = "ClusterTask"
 	CommunityClusterTaskInstallerSet   = "CommunityClusterTask"
 	VersionedClusterTaskInstallerSet   = "VersionedClusterTask"
+	versionedClusterTaskPatchChar      = "0"
 	PipelinesTemplateInstallerSet      = "PipelinesTemplate"
 	TriggersResourcesInstallerSet      = "TriggersResources"
 	ConsoleCLIInstallerSet             = "ConsoleCLI"

--- a/pkg/reconciler/openshift/tektonaddon/installerset.go
+++ b/pkg/reconciler/openshift/tektonaddon/installerset.go
@@ -101,7 +101,7 @@ func makeInstallerSet(ta *v1alpha1.TektonAddon, manifest mf.Manifest, prefix, re
 	// for all patch releases
 	if component == VersionedClusterTaskInstallerSet {
 		labels[v1alpha1.ReleaseMinorVersionKey] = getPatchVersionTrimmed(releaseVersion)
-		namePrefix = fmt.Sprintf("%s%s-", namePrefix, getFormattedVersion(releaseVersion))
+		namePrefix = fmt.Sprintf("%s%s-", namePrefix, formattedVersionMajorMinor(releaseVersion))
 	}
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-versioned-clustertask-name-expected.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-versioned-clustertask-name-expected.yaml
@@ -7,7 +7,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
-  name: buildah-1-7
+  name: buildah-1-7-0
 spec:
   params:
     - name: BUILDER_IMAGE

--- a/pkg/reconciler/openshift/tektonaddon/transformer.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer.go
@@ -160,7 +160,7 @@ func setVersionedNames(operatorVersion string) mf.Transformer {
 			return nil
 		}
 		name := u.GetName()
-		formattedVersion := getFormattedVersion(operatorVersion)
+		formattedVersion := formattedVersionMajorMinorX(operatorVersion, versionedClusterTaskPatchChar)
 		name = fmt.Sprintf("%s-%s", name, formattedVersion)
 		u.SetName(name)
 		return nil


### PR DESCRIPTION
Add logic to format versioned CluterTask names to have a constant "0" as the patch version character

This patch will name versioned clusterTasks as `buildah-1-7-0` instead of `buildah-1-7`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```