### PR TITLE
Add arm64 to supported architectures

### DIFF
--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -14,6 +14,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: openshift-pipelines-operator-rh.v0.0.0

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -42,6 +42,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: openshift-pipelines-operator-rh.v1.6.0


### PR DESCRIPTION
By adding the label `operatorframework.io/arch.arm64: supported` we
are telling OLM this operator supports arm64. I think we already build
arm images anyway, so it should be the only required change.

```release-note
Add `operatorframework.io/arch.arm64: supported` label to tell OLM we support arm64.
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
