### PR TITLE
Improve e2e test tear down mechanism

### DIFF
--- a/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
+++ b/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
@@ -23,17 +23,18 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/tektoncd/operator/test/client"
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/parse"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 // TestTektonChainDeployment verifies the TektonChain creation, deployment recreation, and TektonChain deletion.
@@ -209,5 +210,11 @@ func TestTektonChainsGettingStartedTutorial(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	})
+
+	// Delete the TektonPipeline CR instance to see if all resources will be removed
+	t.Run("delete-pipeline", func(t *testing.T) {
+		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+		resources.TektonPipelineCRDelete(t, clients, crNames)
 	})
 }

--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -55,7 +55,7 @@ func TestTektonResultDeployment(t *testing.T) {
 	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownResult(clients, crNames.TektonResult) })
-	defer utils.TearDownResult(clients, crNames.TektonTrigger)
+	defer utils.TearDownResult(clients, crNames.TektonResult)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
 

--- a/test/utils/cleanup.go
+++ b/test/utils/cleanup.go
@@ -18,11 +18,19 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+type crDeleteVerifier wait.ConditionFunc
+type deploymentDeleteVerifier wait.ConditionFunc
+type crGetFunc func(ctx context.Context) error
 
 // CleanupOnInterrupt will execute the function cleanup if an interrupt signal is caught
 func CleanupOnInterrupt(cleanup func()) {
@@ -38,56 +46,290 @@ func CleanupOnInterrupt(cleanup func()) {
 
 // TearDownPipeline will delete created TektonPipeline CRs using clients.
 func TearDownPipeline(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonPipeline().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	tc, err := clients.TektonPipeline().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonPipeline instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonPipeline().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonPipeline during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonPipeline().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonPipelineDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonPipeline resource, name: %s, error: %v", name, err)
 	}
 }
 
 // TearDownTrigger will delete created TektonTrigger CRs using clients.
 func TearDownTrigger(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonTrigger().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	tc, err := clients.TektonTrigger().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonTrigger instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonTrigger().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonTrigger during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonTrigger().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonTriggerDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonTrigger resource, name: %s, error: %v", name, err)
 	}
 }
 
 // TearDownDashboard will delete created TektonDashboard CRs using clients.
 func TearDownDashboard(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonDashboard().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	tc, err := clients.TektonDashboard().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonDashboard instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonDashboard().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonDashboard during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonDashboard().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonDashboardDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonDashboard resource, name: %s, error: %v", name, err)
 	}
 }
 
 // TearDownAddon will delete created TektonAddon CRs using clients.
 func TearDownAddon(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonAddon().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
 	}
+
+	tc, err := clients.TektonAddon().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonAddon instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonAddon().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonAddon during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonAddon().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonAddonDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonAddon resource, name: %s, error: %v", name, err)
+	}
+
 }
 
 // TearDownNamespace will delete created test Namespace
 func TearDownNamespace(clients *Clients, name string) {
+	ctx := context.Background()
 	if clients != nil && clients.KubeClient != nil {
-		_ = clients.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		_ = clients.KubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	}
 }
 
 // TearDownConfig will delete created TektonConfig CRs using clients.
 func TearDownConfig(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonConfig().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	tc, err := clients.TektonConfig().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonConfig instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonConfig().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonConfig during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonConfig().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, "")
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonConfig resource, name: %s, error: %v", name, err)
 	}
 }
 
 // TearDownResult will delete created TektonResult CRs using clients.
 func TearDownResult(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonResult().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	tc, err := clients.TektonResult().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonResult instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonResult().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonResult during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonResult().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonResultsDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonResult resource, name: %s, error: %v", name, err)
 	}
 }
 
 // TearDownChain will delete created TektonChain CRs using clients.
 func TearDownChain(clients *Clients, name string) {
-	if clients != nil && clients.Operator != nil {
-		_ = clients.TektonChains().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
 	}
+
+	tc, err := clients.TektonChains().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonChains instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := tc.Spec.TargetNamespace
+
+	err = clients.TektonChains().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonChains during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonChains().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonChainDeploymentLabel)
+	err = waitUntilFullDeletion(ctx, crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonChains resource, name: %s, error: %v", name, err)
+	}
+}
+
+func newCRDeleteVerifier(ctx context.Context, f crGetFunc) crDeleteVerifier {
+	return func() (bool, error) {
+		err := f(ctx)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}
+}
+
+func newDeploymentDeleteVerifier(ctx context.Context, c *Clients, namespace, labelSelector string) deploymentDeleteVerifier {
+	return func() (bool, error) {
+		deployemnts, err := c.KubeClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+
+		if err != nil {
+			return false, err
+		}
+		if len(deployemnts.Items) == 0 {
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+func waitUntilFullDeletion(ctx context.Context, cdcf crDeleteVerifier, ddcf deploymentDeleteVerifier) error {
+	if err := ensureDeploymentsRemoval(ctx, ddcf); err != nil {
+		return err
+	}
+	if err := ensureCustomResourceRemoval(ctx, cdcf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureCustomResourceRemoval(ctx context.Context, verifier crDeleteVerifier) error {
+	return waitForCondition(ctx, wait.ConditionFunc(verifier))
+}
+
+func ensureDeploymentsRemoval(ctx context.Context, verifier deploymentDeleteVerifier) error {
+	return waitForCondition(ctx, wait.ConditionFunc(verifier))
+}
+
+func waitForCondition(ctx context.Context, condition wait.ConditionFunc) error {
+	return wait.PollImmediate(common.Interval, common.Timeout, func() (done bool, err error) {
+		ok, err := condition()
+		if err != nil {
+			return false, err
+		}
+		return ok, nil
+	})
 }

--- a/test/utils/e2e_flags.go
+++ b/test/utils/e2e_flags.go
@@ -18,7 +18,9 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 )
 
 var (
@@ -26,6 +28,8 @@ var (
 	TektonTriggerDeploymentLabel   = labelString(v1alpha1.OperandTektoncdTriggers)
 	TektonDashboardDeploymentLabel = labelString(v1alpha1.OperandTektoncdDashboard)
 	TektonChainDeploymentLabel     = labelString(v1alpha1.OperandTektoncdChains)
+	TektonResultsDeploymentLabel   = labelString(v1alpha1.OperandTektoncdResults)
+	TektonAddonDeploymentLabel     = labelString(openshift.OperandOpenShiftPipelinesAddons)
 )
 
 func labelString(operandName string) string {


### PR DESCRIPTION
Add a wait-poll to ensure that CustomResources and managed
deployments are removed completely before proceeding to a new test.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```