### PR TITLE
Filter out PodSecurityPolicy from manifests ✂️

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -46,7 +46,6 @@ var (
 	roleBindingPred                    = mf.ByKind("RoleBinding")
 	clusterRolePred                    = mf.ByKind("ClusterRole")
 	clusterRoleBindingPred             = mf.ByKind("ClusterRoleBinding")
-	podSecurityPolicyPred              = mf.ByKind("PodSecurityPolicy")
 	validatingWebhookConfigurationPred = mf.ByKind("ValidatingWebhookConfiguration")
 	mutatingWebhookConfigurationPred   = mf.ByKind("MutatingWebhookConfiguration")
 	horizontalPodAutoscalerPred        = mf.ByKind("HorizontalPodAutoscaler")
@@ -109,7 +108,6 @@ func (i *installer) EnsureClusterScopedResources() error {
 		mf.Any(
 			namespacePred,
 			clusterRolePred,
-			podSecurityPolicyPred,
 			validatingWebhookConfigurationPred,
 			mutatingWebhookConfigurationPred,
 			clusterInterceptorPred,

--- a/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
@@ -36,7 +36,6 @@ import (
 
 var (
 	namespace          = clusterScopedResource("v1", "Namespace", "test-ns")
-	podSecurityPolicy  = clusterScopedResource("policy/v1beta1", "PodSecurityPolicy", "test-pod-security-policy")
 	clusterRole        = clusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "test-cluster-role")
 	role               = namespacedResource("rbac.authorization.k8s.io/v1", "Role", "test", "test-role")
 	serviceAccount     = namespacedResource("v1", "ServiceAccount", "test", "test-service-account")
@@ -107,7 +106,7 @@ func clusterScopedResource(apiVersion, kind, name string) unstructured.Unstructu
 
 func TestInstaller(t *testing.T) {
 	crd.SetDeletionTimestamp(&metav1.Time{})
-	in := []unstructured.Unstructured{namespace, podSecurityPolicy, deployment, clusterRole, role,
+	in := []unstructured.Unstructured{namespace, deployment, clusterRole, role,
 		roleBinding, clusterRoleBinding, serviceAccount, crd, validatingWebhook, mutatingWebhook, configMap, service, hpa, secret}
 
 	client := &fakeClient{}
@@ -134,7 +133,7 @@ func TestInstaller(t *testing.T) {
 	// reset created array
 	client.creates = []unstructured.Unstructured{}
 
-	want = []unstructured.Unstructured{namespace, podSecurityPolicy, clusterRole, validatingWebhook, mutatingWebhook}
+	want = []unstructured.Unstructured{namespace, clusterRole, validatingWebhook, mutatingWebhook}
 
 	err = i.EnsureClusterScopedResources()
 	if err != nil {


### PR DESCRIPTION
`PodSecurityPolicy` is deprecated and will soon be removed in
kubernetes. The Operator shouldn't ship any of them.

There is already PR(s) to remove this in the components but it doesn't
cost much to filter them out in the operator as well.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
