### PR TITLE
[openshift] [cherry-pick] Improve/rbac reconciling

### DIFF
--- a/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/tektondashboard.go
@@ -297,16 +297,7 @@ func (r *Reconciler) updateTektonDashboardStatus(ctx context.Context, td *v1alph
 	// update the td with TektonInstallerSet and releaseVersion
 	td.Status.SetTektonInstallerSet(createdIs.Name)
 	td.Status.SetVersion(r.dashboardVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonDashboards().
-		UpdateStatus(ctx, td, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return v1alpha1.RECONCILE_AGAIN_ERR
+	return nil
 }
 
 // transform mutates the passed manifest to one with common, component

--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -18,7 +18,6 @@ package tektonpipeline
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"time"
 
@@ -308,16 +307,7 @@ func (r *Reconciler) updateTektonPipelineStatus(ctx context.Context, tp *v1alpha
 	// update the tp with TektonInstallerSet and releaseVersion
 	tp.Status.SetTektonInstallerSet(createdIs.Name)
 	tp.Status.SetVersion(r.pipelineVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonPipelines().
-		UpdateStatus(ctx, tp, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring Reconcile TektonPipeline status update")
+	return nil
 }
 
 func (r *Reconciler) createInstallerSet(ctx context.Context, tp *v1alpha1.TektonPipeline) (*v1alpha1.TektonInstallerSet, error) {

--- a/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/tektontrigger.go
@@ -18,7 +18,6 @@ package tektontrigger
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"time"
 
@@ -348,16 +347,7 @@ func (r *Reconciler) updateTektonTriggerStatus(ctx context.Context, tt *v1alpha1
 	// update the tt with TektonInstallerSet and releaseVersion
 	tt.Status.SetTektonInstallerSet(createdIs.Name)
 	tt.Status.SetVersion(r.triggersVersion)
-
-	// Update the status with TektonInstallerSet so that any new thread
-	// reconciling with know that TektonInstallerSet is created otherwise
-	// there will be 2 instance created if we don't update status here
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonTriggers().
-		UpdateStatus(ctx, tt, metav1.UpdateOptions{}); err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring Reconcile TektonTrigger status update")
+	return nil
 }
 
 func (r *Reconciler) createInstallerSet(ctx context.Context, tt *v1alpha1.TektonTrigger) (*v1alpha1.TektonInstallerSet, error) {

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -73,7 +73,7 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		// then disable auto creation of RBAC resources by deleting installerSet
 		if v.Name == rbacParamName && v.Value == "false" {
 			createRBACResource = false
-			if err := deleteInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, componentName); err != nil {
+			if err := deleteInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, componentNameRBAC); err != nil {
 				return err
 			}
 			// remove openshift-pipelines.tekton.dev/namespace-reconcile-version label from namespaces while deleting RBAC resources.
@@ -83,10 +83,16 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		}
 	}
 
+	// TODO: Remove this after v0.55.0 release, by following a depreciation notice
+	// --------------------
+	if err := r.cleanUpRBACNameChange(ctx); err != nil {
+		return err
+	}
+	// --------------------
+
 	if createRBACResource {
 		return r.createResources(ctx)
 	}
-
 	return nil
 }
 

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -50,7 +50,17 @@ const (
 	namespaceVersionLabel    = "openshift-pipelines.tekton.dev/namespace-reconcile-version"
 	createdByValue           = "RBAC"
 	componentNameRBAC        = "rhosp-rbac"
+	rbacInstallerSetType     = "rhosp-rbac"
 	rbacParamName            = "createRbacResource"
+)
+
+var (
+	rbacInstallerSetSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			v1alpha1.CreatedByKey:     createdByValue,
+			v1alpha1.InstallerSetType: componentNameRBAC,
+		},
+	}
 )
 
 // Namespace Regex to ignore the namespace for creating rbac resources.
@@ -105,9 +115,7 @@ func (r *rbac) EnsureRBACInstallerSet(ctx context.Context) (*v1alpha1.TektonInst
 		return nil, err
 	}
 
-	err = createInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, map[string]string{
-		v1alpha1.CreatedByKey: createdByValue,
-	}, r.version, componentNameRBAC, "rbac-resources")
+	err = createInstallerSet(ctx, r.operatorClientSet, r.tektonConfig, r.version, componentNameRBAC, "rbac-resources")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -52,7 +52,7 @@ const (
 	createdByValue             = "RBAC"
 	componentNameRBAC          = "rhosp-rbac"
 	rbacInstallerSetType       = "rhosp-rbac"
-	rbacInstalelrSetNamePrefix = "rhosp-rbac-"
+	rbacInstallerSetNamePrefix = "rhosp-rbac-"
 	rbacParamName              = "createRbacResource"
 )
 
@@ -707,8 +707,6 @@ func (r *rbac) removeAndUpdate(slice []metav1.OwnerReference, s int) []metav1.Ow
 	ownerRef = append(ownerRef, r.ownerRef)
 	return ownerRef
 }
-
-//func (r *rbac) ensureRbacInstallerSetIsDeleted(ctx context.Context)
 
 // TODO: Remove this after v0.55.0 release, by following a depreciation notice
 // --------------------

--- a/pkg/reconciler/openshift/tektonpipeline/installerset.go
+++ b/pkg/reconciler/openshift/tektonpipeline/installerset.go
@@ -18,14 +18,12 @@ package tektonpipeline
 
 import (
 	"context"
-	stdError "errors"
 	"fmt"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -114,16 +112,9 @@ func createInstallerSet(ctx context.Context, oc clientset.Interface, tp *v1alpha
 		tp.Status.ExtentionInstallerSets = map[string]string{}
 	}
 
-	// Update the status of pipeline with created installerSet name
+	//// Update the status of pipeline with created installerSet name
 	tp.Status.ExtentionInstallerSets[component] = createdIs.Name
-
-	_, err = oc.OperatorV1alpha1().TektonPipelines().
-		UpdateStatus(ctx, tp, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return stdError.New("ensuring TektonPipeline status update")
+	return nil
 }
 
 func makeInstallerSet(tp *v1alpha1.TektonPipeline, manifest mf.Manifest, installerSetType, releaseVersion string) *v1alpha1.TektonInstallerSet {
@@ -162,10 +153,5 @@ func deleteInstallerSet(ctx context.Context, oc clientset.Interface, ta *v1alpha
 
 	// clear the name of installer set from TektonPipeline status
 	delete(ta.Status.ExtentionInstallerSets, component)
-	_, err = oc.OperatorV1alpha1().TektonPipelines().UpdateStatus(ctx, ta, metav1.UpdateOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	return nil
 }

--- a/pkg/reconciler/shared/tektonconfig/controller.go
+++ b/pkg/reconciler/shared/tektonconfig/controller.go
@@ -77,12 +77,12 @@ func NewExtensibleController(generator common.ExtensionGenerator) injection.Cont
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
-		namespaceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(enqueueCustomName(impl, common.ConfigResourceName)))
+		namespaceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(enqueueCustomName(impl, v1alpha1.ConfigResourceName)))
+
+		tektonInstallerinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
-
-		tektonInstallerinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 
 		if os.Getenv("AUTOINSTALL_COMPONENTS") == "true" {
 			// try to ensure that there is an instance of tektonConfig

--- a/pkg/reconciler/shared/tektonconfig/controller.go
+++ b/pkg/reconciler/shared/tektonconfig/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
+	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonTriggerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektontrigger"
 	tektonConfigreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonconfig"
@@ -77,6 +78,11 @@ func NewExtensibleController(generator common.ExtensionGenerator) injection.Cont
 		})
 
 		namespaceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(enqueueCustomName(impl, common.ConfigResourceName)))
+			FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
+			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+		})
+
+		tektonInstallerinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 
 		if os.Getenv("AUTOINSTALL_COMPONENTS") == "true" {
 			// try to ensure that there is an instance of tektonConfig

--- a/test/e2e/common/tektonconfigdeployment_test.go
+++ b/test/e2e/common/tektonconfigdeployment_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonpipeline"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
+	tconfig "github.com/tektoncd/operator/pkg/reconciler/openshift/tektonconfig"
 	"github.com/tektoncd/operator/test/client"
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
@@ -392,7 +393,7 @@ func runRbacTest(t *testing.T, clients *utils.Clients) {
 	})
 
 	pipelinesSCCRoleBinding := "pipelines-scc-rolebinding"
-	editRoleBinding := "edit"
+	editRoleBinding := tconfig.PipelineRoleBinding
 
 	// Test whether the roleBindings are created
 	t.Run("verify-rolebindings", func(t *testing.T) {


### PR DESCRIPTION
# Changes

[OpenShift] Fix RBAC bugs

- Rename rolebinding created by RBAC reconciler to
  'openshift-pipelines-edit' (was 'edit' earlier)

- Add mechanism to ensure that missing RBAC resources are recreated if
  the RBAC installerSet is recreated during an upgrade.
- this ensures that RBAC in the version label in RBAC reconciled
  namespaces are removed during an upgrade and the presence of RBAC
  resources are verified

- Make TektonConfig reconciler listen to TektonInstallerSet events so
  that it can recreate RBAC InstallerSet if it is deleted manually from
  a cluster

- Add a mechanism to remove ownerReference and 'pipeline' sa subject
  from 'edit' rolebinding in namespaces
  - This ensures that operator upgrades won't delete/reset 'edit'
    rolebinding in usernamespaces.

Remove redundant 'UpdateStatus()' calls
    
Remove redundant UpdateStatus calls as UpdateStaus api call is carried
out by knative/pkg generated code at the end of each reconcile loop

[openshift] Use label selectors to find RBAC instalelr set name

Use labelselectr based list query to find the existing RBAC installerset
name, instead of looking it up from a map in tektonconfig.status.

Kubernetes being "optimistically consistent" we cannot guarantee that
the value in tektonconfig status will be updated withing a predictable
time or that whether/when the update will pass or fail.
    
List queries based on label selectors is more reliable

[openshift] Fix upgrade: Tektonconfig staying in Ready: False

Repalce metada.name with metadata.generateName in rbac installerSet creation

Add a mechanism to remove constant name based rbac installer set before an upgrade

[openshift] Fix rbac disable not working bug

Make the delete rbac installerSet logic use labelSelctor based `DeleteCollection` instead of
constant name based `Delete`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
