### PR TITLE
Fixes Hub version to `latest` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ TEKTON_TRIGGERS_VERSION ?= latest
 TEKTON_DASHBOARD_VERSION ?= latest
 TEKTON_RESULTS_VERSION ?= v0.4.0 # latest returns an older version hence hard coding to v0.3.1 for now (tektoncd/results#138)
 PAC_VERSION ?= stable
-TEKTON_HUB_VERSION ?= v1.7.2 # latest doesn't returns any version hence hard coding to v1.7.2 for now
+TEKTON_HUB_VERSION ?= latest
 TEKTON_CHAINS_VERSION ?= latest
 
 # TODO: after updating go version to 1.17 uncommnent the line below to install latest version of ko

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -130,7 +130,14 @@ release_yaml_hub() {
   local version=$2
 
   ko_data=${SCRIPT_DIR}/cmd/${TARGET}/operator/kodata
-  dirPath=${ko_data}/tekton-hub/${version}
+  rm -rf ${ko_data}/tekton-hub
+  if [ ${version} == "latest" ]
+  then
+    version=$(curl -sL https://api.github.com/repos/tektoncd/hub/releases | jq -r ".[].tag_name" | sort -Vr | head -n1)
+    dirPath=${ko_data}/tekton-hub/0.0.0-latest
+  else
+    dirPath=${ko_data}/tekton-hub/${version}
+  fi
   rm -rf ${dirPath} || true
   mkdir -p ${dirPath} || true
 


### PR DESCRIPTION
Initially, Hub version was hard coded in makefile to fetch
the specific version and after each release to get the latest
version we had to update the version in the Makefile

Hence this patch fixes the version to latest where in the script
it fetches the latest Hub version

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
