### PR TITLE
Make sure we push to the right branch

### DIFF
--- a/hack/release-common.sh
+++ b/hack/release-common.sh
@@ -63,7 +63,7 @@ function push_release_branch() {
     case ${confirmation} in
       y|Y|yes|YES|Yes|'')
         echo "pushing ${branch_name} to ${remote_name}"
-        git push ${remote_name} ${branch_name}
+        git push ${remote_name} ${branch_name}:${branch_name}
         break
         ;;
       n|N|no|NO|no)
@@ -95,5 +95,3 @@ function commit_changes() {
 function divider() {
   printf "\n--------------------------------------------------\n"
 }
-
-


### PR DESCRIPTION


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

By using branch-name:branch-name, we are sure we are pushing the local
branch "branch-name" to the remote branch "branch-name". Without that,
it might try to push to the tracking branch, aka main for example.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @concaf @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
