### PR TITLE
Add a mechanism to ensure targetNamespace is deleted up in e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,7 +35,7 @@ header "Setting up environment"
 tektonconfig_ready_wait
 
 header "Running Go e2e tests"
-go_test_e2e -timeout=20m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
+go_test_e2e -timeout=40m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
 go_test_e2e -timeout=20m ./test/e2e/${TARGET} ${KUBECONFIG_PARAM} || failed=1
 
 (( failed )) && fail_test

--- a/test/e2e/common/00_tektonconfigdeployment_test.go
+++ b/test/e2e/common/00_tektonconfigdeployment_test.go
@@ -50,6 +50,7 @@ import (
 func TestTektonConfigDeployment(t *testing.T) {
 	crNames := utils.ResourceNames{
 		TektonConfig:    v1alpha1.ConfigResourceName,
+		TektonPipeline:  v1alpha1.PipelineResourceName,
 		Namespace:       "tekton-operator",
 		TargetNamespace: "tekton-pipelines",
 	}
@@ -64,6 +65,8 @@ func TestTektonConfigDeployment(t *testing.T) {
 	}
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownConfig(clients, crNames.TektonConfig) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
 	defer utils.TearDownConfig(clients, crNames.TektonConfig)
 
 	var (

--- a/test/e2e/common/01_tektonpipelinedeployment_test.go
+++ b/test/e2e/common/01_tektonpipelinedeployment_test.go
@@ -45,6 +45,8 @@ func TestTektonPipelinesDeployment(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
 	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)

--- a/test/e2e/common/02_tektontriggerdeployment_test.go
+++ b/test/e2e/common/02_tektontriggerdeployment_test.go
@@ -44,11 +44,11 @@ func TestTektonTriggersDeployment(t *testing.T) {
 	if os.Getenv("TARGET") == "openshift" {
 		crNames.TargetNamespace = "openshift-pipelines"
 	}
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownTrigger(clients, crNames.TektonTrigger) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 	defer utils.TearDownTrigger(clients, crNames.TektonTrigger)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
@@ -91,5 +91,4 @@ func TestTektonTriggersDeployment(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
 		resources.TektonPipelineCRDelete(t, clients, crNames)
 	})
-
 }

--- a/test/e2e/common/03_tektonchaindeployment_test.go
+++ b/test/e2e/common/03_tektonchaindeployment_test.go
@@ -44,9 +44,10 @@ func TestTektonChainDeployment(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownChain(clients, crNames.TektonChain) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 	defer utils.TearDownChain(clients, crNames.TektonChain)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
@@ -89,5 +90,4 @@ func TestTektonChainDeployment(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
 		resources.TektonPipelineCRDelete(t, clients, crNames)
 	})
-
 }

--- a/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
+++ b/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
@@ -53,9 +53,10 @@ func TestTektonChainsGettingStartedTutorial(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownChain(clients, crNames.TektonChain) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 	defer utils.TearDownChain(clients, crNames.TektonChain)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)

--- a/test/e2e/kubernetes/tektondashboarddeployment_test.go
+++ b/test/e2e/kubernetes/tektondashboarddeployment_test.go
@@ -41,9 +41,10 @@ func TestTektonDashboardsDeployment(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownDashboard(clients, crNames.TektonDashboard) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 	defer utils.TearDownDashboard(clients, crNames.TektonDashboard)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
@@ -91,5 +92,4 @@ func TestTektonDashboardsDeployment(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
 		resources.TektonPipelineCRDelete(t, clients, crNames)
 	})
-
 }

--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -52,9 +52,10 @@ func TestTektonResultDeployment(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-
 	utils.CleanupOnInterrupt(func() { utils.TearDownResult(clients, crNames.TektonResult) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
 	defer utils.TearDownResult(clients, crNames.TektonResult)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)


### PR DESCRIPTION
Add a mechanism to ensure targetNamespace is deleted at the end of
each e2e test.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->
```release-note
NONE
```