### PR TITLE
[TektonConfig] Allows user to set priorityClassName parameter

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -35,6 +35,7 @@ The TektonConfig CR provides the following features
     config:
       nodeSelector: <>
       tolerations: []
+      priorityClassName: system-cluster-critical
     pipeline:
       disable-affinity-assistant: false
       disable-creds-init: false
@@ -86,6 +87,7 @@ Config provides fields to configure deployments created by the Operator.
 This provides following fields:
 - [`nodeSelector`][node-selector]
 - [`tolerations`][tolerations]
+- [`priorityClassName`][priorityClassName]
 
 User can pass the required fields and this would be passed to all Operator components which will get added in all
 deployments created by Operator.
@@ -100,11 +102,13 @@ config:
     operator: "Equal"
     value: "value1"
     effect: "NoSchedule"
+  priorityClassName: system-node-critical
 ```
 
 This is an `Optional` section.
 
-
+**NOTE**: If `spec.config.priorityClassName` is used, then the required [`priorityClass`][priorityClass] is 
+expected to be created by the user to get the Tekton resources pods in running state
 ### Pipeline
 Pipeline section allows user to customize the Tekton pipeline features. This allow user to customize the values in configmaps.
 
@@ -203,3 +207,6 @@ This is an `Optional` section.
 [node-selector]:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 [tolerations]:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 [schedule]:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
+[priorityClassName]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+[priorityClass]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -125,4 +125,7 @@ type TektonConfigList struct {
 type Config struct {
 	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
 	Tolerations  []corev1.Toleration `json:"tolerations,omitempty"`
+	// PriorityClassName holds the priority class to be set to pod template
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -580,6 +580,7 @@ func AddConfiguration(config v1alpha1.Config) mf.Transformer {
 
 		d.Spec.Template.Spec.NodeSelector = config.NodeSelector
 		d.Spec.Template.Spec.Tolerations = config.Tolerations
+		d.Spec.Template.Spec.PriorityClassName = config.PriorityClassName
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 		if err != nil {

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -501,6 +501,7 @@ func TestAddConfiguration(t *testing.T) {
 				Effect:   "noSchedule",
 			},
 		},
+		PriorityClassName: string("system-cluster-critical"),
 	}
 
 	manifest, err = manifest.Transform(AddConfiguration(config))
@@ -509,7 +510,7 @@ func TestAddConfiguration(t *testing.T) {
 	d := &v1beta1.Deployment{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
 	assertNoEror(t, err)
-
 	assert.Equal(t, d.Spec.Template.Spec.NodeSelector["foo"], config.NodeSelector["foo"])
 	assert.Equal(t, d.Spec.Template.Spec.Tolerations[0].Key, config.Tolerations[0].Key)
+	assert.Equal(t, d.Spec.Template.Spec.PriorityClassName, config.PriorityClassName)
 }


### PR DESCRIPTION
# Changes

Allows user to set `priorityClassName` parameter for the Tekton resources created.

In TektonConfig CR, allows  `.spec.config.priorityClassName` as a new optional field where users can set the `priorityClassName`

However, externally the necessary Kubernetes PriorityClass needs to be created accordingly to allow successful pod scheduling, else the pod will not come into Running stage

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x]  Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)

   

- [x]  Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details.
# Release Notes
```release-note
The PR does only allow changes in the parent field which takes the same priorityclass for all the Tekton Resources and doesnt allow user to set individually for each resource. These will be covered in the next PR
```
Fixes  part of https://github.com/tektoncd/operator/issues/580