### PR TITLE
Add honorLabels to the pipelines ServiceMonitor

### DIFF
--- a/cmd/openshift/operator/kodata/openshift-monitoring/00-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/00-monitoring.yaml
@@ -59,6 +59,7 @@ spec:
   endpoints:
     - interval: 10s
       port: http-metrics
+      honorLabels: true
   jobLabel: app
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Added honorLabels to the serviceMonitor because prometheus
override our labels/tags in metrics which leads to namespace
being tagged as exported_namespace and an additional namespace
tag "openshift-pipelines" in the metrics stored.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
