### PR TITLE
allow running buildah on newer nodes

### DIFF
--- a/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
+++ b/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
@@ -15,7 +15,8 @@ allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
-allowedCapabilities: null
+allowedCapabilities:
+- SETFCAP
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -66,6 +66,9 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
+    securityContext:
+      capabilities:
+        add: ["SETFCAP"]
 
   - name: push
     image: $(params.BUILDER_IMAGE)
@@ -78,6 +81,9 @@ spec:
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
+    securityContext:
+      capabilities:
+        add: ["SETFCAP"]
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       workingDir: $(workspaces.source.path)
       image: $(params.BUILDER_IMAGE)
@@ -66,6 +69,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       workingDir: $(workspaces.source.path)
       image: $(params.BUILDER_IMAGE)
@@ -66,6 +69,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
@@ -109,6 +109,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       image: $(params.BUILDER_IMAGE)
       workingDir: $(workspaces.source.path)
@@ -116,6 +119,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       image: $(params.BUILDER_IMAGE)
       workingDir: $(workspaces.source.path)
@@ -66,6 +69,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       workingDir: $(workspaces.source.path)
       image: $(params.BUILDER_IMAGE)
@@ -66,6 +69,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
@@ -59,12 +59,18 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       image: $(params.BUILDER_IMAGE)
       command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
 
       workingDir: $(workspaces.source.path)
@@ -67,6 +70,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
@@ -59,6 +59,9 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: push
       image: $(params.BUILDER_IMAGE)
       workingDir: $(workspaces.source.path)
@@ -66,6 +69,9 @@ spec:
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
       script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST


### PR DESCRIPTION
# Changes
This will allow running buildah on nodes with kernel 5.12 or later.

Buildah requires the `SETFCAP` capability to work.  This pull requests updates  OpenShift SCC to allow adding this capability and the included `buildah` clustertask to request it.

I do not have access to clusters with older kernels so I don't know whether it will work on these nodes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

## Release Notes

```release-note
buildah ClusterTask is now allowed SETFCAP capability
```
