### PR TITLE
Fix warning on OCP 4.11 cluster for operator install

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/component: tkncliserve
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   replicas: 1
   selector:
     matchLabels:
@@ -21,6 +25,11 @@ spec:
           image: docker.io/rupali/serve-tkn:v2
           ports:
             - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 ---
 apiVersion: v1
 kind: Service

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -99,6 +99,10 @@ spec:
         name: tekton-operator
         app: tekton-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tekton-operators-proxy-webhook
       containers:
         - name: proxy
@@ -119,6 +123,9 @@ spec:
               containerPort: 8443
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
 ---
 

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -28,6 +28,10 @@ spec:
         name: openshift-pipelines-operator
         app: openshift-pipelines-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-pipelines-operator
       containers:
       - name: openshift-pipelines-operator-lifecycle  # all reconcilers except tektoninstallerset reconciler
@@ -38,6 +42,11 @@ spec:
         - "-unique-process-name"
         - "tekton-operator-lifecycle"
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -91,6 +100,11 @@ spec:
         - "-unique-process-name"
         - "tekton-operator-cluster-operations"
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         env:
           - name: SYSTEM_NAMESPACE
             valueFrom:

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -30,6 +30,10 @@ spec:
         name: tekton-operator-webhook
         app: tekton-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-pipelines-operator
       containers:
       - name: tekton-operator-webhook
@@ -50,3 +54,8 @@ spec:
         ports:
         - name: https-webhook
           containerPort: 8443
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL


### PR DESCRIPTION
Operator make apply is throwing warning on new OCP 4.11 cluster
because of the restricted PSA getting available by default

This will fix the warning on 4.11

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix warning on OCP 4.11 cluster for operator install
```
