### PR TITLE
Add SETFCAP capability in pipelines-scc

### DIFF
--- a/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
+++ b/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
@@ -16,7 +16,8 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: null
-defaultAddCapabilities: null
+defaultAddCapabilities:
+- SETFCAP
 fsGroup:
   type: MustRunAs
 groups:


### PR DESCRIPTION
This will add SETFCAP capability in pipelines-scc securitycontextconstraint
so that the pipeline sericeaccount which is getting used to
run buildah and s2i clustertask will not fail on ocp 4.11 as now
it will require this added capability to work properly

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add SETFCAP capability in pipelines-scc to make clustertask like buildah and pipeline work on OCP 4.11
```
