### PR TITLE
[Cherry-pick] Updates Hub CR to prevent loss of data on operator upgradation

### DIFF
--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -20,10 +20,11 @@ package tektonhub
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -192,10 +193,17 @@ func (r *Reconciler) manageUiComponent(ctx context.Context, th *v1alpha1.TektonH
 	if !exist {
 		th.Status.MarkUiInstallerSetNotAvailable("UI installer set not available")
 		uiLocation := filepath.Join(hubDir, "ui")
-		err := r.setupAndCreateInstallerSet(ctx, uiLocation, th, uiInstallerSet, version, ui)
+
+		manifest, err := r.getManifest(ctx, th, uiLocation)
 		if err != nil {
 			return err
 		}
+
+		err = r.setUpAndCreateInstallerSet(ctx, *manifest, th, uiInstallerSet, version, ui)
+		if err != nil {
+			return err
+		}
+
 	}
 
 	err = r.checkComponentStatus(ctx, th, uiInstallerSet)
@@ -224,7 +232,18 @@ func (r *Reconciler) manageApiComponent(ctx context.Context, th *v1alpha1.Tekton
 	if !exist {
 		th.Status.MarkApiInstallerSetNotAvailable("API installer set not available")
 		apiLocation := filepath.Join(hubDir, "api")
-		err := r.setupAndCreateInstallerSet(ctx, apiLocation, th, apiInstallerSet, version, api)
+
+		manifest, err := r.getManifest(ctx, th, apiLocation)
+		if err != nil {
+			return err
+		}
+
+		err = applyPVC(ctx, manifest, th)
+		if err != nil {
+			return err
+		}
+
+		err = r.setUpAndCreateInstallerSet(ctx, *manifest, th, apiInstallerSet, version, api)
 		if err != nil {
 			return err
 		}
@@ -248,7 +267,13 @@ func (r *Reconciler) manageDbMigrationComponent(ctx context.Context, th *v1alpha
 	if !exist {
 		dbMigrationLocation := filepath.Join(hubDir, "db-migration")
 		th.Status.MarkDatabasebMigrationFailed("DB migration installerset not available")
-		err = r.setupAndCreateInstallerSet(ctx, dbMigrationLocation, th, dbMigrationInstallerSet, version, dbMigration)
+
+		manifest, err := r.getManifest(ctx, th, dbMigrationLocation)
+		if err != nil {
+			return err
+		}
+
+		err = r.setUpAndCreateInstallerSet(ctx, *manifest, th, dbMigrationInstallerSet, version, dbMigration)
 		if err != nil {
 			return err
 		}
@@ -278,7 +303,17 @@ func (r *Reconciler) manageDbComponent(ctx context.Context, th *v1alpha1.TektonH
 	if !exist {
 		th.Status.MarkDbInstallerSetNotAvailable("DB installer set not available")
 		dbLocation := filepath.Join(hubDir, "db")
-		err := r.setupAndCreateInstallerSet(ctx, dbLocation, th, dbInstallerSet, version, db)
+		manifest, err := r.getManifest(ctx, th, dbLocation)
+		if err != nil {
+			return err
+		}
+
+		err = applyPVC(ctx, manifest, th)
+		if err != nil {
+			return err
+		}
+
+		err = r.setUpAndCreateInstallerSet(ctx, *manifest, th, dbInstallerSet, version, db)
 		if err != nil {
 			return err
 		}
@@ -423,15 +458,23 @@ func createUiConfigMap(name, namespace string, th *v1alpha1.TektonHub) *corev1.C
 	}
 }
 
-func (r *Reconciler) setupAndCreateInstallerSet(ctx context.Context, manifestLocation string, th *v1alpha1.TektonHub, installerSetName, version, prefixName string) error {
+func (r *Reconciler) getManifest(ctx context.Context, th *v1alpha1.TektonHub, manifestLocation string) (*mf.Manifest, error) {
 	manifest := r.manifest.Append()
-	logger := logging.FromContext(ctx)
 
 	if err := common.AppendManifest(&manifest, manifestLocation); err != nil {
-		return err
+		return nil, err
 	}
 
-	manifest = manifest.Filter(mf.Not(mf.Any(mf.ByKind("Secret"), mf.ByKind("Namespace"), mf.ByKind("ConfigMap"))))
+	transformedManifest, err := r.transform(ctx, manifest, th)
+	if err != nil {
+		return nil, err
+	}
+
+	return transformedManifest, nil
+}
+
+func (r *Reconciler) transform(ctx context.Context, manifest mf.Manifest, th *v1alpha1.TektonHub) (*mf.Manifest, error) {
+	logger := logging.FromContext(ctx)
 
 	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.HubImagePrefix))
 	trans := r.extension.Transformers(th)
@@ -446,8 +489,35 @@ func (r *Reconciler) setupAndCreateInstallerSet(ctx context.Context, manifestLoc
 
 	if err != nil {
 		logger.Error("failed to transform manifest")
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+func applyPVC(ctx context.Context, manifest *mf.Manifest, th *v1alpha1.TektonHub) error {
+	logger := logging.FromContext(ctx)
+
+	pvc := manifest.Filter(mf.ByKind("PersistentVolumeClaim"))
+	pvcManifest, err := pvc.Transform(
+		mf.InjectOwner(th),
+		mf.InjectNamespace(th.Spec.GetTargetNamespace()),
+	)
+
+	if err != nil {
+		logger.Error("failed to transform manifest")
 		return err
 	}
+
+	if err := pvcManifest.Apply(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconciler) setUpAndCreateInstallerSet(ctx context.Context, manifest mf.Manifest, th *v1alpha1.TektonHub, installerSetName, version, prefixName string) error {
+	manifest = manifest.Filter(mf.Not(mf.Any(mf.ByKind("Secret"), mf.ByKind("PersistentVolumeClaim"), mf.ByKind("Namespace"), mf.ByKind("ConfigMap"))))
 
 	if err := createInstallerSet(ctx, r.operatorClientSet, th, manifest,
 		version, installerSetName, prefixName, namespace); err != nil {


### PR DESCRIPTION
When operator is upgraded, new hub db is getting created and all the
data from the db gets deleted

Hence this patch fixes this by applying the pvc first by injecting the
owner reference and then filtering out pvc from the installerset

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
