### PR TITLE
Replace polling based logic in reconcilers with requeue

### DIFF
--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	informer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
@@ -27,8 +26,6 @@ import (
 )
 
 var (
-	Interval = 10 * time.Second
-	Timeout  = 1 * time.Minute
 	// DefaultSA is the default service account
 	DefaultSA = "pipeline"
 )

--- a/pkg/reconciler/kubernetes/tektonconfig/extension.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension.go
@@ -55,7 +55,7 @@ func (oe kubernetesExtension) PostReconcile(ctx context.Context, comp v1alpha1.T
 	}
 
 	if configInstance.Spec.Profile == v1alpha1.ProfileLite || configInstance.Spec.Profile == v1alpha1.ProfileBasic {
-		return extension.TektonDashboardCRDelete(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
+		return extension.EnsureTektonDashboardCRNotExists(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonDashboards())
 	}
 
 	return nil
@@ -63,7 +63,7 @@ func (oe kubernetesExtension) PostReconcile(ctx context.Context, comp v1alpha1.T
 func (oe kubernetesExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 	if configInstance.Spec.Profile == v1alpha1.ProfileAll {
-		return extension.TektonDashboardCRDelete(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
+		return extension.EnsureTektonDashboardCRNotExists(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonDashboards())
 	}
 	return nil
 }

--- a/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package extension
 
 import (
+	"context"
+	"os"
 	"testing"
+
+	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
@@ -27,53 +31,97 @@ import (
 	ts "knative.dev/pkg/reconciler/testing"
 )
 
-func TestTektonDashboardCreateAndDeleteCR(t *testing.T) {
+func TestEnsureTektonDashbordExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
 	tConfig := pipeline.GetTektonConfig()
+
+	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
-	util.AssertNotEqual(t, err, nil)
-	err = TektonDashboardCRDelete(ctx, c.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
-	util.AssertEqual(t, err, nil)
-}
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-func TestTektonDashboardUpdate(t *testing.T) {
-	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
-	c := fake.Get(ctx)
-	tConfig := pipeline.GetTektonConfig()
-	_, err := createDashboard(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
-	util.AssertEqual(t, err, nil)
-	// to update dashboard instance
-	tConfig = &v1alpha1.TektonConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: v1alpha1.ConfigResourceName,
-		},
-		Spec: v1alpha1.TektonConfigSpec{
-			Profile: "all",
-			CommonSpec: v1alpha1.CommonSpec{
-				TargetNamespace: "tekton-pipelines1",
-			},
-			Dashboard: v1alpha1.Dashboard{
-				DashboardProperties: v1alpha1.DashboardProperties{
-					Readonly: false,
-				},
-			},
-			Config: v1alpha1.Config{
-				NodeSelector: map[string]string{
-					"key": "value",
-				},
-			},
-		},
-	}
+	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
+	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
 	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
-	util.AssertNotEqual(t, err, nil)
-	err = TektonDashboardCRDelete(ctx, c.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
+	util.AssertEqual(t, err, v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR)
+
+	// make upgrade checks pass
+	makeUpgradeCheckPass(t, ctx, c.OperatorV1alpha1().TektonDashboards())
+
+	// next invocation should return RECONCILE_AGAIN_ERR as Dashboard is waiting for installation (prereconcile, postreconcile, installersets...)
+	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// mark the instance ready
+	markDashboardsReady(t, ctx, c.OperatorV1alpha1().TektonDashboards())
+
+	// next invocation should return nil error as the instance is ready
+	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
+	util.AssertEqual(t, err, nil)
+
+	// test update propagation from tektonConfig
+	tConfig.Spec.TargetNamespace = "foobar"
+	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
 	util.AssertEqual(t, err, nil)
 }
 
-func TestTektonDashboardCRDelete(t *testing.T) {
+func TestEnsureTektonDashboardCRNotExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonDashboardCRDelete(ctx, c.OperatorV1alpha1().TektonDashboards(), v1alpha1.DashboardResourceName)
+
+	// when no instance exists, nil error is returned immediately
+	err := EnsureTektonDashboardCRNotExists(ctx, c.OperatorV1alpha1().TektonDashboards())
 	util.AssertEqual(t, err, nil)
+
+	// create an instance for testing other cases
+	tConfig := pipeline.GetTektonConfig()
+	_, err = EnsureTektonDashboardExists(ctx, c.OperatorV1alpha1().TektonDashboards(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when an instance exists the first invoacation should make the delete API call and
+	// return RECONCILE_AGAI_ERROR. So that the deletion can be confirmed in a subsequent invocation
+	err = EnsureTektonDashboardCRNotExists(ctx, c.OperatorV1alpha1().TektonDashboards())
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when the instance is completely removed from a cluster, the function should return nil error
+	err = EnsureTektonDashboardCRNotExists(ctx, c.OperatorV1alpha1().TektonDashboards())
+	util.AssertEqual(t, err, nil)
+}
+
+func markDashboardsReady(t *testing.T, ctx context.Context, c op.TektonDashboardInterface) {
+	t.Helper()
+	td, err := c.Get(ctx, v1alpha1.DashboardResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	td.Status.MarkDependenciesInstalled()
+	td.Status.MarkPreReconcilerComplete()
+	td.Status.MarkInstallerSetAvailable()
+	td.Status.MarkInstallerSetReady()
+	td.Status.MarkPostReconcilerComplete()
+	_, err = c.UpdateStatus(ctx, td, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonDashboardInterface) {
+	t.Helper()
+	// set necessary version labels to make upgrade check pass
+	dashboard, err := c.Get(ctx, v1alpha1.DashboardResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	setDummyVersionLabel(dashboard)
+	_, err = c.Update(ctx, dashboard, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func setDummyVersionLabel(td *v1alpha1.TektonDashboard) {
+	oprVersion := "v1.2.3"
+	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+
+	labels := td.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[v1alpha1.ReleaseVersionKey] = oprVersion
+	td.SetLabels(labels)
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -108,7 +108,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	}
 
 	if configInstance.Spec.Profile == v1alpha1.ProfileLite || configInstance.Spec.Profile == v1alpha1.ProfileBasic {
-		return extension.TektonAddonCRDelete(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName)
+		return extension.EnsureTektonAddonCRNotExists(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonAddons())
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 	if configInstance.Spec.Profile == v1alpha1.ProfileAll {
-		if err := extension.TektonAddonCRDelete(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), v1alpha1.AddonResourceName); err != nil {
+		if err := extension.EnsureTektonAddonCRNotExists(ctx, oe.operatorClientSet.OperatorV1alpha1().TektonAddons()); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
@@ -17,27 +17,110 @@ limitations under the License.
 package pipeline
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+
+	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	ts "knative.dev/pkg/reconciler/testing"
 )
 
-func TestTektonPipelineCreateAndDeleteCR(t *testing.T) {
+func TestEnsureTektonPipelineExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
 	tConfig := GetTektonConfig()
+
+	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
-	util.AssertEqual(t, err.Error(), "reconcile again and proceed")
-	err = TektonPipelineCRDelete(ctx, c.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
+	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR)
+
+	// make upgrade checks pass
+	makeUpgradeCheckPass(t, ctx, c.OperatorV1alpha1().TektonPipelines())
+
+	// next invocation should return RECONCILE_AGAIN_ERR as Dashboard is waiting for installation (prereconcile, postreconcile, installersets...)
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// mark the instance ready
+	markPipelineReady(t, ctx, c.OperatorV1alpha1().TektonPipelines())
+
+	// next invocation should return nil error as the instance is ready
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err, nil)
+
+	// test update propagation from tektonConfig
+	tConfig.Spec.TargetNamespace = "foobar"
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
 	util.AssertEqual(t, err, nil)
 }
 
-func TestTektonPipelineCRDelete(t *testing.T) {
+func TestEnsureTektonPipelineCRNotExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonPipelineCRDelete(ctx, c.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
+
+	// when no instance exists, nil error is returned immediately
+	err := EnsureTektonPipelineCRNotExists(ctx, c.OperatorV1alpha1().TektonPipelines())
 	util.AssertEqual(t, err, nil)
+
+	// create an instance for testing other cases
+	tConfig := GetTektonConfig()
+	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when an instance exists the first invoacation should make the delete API call and
+	// return RECONCILE_AGAI_ERROR. So that the deletion can be confirmed in a subsequent invocation
+	err = EnsureTektonPipelineCRNotExists(ctx, c.OperatorV1alpha1().TektonPipelines())
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when the instance is completely removed from a cluster, the function should return nil error
+	err = EnsureTektonPipelineCRNotExists(ctx, c.OperatorV1alpha1().TektonPipelines())
+	util.AssertEqual(t, err, nil)
+}
+
+func markPipelineReady(t *testing.T, ctx context.Context, c op.TektonPipelineInterface) {
+	t.Helper()
+	tp, err := c.Get(ctx, v1alpha1.PipelineResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	tp.Status.MarkPreReconcilerComplete()
+	tp.Status.MarkInstallerSetAvailable()
+	tp.Status.MarkInstallerSetReady()
+	tp.Status.MarkPostReconcilerComplete()
+	_, err = c.UpdateStatus(ctx, tp, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonPipelineInterface) {
+	t.Helper()
+	// set necessary version labels to make upgrade check pass
+	pipeline, err := c.Get(ctx, v1alpha1.PipelineResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	setDummyVersionLabel(pipeline)
+	_, err = c.Update(ctx, pipeline, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func setDummyVersionLabel(tp *v1alpha1.TektonPipeline) {
+	oprVersion := "v1.2.3"
+	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+
+	labels := tp.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[v1alpha1.ReleaseVersionKey] = oprVersion
+	tp.SetLabels(labels)
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -60,13 +60,13 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 	}
 
 	if original.Spec.Profile == v1alpha1.ProfileLite {
-		return pipeline.TektonPipelineCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName)
+		return pipeline.EnsureTektonPipelineCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines())
 	} else {
 		// TektonPipeline and TektonTrigger is common for profile type basic and all
-		if err := trigger.TektonTriggerCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName); err != nil {
+		if err := trigger.EnsureTektonTriggerCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers()); err != nil {
 			return err
 		}
-		if err := pipeline.TektonPipelineCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), v1alpha1.PipelineResourceName); err != nil {
+		if err := pipeline.EnsureTektonPipelineCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines()); err != nil {
 			return err
 		}
 	}
@@ -127,7 +127,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 	} else {
-		if err := trigger.TektonTriggerCRDelete(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName); err != nil {
+		if err := trigger.EnsureTektonTriggerCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers()); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
@@ -18,7 +18,6 @@ package trigger
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func EnsureTektonTriggerExists(ctx context.Context, clients op.TektonTriggerInterface, config *v1alpha1.TektonConfig) (*v1alpha1.TektonTrigger, error) {
@@ -135,41 +133,6 @@ func isTektonTriggerReady(s *v1alpha1.TektonTrigger, err error) (bool, error) {
 	return s.Status.IsReady(), err
 }
 
-// TektonTriggerCRDelete deletes tha TektonTrigger to see if all resources will be deleted
-func TektonTriggerCRDelete(ctx context.Context, clients op.TektonTriggerInterface, name string) error {
-	if _, err := GetTrigger(ctx, clients, v1alpha1.TriggerResourceName); err != nil {
-		if apierrs.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if err := clients.Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("TektonTrigger %q failed to delete: %v", name, err)
-	}
-	err := wait.PollImmediate(common.Interval, common.Timeout, func() (bool, error) {
-		_, err := clients.Get(ctx, name, metav1.GetOptions{})
-		if apierrs.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		return fmt.Errorf("Timed out waiting on TektonTrigger to delete %v", err)
-	}
-	return verifyNoTektonTriggerCR(ctx, clients)
-}
-
-func verifyNoTektonTriggerCR(ctx context.Context, clients op.TektonTriggerInterface) error {
-	triggers, err := clients.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	if len(triggers.Items) > 0 {
-		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonTrigger exists")
-	}
-	return nil
-}
-
 func GetTektonConfig() *v1alpha1.TektonConfig {
 	return &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -182,4 +145,26 @@ func GetTektonConfig() *v1alpha1.TektonConfig {
 			},
 		},
 	}
+}
+
+func EnsureTektonTriggerCRNotExists(ctx context.Context, clients op.TektonTriggerInterface) error {
+	if _, err := GetTrigger(ctx, clients, v1alpha1.TriggerResourceName); err != nil {
+		if apierrs.IsNotFound(err) {
+			// TektonTrigger CR is gone, hence return nil
+			return nil
+		}
+		return err
+	}
+	// if the Get was successful, try deleting the CR
+	if err := clients.Delete(ctx, v1alpha1.TriggerResourceName, metav1.DeleteOptions{}); err != nil {
+		if apierrs.IsNotFound(err) {
+			// TektonTrigger CR is gone, hence return nil
+			return nil
+		}
+		return fmt.Errorf("TektonTrigger %q failed to delete: %v", v1alpha1.TriggerResourceName, err)
+	}
+	// if the Delete API call was success,
+	// then return requeue_event
+	// so that in a subsequent reconcile call the absence of the CR is verified by one of the 2 checks above
+	return v1alpha1.RECONCILE_AGAIN_ERR
 }

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -17,27 +17,111 @@ limitations under the License.
 package trigger
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	ts "knative.dev/pkg/reconciler/testing"
 )
 
-func TestTektonTriggerCreateAndDeleteCR(t *testing.T) {
+func TestEnsureTektonTriggerExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
 	tConfig := GetTektonConfig()
+
+	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
-	util.AssertEqual(t, err.Error(), "reconcile again and proceed")
-	err = TektonTriggerCRDelete(ctx, c.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
+	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR)
+
+	// make upgrade checks pass
+	makeUpgradeCheckPass(t, ctx, c.OperatorV1alpha1().TektonTriggers())
+
+	// next invocation should return RECONCILE_AGAIN_ERR as Dashboard is waiting for installation (prereconcile, postreconcile, installersets...)
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// mark the instance ready
+	markTriggersReady(t, ctx, c.OperatorV1alpha1().TektonTriggers())
+
+	// next invocation should return nil error as the instance is ready
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err, nil)
+
+	// test update propagation from tektonConfig
+	tConfig.Spec.TargetNamespace = "foobar"
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
 	util.AssertEqual(t, err, nil)
 }
 
-func TestTektonTriggerCRDelete(t *testing.T) {
+func TestEnsureTektonTriggerCRNotExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	err := TektonTriggerCRDelete(ctx, c.OperatorV1alpha1().TektonTriggers(), v1alpha1.TriggerResourceName)
+
+	// when no instance exists, nil error is returned immediately
+	err := EnsureTektonTriggerCRNotExists(ctx, c.OperatorV1alpha1().TektonTriggers())
 	util.AssertEqual(t, err, nil)
+
+	// create an instance for testing other cases
+	tConfig := GetTektonConfig()
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when an instance exists the first invoacation should make the delete API call and
+	// return RECONCILE_AGAI_ERROR. So that the deletion can be confirmed in a subsequent invocation
+	err = EnsureTektonTriggerCRNotExists(ctx, c.OperatorV1alpha1().TektonTriggers())
+	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+
+	// when the instance is completely removed from a cluster, the function should return nil error
+	err = EnsureTektonTriggerCRNotExists(ctx, c.OperatorV1alpha1().TektonTriggers())
+	util.AssertEqual(t, err, nil)
+}
+
+func markTriggersReady(t *testing.T, ctx context.Context, c op.TektonTriggerInterface) {
+	t.Helper()
+	tr, err := c.Get(ctx, v1alpha1.TriggerResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	tr.Status.MarkDependenciesInstalled()
+	tr.Status.MarkPreReconcilerComplete()
+	tr.Status.MarkInstallerSetAvailable()
+	tr.Status.MarkInstallerSetReady()
+	tr.Status.MarkPostReconcilerComplete()
+	_, err = c.UpdateStatus(ctx, tr, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonTriggerInterface) {
+	t.Helper()
+	// set necessary version labels to make upgrade check pass
+	trigger, err := c.Get(ctx, v1alpha1.TriggerResourceName, metav1.GetOptions{})
+	util.AssertEqual(t, err, nil)
+	setDummyVersionLabel(trigger)
+	_, err = c.Update(ctx, trigger, metav1.UpdateOptions{})
+	util.AssertEqual(t, err, nil)
+}
+
+func setDummyVersionLabel(tr *v1alpha1.TektonTrigger) {
+	oprVersion := "v1.2.3"
+	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+
+	labels := tr.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[v1alpha1.ReleaseVersionKey] = oprVersion
+	tr.SetLabels(labels)
 }

--- a/test/utils/cleanup.go
+++ b/test/utils/cleanup.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -195,7 +194,7 @@ func TearDownNamespace(clients *Clients, name string) {
 		return
 	}
 
-	err = waitForCondition(ctx, func() (bool, error) {
+	err = WaitForCondition(ctx, func() (bool, error) {
 		_, err := clients.KubeClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -347,15 +346,15 @@ func waitUntilFullDeletion(ctx context.Context, cdcf crDeleteVerifier, ddcf depl
 }
 
 func ensureCustomResourceRemoval(ctx context.Context, verifier crDeleteVerifier) error {
-	return waitForCondition(ctx, wait.ConditionFunc(verifier))
+	return WaitForCondition(ctx, wait.ConditionFunc(verifier))
 }
 
 func ensureDeploymentsRemoval(ctx context.Context, verifier deploymentDeleteVerifier) error {
-	return waitForCondition(ctx, wait.ConditionFunc(verifier))
+	return WaitForCondition(ctx, wait.ConditionFunc(verifier))
 }
 
-func waitForCondition(ctx context.Context, condition wait.ConditionFunc) error {
-	return wait.PollImmediate(common.Interval, common.Timeout, func() (done bool, err error) {
+func WaitForCondition(ctx context.Context, condition wait.ConditionFunc) error {
+	return wait.PollImmediate(Interval, Timeout, func() (done bool, err error) {
 		ok, err := condition()
 		if err != nil {
 			return false, err

--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -1,0 +1,8 @@
+package utils
+
+import "time"
+
+var (
+	Interval = 10 * time.Second
+	Timeout  = 5 * time.Minute
+)


### PR DESCRIPTION
Replace polling based logic in reconcilers with requeues

Improve Unit tests

For components:

- Addons
- Dashboard
- Pipeline
- Triggers


Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```