### PR TITLE
Generate standalone CRDs manifests and update Helm chart in release pipeline

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.1.0
 # corresponds to the version of tekton-operator
 # https://github.com/tektoncd/operator/releases
-appVersion: "v0.57.0"
+appVersion: "devel"
 maintainers:
   - name: Jack Henschel
     email: jack.henschel@cern.ch

--- a/hack/release-common.sh
+++ b/hack/release-common.sh
@@ -20,6 +20,9 @@ function set_version_label() {
     sed -i -e 's/\(operator.tekton.dev\/release\): "devel"/\1: '${operator_version}'/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: '${operator_version}'/g' -e 's/\(version\): "devel"/\1: '${operator_version}'/g' -e 's/\("-version"\), "devel"/\1, '${operator_version}'/g' cmd/${platform}/operator/kodata/webhook/*.yaml
     sed -i 's/\(value\): "devel"/\1: '${operator_version}'/g' config/${platform}/base/operator.yaml
   done
+
+  echo updating Helm chart version to ${operator_version}
+  sed -i 's/appVersion: "devel"/appVersion: "'${operator_version}'"/g' chart/Chart.yaml
 }
 
 function remote_exists_or_fail() {

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -133,6 +133,9 @@ spec:
       # This is currently the case for `cri-o` (and most likely others)
       kustomize build ${PROJECT_ROOT}/config/${KUBE_DISTRO}/overlays/default | ko resolve --platform=$(params.platforms) --preserve-import-paths -f - > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.notags.yaml
 
+      # Extract CRDs as separate manifests from release.yaml
+      cat $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.yaml | yq '. | select(.kind == "CustomResourceDefinition") | .' > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}crds.yaml
+
   - name: koparse
     image: gcr.io/tekton-releases/dogfooding/koparse:latest
     script: |

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -76,6 +76,12 @@ spec:
   - name: release-file-no-tag
     description: the URL of the release file for OpenShift platform
     value: $(tasks.report-bucket.results.openshift-release-no-tag)
+  - name: crds-file
+    description: the URL of the Kubernetes CRD manifests
+    value: $(tasks.report-bucket.results.crds)
+  - name: openshift-crds-file
+    description: the URL of the Openshift CRD manifests
+    value: $(tasks.report-bucket.results.openshift-crds)
   tasks:
   - name: git-clone
     taskRef:
@@ -289,6 +295,10 @@ spec:
         description: The full URL of the release file (platform - OpenShift) in the bucket
       - name: openshift-release-no-tag
         description: The full URL of the release file (no tag, platform - OpenShift) in the bucket
+      - name: crds
+        description: The full URL of the Kubernetes CRD manifests in the bucket
+      - name: openshift-crds
+        description: The full URL of the Openshift CRD manifests in the bucket
       steps:
       - name: create-results
         image: alpine
@@ -300,3 +310,5 @@ spec:
           echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
           echo "${BASE_URL}/openshift-release.yaml" > $(results.openshift-release.path)
           echo "${BASE_URL}/openshift-release.notags.yaml" > $(results.openshift-release-no-tag.path)
+          echo "${BASE_URL}/crds.yaml" > $(results.crds.path)
+          echo "${BASE_URL}/openshift-crds.yaml" > $(results.openshift-crds.path)


### PR DESCRIPTION
As discussed in https://github.com/tektoncd/operator/issues/793 it would be useful to have separate CRD.yaml manifests attached to the Github releases.
While I'm working on modifying the pipeline, I also added a small change that will automatically set the correct version on the Helm chart when a new release is created.

# Changes

* Generate standalone CRDs manifests attached to the Github releases - fixes https://github.com/tektoncd/operator/issues/793
* Update image versions used in Helm chart when creating a new release - fixes https://github.com/tektoncd/operator/issues/792

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._
