### PR TITLE
Increase e2e poll timeout to 10min

### DIFF
--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -4,5 +4,5 @@ import "time"
 
 var (
 	Interval = 10 * time.Second
-	Timeout  = 5 * time.Minute
+	Timeout  = 10 * time.Minute
 )


### PR DESCRIPTION
Set e2e poll timeout to 10 min to avoid flakes like

```
    tektonconfigs.go:122: TektonConfigCR "config" failed to get to the READY status: tektonconfig config is not in desired state, got: <nil>: timed out waiting for the condition

```

This is necessary because of the new wait on namespace deletion at the end of each e2e test group.


Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```