### PR TITLE
Update the PipelinesAsCode reconciler to support latest version

### DIFF
--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -209,7 +209,9 @@ image-substitutions:
       - deploymentName: openshift-pipelines-operator
         containerName: openshift-pipelines-operator
         envKeys:
-          - IMAGE_PAC_TRIGGERTEMPLATE_APPLY_AND_LAUNCH
+          - IMAGE_PAC_CONTROLLER
+          - IMAGE_PAC_WEBHOOK
+          - IMAGE_PAC_WATCHER
 
 # add third party images which are not replaced by operator
 # but pulled directly by tasks here

--- a/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 
@@ -77,13 +76,11 @@ func (r *Reconciler) ensurePAC(ctx context.Context, ta *v1alpha1.TektonAddon) er
 	// to skip it we filter out namespace
 	pacManifest = pacManifest.Filter(mf.Not(mf.ByKind("Namespace")))
 
+	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.PacImagePrefix))
 	// Run transformers
 	tfs := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(openshift.OperandOpenShiftPipelineAsCode),
-	}
-	// don't run the transformer if no replace images are found
-	if triggerTemplateSteps := pacTriggerTemplateStepImages(); len(triggerTemplateSteps) > 0 {
-		tfs = append(tfs, replacePACTriggerTemplateImages(triggerTemplateSteps))
+		common.DeploymentImages(images),
 	}
 
 	if err := r.addonTransform(ctx, &pacManifest, ta, tfs...); err != nil {
@@ -96,27 +93,4 @@ func (r *Reconciler) ensurePAC(ctx context.Context, ta *v1alpha1.TektonAddon) er
 	}
 
 	return nil
-}
-
-// pacTriggerTemplateStepImages returns a map[string]string with key as step name and
-// value as image name to be replaced with, from the env vars that start with
-// IMAGE_PAC_
-func pacTriggerTemplateStepImages() map[string]string {
-	triggerTemplateSteps := make(map[string]string)
-
-	// pacImage is a map[string]string which will have key-values like
-	// "triggertemplate_apply_and_launch": "registry.example.io/pac-image"
-	pacImages := common.ToLowerCaseKeys(common.ImagesFromEnv(common.PacImagePrefix))
-	for env, image := range pacImages {
-		prefix := "triggertemplate_"
-		if strings.HasPrefix(env, prefix) {
-			// step 3: "apply-and-launch": "registry.example.io/pac-image"
-			triggerTemplateSteps[
-			// step 2: apply_and_launch --> apply-and-launch
-			strings.ReplaceAll(
-				// step 1: triggertemplate_apply_and_launch --> apply_and_launch
-				strings.TrimPrefix(env, prefix), "_", "-")] = image
-		}
-	}
-	return triggerTemplateSteps
 }

--- a/pkg/reconciler/openshift/tektonaddon/transformer.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer.go
@@ -17,14 +17,10 @@ limitations under the License.
 package tektonaddon
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 
 	mf "github.com/manifestival/manifestival"
 	console "github.com/openshift/api/console/v1"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -163,87 +159,6 @@ func setVersionedNames(operatorVersion string) mf.Transformer {
 		formattedVersion := formattedVersionMajorMinorX(operatorVersion, versionedClusterTaskPatchChar)
 		name = fmt.Sprintf("%s-%s", name, formattedVersion)
 		u.SetName(name)
-		return nil
-	}
-}
-
-// replacePACTriggerTemplateImages replaces images in all the TriggerTemplates that
-// PAC creates. It takes a map with key as step name and value as image and replaces
-// it in TaskRun.Spec.TaskSpec.Steps if that step is present.
-func replacePACTriggerTemplateImages(stepsImages map[string]string) mf.Transformer {
-	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "TriggerTemplate" {
-			return nil
-		}
-
-		tt := &triggersv1beta1.TriggerTemplate{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, tt)
-		if err != nil {
-			return err
-		}
-
-		// we want the label "app.kubernetes.io/part-of: pipelines-as-code" on the
-		// TriggerTemplate to make sure we are working with a PAC TriggerTemplate
-		if partOfValue, ok := tt.ObjectMeta.Labels["app.kubernetes.io/part-of"]; ok {
-			if partOfValue != "pipelines-as-code" {
-				return nil
-			}
-		}
-
-		for i, resourceTemplate := range tt.Spec.ResourceTemplates {
-			// let' start by checking that we are only dealing with a TaskRun
-
-			// first we need to decode the raw ResourceTemplate
-			rawReader := mf.Reader(bytes.NewReader(resourceTemplate.RawExtension.Raw))
-			rawObjects, err := rawReader.Parse()
-			if err != nil {
-				return err
-			}
-
-			if len(rawObjects) == 0 {
-				// if no object is present in the ResourceTemplate, we don't want to proceed
-				return nil
-			} else if len(rawObjects) > 1 {
-				// while this will never happen, let's check for it just in case
-				return fmt.Errorf("more than one resources present in a ResourceTemplate")
-			}
-
-			// we only care about TaskRuns in ResourceTemplate for image replacement
-			if rawObjects[0].GetKind() != "TaskRun" {
-				return nil
-			}
-
-			// now that we know it's a TaskRun, let's decode and move forward
-			taskRun := pipelinev1beta1.TaskRun{}
-			decoder := json.NewDecoder(bytes.NewBuffer(resourceTemplate.RawExtension.Raw))
-			if err := decoder.Decode(&taskRun); err != nil {
-				return err
-			}
-
-			for j, step := range taskRun.Spec.TaskSpec.Steps {
-				// if the step exists, then replace the image
-				if image, ok := stepsImages[step.Name]; ok {
-					step.Container.Image = image
-					taskRun.Spec.TaskSpec.Steps[j] = step
-				}
-			}
-
-			// encode the TaskRun back to []byte
-			trJson, err := json.Marshal(taskRun)
-			if err != nil {
-				return err
-			}
-
-			resourceTemplate.RawExtension.Raw = trJson
-			tt.Spec.ResourceTemplates[i] = resourceTemplate
-		}
-
-		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt)
-		if err != nil {
-			return err
-		}
-		u.SetUnstructuredContent(unstrObj)
-
 		return nil
 	}
 }

--- a/pkg/reconciler/openshift/tektonaddon/transformer_test.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer_test.go
@@ -17,18 +17,13 @@ limitations under the License.
 package tektonaddon
 
 import (
-	"bytes"
-	"encoding/json"
-	"os"
 	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	console "github.com/openshift/api/console/v1"
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
-	triggersv1beta1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1beta1"
 	"gotest.tools/v3/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -77,46 +72,5 @@ func TestSetVersionedNames(t *testing.T) {
 
 	if d := cmp.Diff(expectedManifest.Resources(), newManifest.Resources()); d != "" {
 		t.Errorf("failed to update versioned clustertask name %s", diff.PrintWantGot(d))
-	}
-}
-
-func TestReplacePACTriggerTemplateImages(t *testing.T) {
-	testData := path.Join("testdata", "test-triggertemplate-taskrun.yaml")
-	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assert.NilError(t, err)
-
-	stepName := "apply-and-launch"
-	pacTestImage := "registry.test.io/openshift-pipelines/pipelines-as-code"
-	err = os.Setenv("IMAGE_PAC_TRIGGERTEMPLATE_APPLY_AND_LAUNCH", pacTestImage)
-	assert.NilError(t, err)
-
-	pacImages := pacTriggerTemplateStepImages()
-	t.Log(pacImages)
-	assert.Equal(t, len(pacImages), 1)
-
-	transformedManifest, err := manifest.Transform(replacePACTriggerTemplateImages(pacImages))
-	assert.NilError(t, err)
-
-	for _, resource := range transformedManifest.Resources() {
-		// replacement is only done for TriggerTemplates
-		if resource.GetKind() != "TriggerTemplate" {
-			continue
-		}
-		tt := &triggersv1beta1.TriggerTemplate{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, tt)
-		assert.NilError(t, err)
-
-		for _, resourceTemplate := range tt.Spec.ResourceTemplates {
-			taskRun := pipelinev1beta1.TaskRun{}
-			decoder := json.NewDecoder(bytes.NewBuffer(resourceTemplate.RawExtension.Raw))
-			err := decoder.Decode(&taskRun)
-			assert.NilError(t, err)
-
-			for _, step := range taskRun.Spec.TaskSpec.Steps {
-				if step.Name == stepName {
-					assert.Equal(t, step.Container.Image, pacTestImage)
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION


# Changes

There is no more TriggerTemplate *but* there is now 3 new images. This
updates the reconciler and the yamls to support the latest release of
PAC in the operator.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature

/cc @concaf @nikhil-thomas @sm43 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Update Pipeline As Code reconciler to work with latest : no more trigger template and 3 images.
```
