### PR TITLE
[Cherry-pick] Checks and updates ownerRef of Hub-db pvc if Hub instance is already created

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -54,7 +54,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, installerSet *v1alpha1.Te
 	// Delete all resources except CRDs and Namespace as they are own by owner of
 	// TektonInstallerSet
 	// They will be deleted when the component CR is deleted
-	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs)))
+	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs, pvcPred)))
 	err = deleteManifests.Delete(mf.PropagationPolicy(v1.DeletePropagationForeground))
 	if err != nil {
 		logger.Error("failed to delete resources")


### PR DESCRIPTION
- If Hub instance is already created, then the data in the Hub db should
be preserved

- Hence, this patch checks the ownerRef of hub-db pvc and updates it
to `TektonHub` so while upgrade the pvc is not deleted and the data
is preserved

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
