### PR TITLE
Set version in TektonConfig status in main reconciler

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -18,8 +18,9 @@ package v1alpha1
 
 import (
 	"fmt"
-	"knative.dev/pkg/controller"
 	"time"
+
+	"knative.dev/pkg/controller"
 )
 
 const (

--- a/pkg/reconciler/common/transformer_injectlabel_test.go
+++ b/pkg/reconciler/common/transformer_injectlabel_test.go
@@ -1,12 +1,13 @@
 package common
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	"gotest.tools/v3/assert"
 	"k8s.io/apimachinery/pkg/labels"
-	"path/filepath"
-	"testing"
 )
 
 func TestInjectOperandNameLabel(t *testing.T) {

--- a/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
+++ b/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
@@ -19,6 +19,7 @@ package tektonchain
 import (
 	"context"
 	"fmt"
+
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	clientset "github.com/tektoncd/operator/pkg/client/clientset/versioned"

--- a/pkg/reconciler/openshift/tektonaddon/clustertTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTask.go
@@ -19,11 +19,12 @@ package tektonaddon
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 var clusterTaskLS = metav1.LabelSelector{

--- a/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
@@ -18,10 +18,11 @@ package tektonaddon
 
 import (
 	"context"
-	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -19,7 +19,6 @@ package tektonaddon
 import (
 	"context"
 	"fmt"
-	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +31,7 @@ import (
 	tektonaddonreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonaddon"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"

--- a/pkg/reconciler/openshift/tektonconfig/common.go
+++ b/pkg/reconciler/openshift/tektonconfig/common.go
@@ -43,7 +43,6 @@ func createInstallerSet(ctx context.Context, oc versioned.Interface, tc *v1alpha
 
 	// Update the status of tektonConfig with created installerSet name
 	tc.Status.TektonInstallerSet[rbacInstallerSetType] = createdIs.Name
-	tc.Status.SetVersion(releaseVersion)
 	return nil
 }
 

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -79,6 +79,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfig) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	tc.Status.InitializeConditions()
+	tc.Status.SetVersion(r.operatorVersion)
 
 	logger.Infow("Reconciling TektonConfig", "status", tc.Status)
 	if tc.GetName() != v1alpha1.ConfigResourceName {

--- a/test/resources/cosign.go
+++ b/test/resources/cosign.go
@@ -19,9 +19,10 @@ package resources
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/sigstore/cosign/cmd/cosign/cli"
 	"github.com/sigstore/cosign/pkg/cosign/kubernetes"
-	"os"
 )
 
 func CosignGenerateKeyPair(namespace, secretName string) error {


### PR DESCRIPTION
there was a issue reported where after upgrade version was not getting updated
it is not reproducible but this fix sets the version at the start of main reconciler

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
