### PR TITLE
[Cherry-pick] Refactors the check for Hub pvc and fixes the duplication of Hub installerset when there is an operator upgrade

### DIFF
--- a/pkg/reconciler/kubernetes/tektonhub/controller.go
+++ b/pkg/reconciler/kubernetes/tektonhub/controller.go
@@ -60,11 +60,17 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalw("Error creating initial manifest", zap.Error(err))
 		}
 
+		operatorVer, err := common.OperatorVersion(ctx)
+		if err != nil {
+			logger.Fatal(err)
+		}
+
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),
 			extension:         generator(ctx),
 			manifest:          manifest,
+			operatorVersion:   operatorVer,
 		}
 		impl := tektonHubReconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -137,6 +137,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, th *v1alpha1.TektonHub) 
 	}
 	th.Status.MarkPreReconcilerComplete()
 
+	// TODO: remove this after operator openshift-build version 1.8
+	if err := r.checkDbApiPVCOwnerRef(ctx, th); err != nil {
+		return err
+	}
+
 	// Manage DB
 	if err := r.manageDbComponent(ctx, th, hubDir, version); err != nil {
 		return r.handleError(err, th)
@@ -224,25 +229,6 @@ func (r *Reconciler) manageApiComponent(ctx context.Context, th *v1alpha1.Tekton
 
 	th.Status.MarkApiDependenciesInstalled()
 
-	pvc, err := r.checkPVC(ctx, th, "tekton-hub-api")
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if pvc != nil {
-		if !r.checkPVCOwnerRef(pvc, th) {
-			ownerRef := *metav1.NewControllerRef(th, th.GroupVersionKind())
-			pvc.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-
-			_, err := r.kubeClientSet.CoreV1().PersistentVolumeClaims(th.Spec.GetTargetNamespace()).Update(ctx, pvc, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, version, th, apiInstallerSet)
 	if err != nil {
 		return err
@@ -313,24 +299,6 @@ func (r *Reconciler) manageDbComponent(ctx context.Context, th *v1alpha1.TektonH
 		return err
 	}
 	th.Status.MarkDbDependenciesInstalled()
-
-	pvc, err := r.checkPVC(ctx, th, "tekton-hub-db")
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if pvc != nil {
-		if !r.checkPVCOwnerRef(pvc, th) {
-			ownerRef := *metav1.NewControllerRef(th, th.GroupVersionKind())
-			pvc.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
-			_, err := r.kubeClientSet.CoreV1().PersistentVolumeClaims(th.Spec.GetTargetNamespace()).Update(ctx, pvc, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-		}
-	}
 
 	exist, err := checkIfInstallerSetExist(ctx, r.operatorClientSet, version, th, dbInstallerSet)
 	if err != nil {
@@ -532,6 +500,55 @@ func (r *Reconciler) transform(ctx context.Context, manifest mf.Manifest, th *v1
 	return &manifest, nil
 }
 
+// TODO: remove this after operator openshift-build version 1.8
+func (r *Reconciler) checkDbApiPVCOwnerRef(ctx context.Context, th *v1alpha1.TektonHub) error {
+	// Check and update pvc for db component
+	dbPvc, err := r.checkPVC(ctx, th, "tekton-hub-db")
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if dbPvc != nil {
+		if err := r.checkAndUpdatePVCOwnerRef(ctx, dbPvc, th); err != nil {
+			return err
+		}
+	}
+
+	// Check and update pvc for api component
+	apiPvc, err := r.checkPVC(ctx, th, "tekton-hub-api")
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if apiPvc != nil {
+		if err := r.checkAndUpdatePVCOwnerRef(ctx, apiPvc, th); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TODO: remove this after operator openshift-build version 1.8
+// This patch checks if the ownerRef is set to `TektonHub`,
+// if not it sets and updates the ownerRef of pvc to `TektonHub`
+func (r *Reconciler) checkAndUpdatePVCOwnerRef(ctx context.Context, pvc *corev1.PersistentVolumeClaim, th *v1alpha1.TektonHub) error {
+	if !r.checkPVCOwnerRef(pvc, th) {
+		ownerRef := *metav1.NewControllerRef(th, th.GroupVersionKind())
+		pvc.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+
+		_, err := r.kubeClientSet.CoreV1().PersistentVolumeClaims(th.Spec.GetTargetNamespace()).Update(ctx, pvc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *Reconciler) checkPVC(ctx context.Context, th *v1alpha1.TektonHub, name string) (*corev1.PersistentVolumeClaim, error) {
 	pvc, err := r.kubeClientSet.CoreV1().PersistentVolumeClaims(th.Spec.GetTargetNamespace()).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -541,7 +558,7 @@ func (r *Reconciler) checkPVC(ctx context.Context, th *v1alpha1.TektonHub, name 
 	return pvc, nil
 }
 
-// TODO: remove this after operator <x.y.z>
+// TODO: remove this after operator openshift-build version 1.8
 func (r *Reconciler) checkPVCOwnerRef(pvc *corev1.PersistentVolumeClaim, th *v1alpha1.TektonHub) bool {
 	if len(pvc.GetOwnerReferences()) == 1 {
 		if pvc.GetOwnerReferences()[0].Kind == th.Kind {


### PR DESCRIPTION
- Refactors the check for Hub db and api pvc if Hub instance is already created
---
- Fix occurrence of duplicate hub installerSets reconciler logic of TektonHub

- This patch also adds a label based querying to identify InstallerSets instead
of querying by there name

Signed-off-by: Puneet Punamiya [ppunamiy@redhat.com](mailto:ppunamiy@redhat.com)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
