### PR TITLE
Skip Tekton Chain tests for Z and Power platforms

### DIFF
--- a/test/e2e/common/03_tektonchaindeployment_test.go
+++ b/test/e2e/common/03_tektonchaindeployment_test.go
@@ -40,6 +40,10 @@ func TestTektonChainDeployment(t *testing.T) {
 	if os.Getenv("TARGET") == "openshift" {
 		crNames.TargetNamespace = "openshift-pipelines"
 	}
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("Tekton chain is not available for %q", platform)
+	}
 
 	clients := client.Setup(t, crNames.TargetNamespace)
 

--- a/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
+++ b/test/e2e/common/04_tektonchainsgettingstartedtutorial_test.go
@@ -49,6 +49,10 @@ func TestTektonChainsGettingStartedTutorial(t *testing.T) {
 	if os.Getenv("TARGET") == "openshift" {
 		crNames.TargetNamespace = "openshift-pipelines"
 	}
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("Tekton chain is not available for %q", platform)
+	}
 
 	clients := client.Setup(t, crNames.TargetNamespace)
 


### PR DESCRIPTION
# Changes

At this moment Tekton Chains is available only for Intel platform, so the tests on Z and Power platforms should be skipped.

The issue to discuss multi-arch options for Tekton Chains is open https://github.com/tektoncd/chains/issues/459

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

```release-note
NONE
```
-->