### PR TITLE
Refactors update logic for TektonPipeline reconciler

### DIFF
--- a/pkg/reconciler/shared/tektoninstallerset/install_test.go
+++ b/pkg/reconciler/shared/tektoninstallerset/install_test.go
@@ -54,11 +54,21 @@ func TestCreateInstallerset(t *testing.T) {
 
 	newISM := newTisMetaWithName("pipeline")
 
-	createdIs, err := createInstallerSetWithClient(context.Background(), client, di, newISM)
+	generateIs, err := generateInstallerSet(context.Background(), di, newISM)
+	assert.NilError(t, err)
+
+	createdIs, err := createWithClient(context.Background(), client, generateIs)
 	assert.Equal(t, err, nil)
 
 	labels := map[string]string{v1alpha1.CreatedByKey: "pipeline"}
-	annotations := map[string]string{"ns": "tekton-pipelines"}
+
+	specHash, err := getHash(installerSpec(&manifest))
+	assert.NilError(t, err)
+
+	annotations := map[string]string{
+		"ns":                                    "tekton-pipelines",
+		"operator.tekton.dev/last-applied-hash": specHash,
+	}
 
 	expectedIs := &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,10 +98,18 @@ func TestMakeInstallerset(t *testing.T) {
 	tis.Labels = map[string]string{v1alpha1.CreatedByKey: "pipeline"}
 	tis.Annotations = map[string]string{"ns": "tekton-pipelines"}
 
-	actual := makeInstallerSet(&manifest, tis)
+	actual, err := makeInstallerSet(&manifest, tis)
+	assert.NilError(t, err)
 
 	labels := map[string]string{v1alpha1.CreatedByKey: "pipeline"}
-	annotations := map[string]string{"ns": "tekton-pipelines"}
+
+	specHash, err := getHash(installerSpec(&manifest))
+	assert.NilError(t, err)
+
+	annotations := map[string]string{
+		"ns":                                    "tekton-pipelines",
+		"operator.tekton.dev/last-applied-hash": specHash,
+	}
 
 	expected := &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
- Initially in pipeline installerset the annotation `lastAppliedHash`
of TektonPipeline spec was stored instead of hash of spec of
TektonInstallerSet

- Hence this patch stores the hash of spec of TektonInstallerSet
as annotations to check if an upgrade is required for an installerset

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
