### PR TITLE
Add script for upgrade tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -43,12 +43,9 @@ function install_operator_resources() {
 
   make KO_BIN=$(which ko) KUSTOMIZE_BIN=$(which kustomize) TARGET=${TARGET:-kubernetes} apply || fail_test "Tekton Operator installation failed"
 
-  OPERATOR_NAMESPACE="tekton-operator"
-  [[ "${TARGET}" == "openshift" ]] && OPERATOR_NAMESPACE="openshift-operators"
-
   # Wait for pods to be running in the namespaces we are deploying to
-  # TODO: parameterize namespace, operator can run in a namespace different from the namespace where tektonpipelines is installed
-  wait_until_pods_running ${OPERATOR_NAMESPACE} || fail_test "Tekton Operator controller did not come up"
+  local operator_namespace=$(get_operator_namespace)
+  wait_until_pods_running ${operator_namespace} || fail_test "Tekton Operator controller did not come up"
 }
 
 function tektonconfig_ready_wait() {
@@ -57,13 +54,79 @@ function tektonconfig_ready_wait() {
   until [[ "${TEKTONCONFIG_READY}" = "True" ]]; do
     echo waiting for TektonConfig config Ready status
     sleep 5
-    kubectl get TektonConfig config > /dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-      echo TektonConfig config not yet created
-      continue
+    if is_tektonconfig_cr_created && is_tektonconfig_cr_uptodate && is_tektonconfig_cr_ready; then
+      TEKTONCONFIG_READY=True
     fi
-    TEKTONCONFIG_READY=$(kubectl get tektonconfig config -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-
   done
   echo "TektonConfig config Ready: True"
+}
+
+function is_tektonconfig_cr_created() {
+  kubectl get TektonConfig config > /dev/null 2>&1
+}
+
+function is_tektonconfig_cr_uptodate() {
+  cr_status_version=$(current_tektonconfig_version)
+  expected_version=$(version_from_info_cm)
+  [[ ${cr_status_version} == ${expected_version} ]]
+}
+
+function is_tektonconfig_cr_ready() {
+  ready_status=$(kubectl get tektonconfig config -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+  [[ ${ready_status} == "True" ]]
+}
+
+function current_tektonconfig_version() {
+  tektonconfig_version_from_label
+  # TODO: Read version from status instead of label
+  # reading from status is flaky during upgrade
+  # tektonconfig_version_from_status
+}
+
+function tektonconfig_version_from_label() {
+  label_key='operator.tekton.dev/release-version'
+  kubectl get tektonconfig config  -o yaml | grep ${label_key} | tr -d ' ' | cut -d ':' -f 2
+}
+
+tektonconfig_version_from_status() {
+  kubectl get tektonconfig config -o jsonpath='{.status.version}'
+}
+
+function version_from_info_cm() {
+  local operator_namespace=$(get_operator_namespace)
+  kubectl get configmap tekton-operator-info -n ${operator_namespace} -o jsonpath="{.data.version}"
+}
+
+function latest_released_version() {
+  repo_url='https://api.github.com/repos/tektoncd/operator/releases'
+  curl -sSL ${repo_url} | jq -r '.[].tag_name' | sort -Vr | head -n 1
+}
+
+function set_release_file_name() {
+  local platform=${1}
+  local name='release.notags.yaml'
+  if [[ ${platform} != "kubernetes" ]]; then
+    name=${platform}-${name}
+  fi
+  echo ${name}
+}
+
+function get_operator_namespace() {
+  # TODO: parameterize namespace, operator can run in a namespace different from the namespace where tektonpipelines is installed
+  local operator_namespace="tekton-operator"
+  [[ "${TARGET}" == "openshift" ]] && operator_namespace="openshift-operators"
+  echo ${operator_namespace}
+}
+
+function install_latest_released_version() {
+  local platform=${1}
+  version=$(latest_released_version)
+  release_file_name=$(set_release_file_name ${platform})
+  release_manifest_url="https://github.com/tektoncd/operator/releases/download/${version}/${release_file_name}"
+  echo "latest_release_url: ${release_manifest_url}"
+  kubectl apply -f ${release_manifest_url}
+
+  # Wait for pods to be running in the namespaces we are deploying to
+  local operator_namespace=$(get_operator_namespace)
+  wait_until_pods_running ${operator_namespace} || fail_test "Tekton Operator controller did not come up"
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,6 +22,7 @@ source $(dirname $0)/e2e-common.sh
 # Script entry point.
 TARGET=${TARGET:-kubernetes}
 # In case if KUBECONFIG variable is specified, it will be used for `go test`
+KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
 KUBECONFIG_PARAM=${KUBECONFIG:+"--kubeconfig $KUBECONFIG"}
 
 echo "Running tests on ${TARGET}"

--- a/test/upgrade-tests.sh
+++ b/test/upgrade-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# usage:
+# local testing:
+# E2E_SKIP_CLUSTER_CREATION=true ./test/upgrade-tests.sh # assumption: test cluster already exists
+#
+# in upstream ci:
+# ./test/upgrade-tests.sh if test cluster already exists
+
+source $(dirname $0)/e2e-common.sh
+set -ue
+
+TARGET=${TARGET:-kubernetes}
+echo upgrade test platform: ${TARGET}
+
+# create cluster (upstream gke cluster will be provisioned
+# set E2E_SKIP_CLUSTER_CREATION=true ./test/upgrade-tests.sh if test cluster already exists
+[[ -z ${E2E_SKIP_CLUSTER_CREATION} ]] && initialize $@
+
+# install latest released version
+install_latest_released_version ${TARGET}
+tektonconfig_ready_wait
+
+# run e2e tests (explicitly skip cluster creation as cluster is already created)
+# running e2e tests will install the operator from current code base,
+# causing an upgrade. Once Tektonconfig config is Ready: True
+# e2e tests will be run
+E2E_SKIP_CLUSTER_CREATION=true $(dirname $0)/e2e-tests.sh


### PR DESCRIPTION
Add a script which can install the latest released version
of operator and run e2e tests

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```