### PR TITLE
Admin can provide a database to be used by TektonHub

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonhub_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_default_test.go
@@ -40,9 +40,6 @@ func TestSetDefault(t *testing.T) {
 		},
 	}
 	th.SetDefaults(context.TODO())
-	if th.Spec.Db.DbSecretName != "tekton-hub-db" {
-		t.Error("Setting default failed for TektonHub (spec.db.dbSecretName)")
-	}
 	if th.Spec.TargetNamespace != "tekton-pipelines" {
 		t.Error("Setting default failed for TektonHub (spec.targetNamespace)")
 	}

--- a/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
@@ -23,10 +23,6 @@ import (
 
 func (th *TektonHub) SetDefaults(ctx context.Context) {
 
-	if th.Spec.Db.DbSecretName == "" {
-		th.Spec.Db.DbSecretName = "tekton-hub-db"
-	}
-
 	if th.Spec.Api.ApiSecretName == "" {
 		th.Spec.Api.ApiSecretName = "tekton-hub-api"
 	}


### PR DESCRIPTION
- Initially while creating a Hub instance, default database provided
by Hub was used to store the data, but in that case if user had his
own database, he couldn't use his database instead of the default one

- Hence this patch makes the provision that user can use his database
and can just use the other Hub services i.e. db-migration, api and ui

- To know if the user wants to use his own database, user can provide
the secret name in the Hub cr with secret name as `tekton-hub-db`

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

With the provision of admin providing his own database to be used by Tekton Hub, following cases are handled
- Easy installation of Hub with default database provided by Hub
- Smooth working with default database but if user provides his own secret to use his database, easy transition done to use the other services provided by Hub except database and the default database will be deleted
- Easy installation with Hub instance created for the first time with his own database i.e. secret of db provided by user

Cases that needs to be handled yet
- If user installs Hub with his own db and wants to shift to default database in the case, database will be created but with no data
  - To handle this case, currently user needs to delete the `dbMigration` and `api` installerset 

cc @nikhil-thomas @concaf @piyush-garg 

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
