### PR TITLE
Adds validation logic to check if labels are added before creation of installerset

### DIFF
--- a/pkg/reconciler/shared/tektoninstallerset/install.go
+++ b/pkg/reconciler/shared/tektoninstallerset/install.go
@@ -40,7 +40,9 @@ func GenerateInstallerSetWithPrefixName(ctx context.Context, ci ComponentInstall
 
 // Generates the installerset without applying on the cluster
 func generateInstallerSet(ctx context.Context, ci ComponentInstaller, tis *tisMeta) (*v1alpha1.TektonInstallerSet, error) {
-	tis.config(ctx, ci)
+	if err := tis.config(ctx, ci); err != nil {
+		return nil, err
+	}
 
 	manifest, err := ci.GetManifest(ctx)
 	if err != nil {

--- a/pkg/reconciler/shared/tektoninstallerset/install_test.go
+++ b/pkg/reconciler/shared/tektoninstallerset/install_test.go
@@ -41,7 +41,9 @@ func TestCreateInstallerset(t *testing.T) {
 	di.AddManifest(manifest)
 
 	di.AddLabelsFromMap(map[string]string{
-		v1alpha1.CreatedByKey: "pipeline",
+		v1alpha1.InstallerSetType:  "tekton-pipeline",
+		v1alpha1.CreatedByKey:      "pipeline",
+		v1alpha1.ReleaseVersionKey: "0.55.0",
 	})
 
 	di.AddAnnotationsFromMap(map[string]string{
@@ -60,7 +62,11 @@ func TestCreateInstallerset(t *testing.T) {
 	createdIs, err := createWithClient(context.Background(), client, generateIs)
 	assert.Equal(t, err, nil)
 
-	labels := map[string]string{v1alpha1.CreatedByKey: "pipeline"}
+	labels := map[string]string{
+		v1alpha1.CreatedByKey:      "pipeline",
+		v1alpha1.InstallerSetType:  "tekton-pipeline",
+		v1alpha1.ReleaseVersionKey: "0.55.0",
+	}
 
 	specHash, err := getHash(installerSpec(&manifest))
 	assert.NilError(t, err)


### PR DESCRIPTION
This patch adds a simple validation check if the specified
required labels are added before creating the installerset

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
