### PR TITLE
changes related to refresh hub api with specified interval

### DIFF
--- a/config/crs/openshift/hub/operator_v1alpha1_hub_cr.yaml
+++ b/config/crs/openshift/hub/operator_v1alpha1_hub_cr.yaml
@@ -19,3 +19,4 @@ metadata:
 spec:
   api:
     hubConfigUrl: https://raw.githubusercontent.com/tektoncd/hub/main/config.yaml
+    catalogRefreshInterval: 30m

--- a/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_defaults.go
@@ -35,4 +35,7 @@ func (th *TektonHub) SetDefaults(ctx context.Context) {
 		th.Spec.CommonSpec.TargetNamespace = os.Getenv("DEFAULT_TARGET_NAMESPACE")
 	}
 
+	if th.Spec.Api.CatalogRefreshInterval == "" {
+		th.Spec.Api.CatalogRefreshInterval = "30m"
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonhub_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_types.go
@@ -58,9 +58,10 @@ type DbSpec struct {
 }
 
 type ApiSpec struct {
-	HubConfigUrl  string `json:"hubConfigUrl,omitempty"`
-	ApiSecretName string `json:"secret,omitempty"`
-	RouteHostUrl  string `json:"routeHostUrl,omitempty"`
+	HubConfigUrl           string `json:"hubConfigUrl,omitempty"`
+	ApiSecretName          string `json:"secret,omitempty"`
+	RouteHostUrl           string `json:"routeHostUrl,omitempty"`
+	CatalogRefreshInterval string `json:"catalogRefreshInterval,omitempty"`
 }
 
 // TektonHubStatus defines the observed state of TektonHub

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -380,7 +380,7 @@ func (r *Reconciler) validateOrCreateDBSecrets(ctx context.Context, th *v1alpha1
 func (r *Reconciler) validateApiDependencies(ctx context.Context, th *v1alpha1.TektonHub) error {
 	logger := logging.FromContext(ctx)
 	apiSecretKeys := []string{"GH_CLIENT_ID", "GH_CLIENT_SECRET", "JWT_SIGNING_KEY", "ACCESS_JWT_EXPIRES_IN", "REFRESH_JWT_EXPIRES_IN", "GHE_URL"}
-	apiConfigMapKeys := []string{"CONFIG_FILE_URL"}
+	apiConfigMapKeys := []string{"CONFIG_FILE_URL", "CATALOG_REFRESH_INTERVAL"}
 
 	th.Status.MarkApiDependencyInstalling("checking for api secrets in the namespace and creating the ConfigMap")
 
@@ -799,7 +799,8 @@ func createApiConfigMap(name, namespace string, th *v1alpha1.TektonHub) *corev1.
 			},
 		},
 		Data: map[string]string{
-			"CONFIG_FILE_URL": th.Spec.Api.HubConfigUrl,
+			"CONFIG_FILE_URL":          th.Spec.Api.HubConfigUrl,
+			"CATALOG_REFRESH_INTERVAL": th.Spec.Api.CatalogRefreshInterval,
 		},
 	}
 }


### PR DESCRIPTION
# Changes
- Adding `refreshInterval` field in Hub CR to configure the interval


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
