### PR TITLE
Add graceful termination to webhook pods

### DIFF
--- a/cmd/kubernetes/webhook/main.go
+++ b/cmd/kubernetes/webhook/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/tektoncd/operator/pkg/webhook"
@@ -49,6 +50,8 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("kubernetes")
 
+	go gracefulTermination(ctx)
+
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -56,4 +59,9 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
+}
+
+func gracefulTermination(ctx context.Context) {
+	<-ctx.Done()
+	webhook.CleanupWebhookResources(ctx)
 }

--- a/cmd/openshift/webhook/main.go
+++ b/cmd/openshift/webhook/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/tektoncd/operator/pkg/webhook"
@@ -49,6 +50,8 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("openshift")
 
+	go gracefulTermination(ctx)
+
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -56,4 +59,9 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
+}
+
+func gracefulTermination(ctx context.Context) {
+	<-ctx.Done()
+	webhook.CleanupWebhookResources(ctx)
 }

--- a/pkg/webhook/webhook_init.go
+++ b/pkg/webhook/webhook_init.go
@@ -39,11 +39,26 @@ func CreateWebhookResources(ctx context.Context) {
 	client := operatorclient.Get(ctx)
 	err = checkAndDeleteInstallerSet(ctx, client)
 	if err != nil {
-		logger.Fatalw("error creating client from injected config", zap.Error(err))
+		logger.Fatalw("error deleting webhook installerset", zap.Error(err))
 	}
 
 	if err := createInstallerSet(ctx, client, *manifest); err != nil {
-		logger.Fatalw("error creating client from injected config", zap.Error(err))
+		logger.Fatalw("error creating webhook installerset", zap.Error(err))
+	}
+
+}
+
+func CleanupWebhookResources(ctx context.Context) {
+	logger := logging.FromContext(ctx)
+	client := operatorclient.Get(ctx)
+
+	// cannot use the ctx passed from main as it will be cancelled
+	// by the time we use in kube api calls
+	freshContext := context.Background()
+
+	err := checkAndDeleteInstallerSet(freshContext, client)
+	if err != nil {
+		logger.Fatalw("error deleting webhook installerset", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
This patch adds a mechanism to remove webhook defintions created by the webhook pod when it is
being terminated. This eases 2 situations:

1. Operaor CRD instance CRDs can be deleted manually even after webhook pods are removed (eg: OLM uninstalls operator without removing components)
2. When operator in uninstalled the webhook definitions are never removed. Therefore, if the operator is ever installed in a different namespaces there is a timewindow in which the service namespaces are updated in the webhook definition during which all call to webhook fails.

**Note:-** We create mutatingWebhookConfigurations and validatingWebhookConfigurations explicitly using
Kubeapi calls from webhook pod. We do that be cause OLM (operator lifecycle manager) doesnot work well with knative/pkg based webhooks.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
fixes explicit deletion of instances of operator's CRDs (eg: TektonConfig, TektonAddons...) being blocked if the operator is uninstalled before removing the components
```