### PR TITLE
Create PAC pipelinerun templates for console to access

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/rbac.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pipelines-as-code-templates
+  labels:
+    app.kubernetes.io/part-of: pipelines-as-code
+rules:
+  # All system:authenticated users needs to have access
+  # of the pipelines-as-code-templates ConfigMap even if they don't
+  # have access to the other resources present in the
+  # installed namespace.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+    resourceNames: ["pipelines-as-code-go-template", "pipelines-as-code-java-template", "pipelines-as-code-nodejs-template", "pipelines-as-code-python-template"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipelines-as-code-templates
+  labels:
+    app.kubernetes.io/part-of: pipelines-as-code
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipelines-as-code-templates

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/code-generator v0.23.5
 	knative.dev/pkg v0.0.0-20220329144915-0a1ec2e0d46c
 	sigs.k8s.io/controller-runtime v0.7.2
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -253,7 +254,6 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 go 1.17

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -126,14 +126,14 @@ release_yaml_pac() {
     runtime=( go java nodejs python )
     for run in "${runtime[@]}"
     do
-    	echo "fetching PipelineRun template for runtime: $run"
+      echo "fetching PipelineRun template for runtime: $run"
 
-    	source="https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/cmd/tknpac/generate/templates/${run}-template.yaml"
-    	dest_dir="${ko_data}/tekton-addon/pipelines-as-code-templates"
+      source="https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/${version}/pkg/cmd/tknpac/generate/templates/${run}.yaml"
+      dest_dir="${ko_data}/tekton-addon/pipelines-as-code-templates"
       mkdir -p ${dest_dir} || true
-      destination="${dest_dir}/${run}-template.yaml"
+      destination="${dest_dir}/${run}.yaml"
 
-    	http_response=$(curl -s -o ${destination} -w "%{http_code}" ${source})
+      http_response=$(curl -s -o ${destination} -w "%{http_code}" ${source})
       echo url: ${source}
 
       if [[ $http_response != "200" ]]; then

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -122,6 +122,27 @@ release_yaml_pac() {
 
     echo "Info: Added $comp/$fileName:$version release yaml !!"
     echo ""
+
+    runtime=( go java nodejs python )
+    for run in "${runtime[@]}"
+    do
+    	echo "fetching PipelineRun template for runtime: $run"
+
+    	source="https://raw.githubusercontent.com/sm43/pipelines-as-code/pac-pr-templates/pkg/cmd/tknpac/generate/templates/${run}-template.yaml"
+    	dest_dir="${ko_data}/tekton-addon/pipelines-as-code-templates"
+      mkdir -p ${dest_dir} || true
+      destination="${dest_dir}/${run}-template.yaml"
+
+    	http_response=$(curl -s -o ${destination} -w "%{http_code}" ${source})
+      echo url: ${url}
+
+      if [[ $http_response != "200" ]]; then
+        echo "Error: failed to get pipelinerun template for $run, status code: $http_response"
+        exit 1
+      fi
+
+    done
+
 }
 
 

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -128,13 +128,13 @@ release_yaml_pac() {
     do
     	echo "fetching PipelineRun template for runtime: $run"
 
-    	source="https://raw.githubusercontent.com/sm43/pipelines-as-code/pac-pr-templates/pkg/cmd/tknpac/generate/templates/${run}-template.yaml"
+    	source="https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/cmd/tknpac/generate/templates/${run}-template.yaml"
     	dest_dir="${ko_data}/tekton-addon/pipelines-as-code-templates"
       mkdir -p ${dest_dir} || true
       destination="${dest_dir}/${run}-template.yaml"
 
     	http_response=$(curl -s -o ${destination} -w "%{http_code}" ${source})
-      echo url: ${url}
+      echo url: ${source}
 
       if [[ $http_response != "200" ]]; then
         echo "Error: failed to get pipelinerun template for $run, status code: $http_response"
@@ -142,7 +142,7 @@ release_yaml_pac() {
       fi
 
     done
-
+    echo ""
 }
 
 

--- a/pkg/reconciler/openshift/tektonaddon/pipelinesascode_test.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinesascode_test.go
@@ -1,0 +1,39 @@
+package tektonaddon
+
+import (
+	"path"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestPipelineRunToConfigMapConverter(t *testing.T) {
+	testData := path.Join("testdata", "test-pac-pr-template.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	cmManifest, err := pipelineRunToConfigMapConverter(&manifest)
+	assert.NilError(t, err)
+
+	got := &v1.ConfigMap{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(cmManifest.Resources()[0].Object, got)
+	if err != nil {
+		assert.NilError(t, err)
+	}
+
+	testData = path.Join("testdata", "test-expected-pac-pr-template.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	expected := &v1.ConfigMap{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expected)
+	if err != nil {
+		assert.NilError(t, err)
+	}
+
+	assert.DeepEqual(t, expected.GetName(), got.GetName())
+	assert.DeepEqual(t, expected.GetLabels(), got.GetLabels())
+}

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-expected-pac-pr-template.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-expected-pac-pr-template.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipelines-as-code-go-template
+  labels:
+    pipelinesascode.openshift.io/runtime: "go"
+    app.kubernetes.io/part-of: pipelines-as-code
+data:
+  template: |
+    apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      annotations:
+        pipelinesascode.tekton.dev/max-keep-runs: "5"
+        pipelinesascode.tekton.dev/on-event: pull_request
+        pipelinesascode.tekton.dev/on-target-branch: main
+        pipelinesascode.tekton.dev/task: git-clone
+        pipelinesascode.tekton.dev/task-1: '[golangci-lint]'
+      name: go-template
+    spec:
+      params:
+        - name: repo_url
+          value: "{{ repo_url }}"
+        - name: revision
+          value: "{{ revision }}"
+      pipelineSpec:
+        params:
+          - name: repo_url
+          - name: revision
+        workspaces:
+          - name: source
+          - name: basic-auth
+        tasks:
+          - name: fetch-repository
+            taskRef:
+              name: git-clone
+            workspaces:
+              - name: output
+                workspace: source
+              - name: basic-auth
+                workspace: basic-auth
+            params:
+              - name: url
+                value: $(params.repo_url)
+              - name: revision
+                value: $(params.revision)
+          - name: golangci-lint
+            taskRef:
+              name: golangci-lint
+            runAfter:
+              - fetch-repository
+            params:
+              - name: package
+                value: .
+            workspaces:
+              - name: source
+                workspace: source
+      workspaces:
+        - name: source
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: basic-auth
+          secret:
+            secretName: "{{ git_auth_secret }}"

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-expected-pac-pr-template.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-expected-pac-pr-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pipelines-as-code-go-template
+  name: pipelines-as-code-pipelinerun-go
   labels:
     pipelinesascode.openshift.io/runtime: "go"
     app.kubernetes.io/part-of: pipelines-as-code

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-pac-pr-template.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-pac-pr-template.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-template
+  annotations:
+    # The event we are targeting as seen from the webhook payload
+    # this can be an array too, i.e: [pull_request, push]
+    pipelinesascode.tekton.dev/on-event: "pull_request"
+
+    # The branch or tag we are targeting (ie: main, refs/tags/*)
+    pipelinesascode.tekton.dev/on-target-branch: "main"
+
+    # Fetch the git-clone task from hub, we are able to reference later on it
+    # with taskRef and it will automatically be embedded into our pipeline.
+    pipelinesascode.tekton.dev/task: "git-clone"
+
+
+    # Task for Golang
+    pipelinesascode.tekton.dev/task-1: "[golangci-lint]"
+
+    # You can add more tasks in here to reuse, browse the one you like from here
+    # https://hub.tekton.dev/
+    # example:
+    # pipelinesascode.tekton.dev/task-2: "[maven, buildah]"
+
+    # How many runs we want to keep attached to this event
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    # The variable with brackets are special to Pipelines as Code
+    # They will automatically be expanded with the events from Github.
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: revision
+    workspaces:
+      - name: source
+      - name: basic-auth
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+          - name: basic-auth
+            workspace: basic-auth
+        params:
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      - name: golangci-lint
+        taskRef:
+          name: golangci-lint
+        runAfter:
+          - fetch-repository
+        params:
+          - name: package
+            value: .
+        workspaces:
+          - name: source
+            workspace: source
+
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    # This workspace will inject secret to help the git-clone task to be able to
+    # checkout the private repositories
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"

--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-pac-pr-template.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-pac-pr-template.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: go-template
+  name: pipelinerun-go
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]


### PR DESCRIPTION
this fetches the pr templates while fetching release yaml and keep in ko data
later it creates configmaps with pipelinerun templates and add in installer set
console will use this templates.
also adds rbac to access templates for non admin users

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
