### PR TITLE
[OpenShit] Skip RBAC setup in namespaces which are being deleted

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -175,9 +175,13 @@ func (r *rbac) createResources(ctx context.Context) error {
 	var rbacNamespaces []corev1.Namespace
 
 	// filter namespaces:
-	// ignore ns with name passing regex `^(openshift|kube)-`
 	for _, n := range namespaces.Items {
+		// ignore namespaces with name passing regex `^(openshift|kube)-`
 		if ignore := nsRegex.MatchString(n.GetName()); ignore {
+			continue
+		}
+		// ignore namespaces with DeletionTimestamp set
+		if n.GetObjectMeta().GetDeletionTimestamp() != nil {
 			continue
 		}
 		rbacNamespaces = append(rbacNamespaces, n)


### PR DESCRIPTION
Add a check to ignore namespaces with DeletionTimestamp set

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
OpenShift Pipelines will not set up RBAC resources in namespaces which are being deleted.
```