### PR TITLE
Removes PropagationPolicy for resource deletion

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -56,7 +56,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, installerSet *v1alpha1.Te
 	// TektonInstallerSet
 	// They will be deleted when the component CR is deleted
 	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs, pvcPred)))
-	err = deleteManifests.Delete(mf.PropagationPolicy(v1.DeletePropagationForeground))
+	err = deleteManifests.Delete()
 	if err != nil {
 		logger.Error("failed to delete resources")
 		return err


### PR DESCRIPTION
PropagationPolicy is affecting upgrades as resource will be in
etcd till the child resources are deleted which takes time.

in case of pac, after deleting pac installerset , eventlistener is
taking time to delete its deployment and service and the new installer set
is up and override the previous EL as it is still in etcd because of its childs.
when the child are removed the eventlisterner is getting removed and
there is not EL for newer version, we have to manually trigger the reconciler
for the pac installerSet to get it created again.

default deletion is working fine for upgrade hence removing PropagationPolicy.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
