### PR TITLE
Add job replacement tranform in tekton hub

### DIFF
--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -532,6 +532,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest mf.Manifest, th *v1
 		mf.InjectOwner(th),
 		mf.InjectNamespace(namespace),
 		common.DeploymentImages(images),
+		common.JobImages(images),
 	}
 	trans = append(trans, extra...)
 


### PR DESCRIPTION
This will add job replacement transform also in
hub reconciler because db-migration is a job
whose image needs to be replaces

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add job replacement transform in tekton hub
```
