### PR TITLE
Add a bump (and bump-bugfix) command to operator-tool

### DIFF
--- a/cmd/operator-tool/bump.go
+++ b/cmd/operator-tool/bump.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"sort"
+)
+
+func bump(filename string, bugfix bool) error {
+	newComponents := map[string]component{}
+	components, err := readCompoments(filename)
+	if err != nil {
+		return err
+	}
+	for name, component := range components {
+		newComponent, err := bumpComponent(name, component, bugfix)
+		if err != nil {
+			return err
+		}
+		newComponents[name] = newComponent
+	}
+	return writeComponents(filename, newComponents)
+}
+
+func bumpComponent(name string, c component, bugfix bool) (component, error) {
+	newVersion := c.Version
+	newerVersions, err := checkComponentNewerVersions(c, bugfix)
+	if err != nil {
+		return component{}, err
+	}
+	if len(newerVersions) > 0 {
+		// Get the latest one
+		sort.Sort(newerVersions) // sort just in case
+		newVersion = "v" + newerVersions[len(newerVersions)-1].String()
+	}
+	return component{
+		Github:  c.Github,
+		Version: newVersion,
+	}, nil
+}

--- a/cmd/operator-tool/check.go
+++ b/cmd/operator-tool/check.go
@@ -44,32 +44,59 @@ func check(filename string, bugfix bool) error {
 }
 
 func checkComponent(ctx context.Context, name string, component component, bugfix bool) error {
-	client, err := gh.RESTClient(nil)
+	newerVersion, err := checkComponentNewerVersions(component, bugfix)
 	if err != nil {
 		return err
+	}
+	if len(newerVersion) > 0 {
+		fmt.Printf("%s: %v\n", name, newerVersion)
+	}
+
+	return nil
+}
+
+func checkComponentNewerVersions(component component, bugfix bool) (semver.Collection, error) {
+	sVersions, err := fetchVersions(component.Github)
+	if err != nil {
+		return nil, err
+	}
+	currentVersion, err := semver.NewVersion(component.Version)
+	if err != nil {
+		return nil, err
+	}
+	newerVersion, err := getNewerVersion(currentVersion, sVersions, bugfix)
+	if err != nil {
+		return nil, err
+	}
+	return newerVersion, nil
+}
+
+func fetchVersions(github string) (semver.Collection, error) {
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		return nil, err
 	}
 	versions := []struct {
 		Name    string
 		TagName string `json:"tag_name"`
 	}{}
-	err = client.Get(fmt.Sprintf("repos/%s/releases", component.Github), &versions)
+	err = client.Get(fmt.Sprintf("repos/%s/releases", github), &versions)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sVersions := semver.Collection([]*semver.Version{})
 	for _, v := range versions {
 		sVersion, err := semver.NewVersion(v.TagName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		sVersions = append(sVersions, sVersion)
 	}
 	sort.Sort(sVersions)
+	return sVersions, nil
+}
 
-	currentVersion, err := semver.NewVersion(component.Version)
-	if err != nil {
-		return err
-	}
+func getNewerVersion(currentVersion *semver.Version, versions []*semver.Version, bugfix bool) (semver.Collection, error) {
 	constraint := fmt.Sprintf("> %s", currentVersion)
 	if bugfix {
 		nextMinorVersion := currentVersion.IncMinor()
@@ -77,17 +104,13 @@ func checkComponent(ctx context.Context, name string, component component, bugfi
 	}
 	c, err := semver.NewConstraint(constraint)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	newerVersion := []*semver.Version{}
-	for _, sv := range sVersions {
+	newerVersion := semver.Collection([]*semver.Version{})
+	for _, sv := range versions {
 		if c.Check(sv) {
 			newerVersion = append(newerVersion, sv)
 		}
 	}
-	if len(newerVersion) > 0 {
-		fmt.Printf("%s: %v\n", name, newerVersion)
-	}
-
-	return nil
+	return newerVersion, nil
 }

--- a/cmd/operator-tool/components.go
+++ b/cmd/operator-tool/components.go
@@ -23,8 +23,8 @@ import (
 )
 
 type component struct {
-	Github  string
-	Version string
+	Github  string `json:"github"`
+	Version string `json:"version"`
 }
 
 func readCompoments(filename string) (map[string]component, error) {
@@ -38,6 +38,14 @@ func readCompoments(filename string) (map[string]component, error) {
 		return nil, err
 	}
 	return components, nil
+}
+
+func writeComponents(filename string, components map[string]component) error {
+	data, err := yaml.Marshal(components)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
 }
 
 func componentVersion(filename string, args []string) error {

--- a/cmd/operator-tool/main.go
+++ b/cmd/operator-tool/main.go
@@ -42,6 +42,10 @@ func main() {
 		err = check(config, false)
 	case "check-bugfix":
 		err = check(config, true)
+	case "bump":
+		err = bump(config, false)
+	case "bump-bugfix":
+		err = bump(config, true)
 	default:
 		os.Exit(1)
 	}

--- a/components.yaml
+++ b/components.yaml
@@ -1,26 +1,21 @@
-# List of components shipped by the operator
-# This files contains the name, url and version of each component.
-#
-# This is considered the source of truth for component shipped in the operator.
-# The rest of the operator tooling uses this as such.
-pipeline:
-  github: tektoncd/pipeline
-  version: v0.37.0
-triggers:
-  github: tektoncd/triggers
-  version: v0.20.0
-dashboard:
-  github: tektoncd/dashboard
-  version: v0.27.0
 chains:
   github: tektoncd/chains
   version: v0.9.0
-results:
-  github: tektoncd/results
-  version: v0.4.0
+dashboard:
+  github: tektoncd/dashboard
+  version: v0.27.0
 hub:
   github: tektoncd/hub
   version: v1.8.0
+pipeline:
+  github: tektoncd/pipeline
+  version: v0.37.2
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code
   version: 0.10.1
+results:
+  github: tektoncd/results
+  version: v0.4.0
+triggers:
+  github: tektoncd/triggers
+  version: v0.20.1

--- a/components.yaml
+++ b/components.yaml
@@ -1,18 +1,18 @@
 chains:
   github: tektoncd/chains
-  version: v0.9.0
+  version: v0.11.0
 dashboard:
   github: tektoncd/dashboard
-  version: v0.27.0
+  version: v0.28.0
 hub:
   github: tektoncd/hub
   version: v1.8.0
 pipeline:
   github: tektoncd/pipeline
-  version: v0.37.2
+  version: v0.38.1
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code
-  version: 0.10.1
+  version: v0.11.0
 results:
   github: tektoncd/results
   version: v0.4.0


### PR DESCRIPTION
# Changes

The idea is similar to the check subcommand, but it edits the
components.yaml with the latest found version (either bugfix or "in
general").

With this subcommand, we can have a cronjob and a "bot" that
automatically updates the versions of the main components.yaml
file. And we could have a similar one for the release branches.

/cc @sm43 @concaf @tektoncd/operator-maintainers 

This is part of the effort to automate bumping payloads **and** release of the operator 👼🏼

/kind misc 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
