### PR TITLE
Adds missing MetricsDomain env for operator container

### DIFF
--- a/config/kubernetes/base/operator.yaml
+++ b/config/kubernetes/base/operator.yaml
@@ -91,3 +91,5 @@ spec:
             value: "9009"
           - name: VERSION
             value: "devel"
+          - name: METRICS_DOMAIN
+            value: tekton.dev/operator

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -104,3 +104,5 @@ spec:
             value: "9009"
           - name: VERSION
             value: "devel"
+          - name: METRICS_DOMAIN
+            value: tekton.dev/operator


### PR DESCRIPTION
if knative operator is running is same namespace as pipelines
then this would break the container as the env is missing.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
