### PR TITLE
Add env to replace the s2i-java env step

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -81,6 +81,8 @@ spec:
           value: registry.redhat.io/rhel8/skopeo@sha256:3f16176d50e8132dd447aa5a513466a48d84e724bbb194d30501ae620a58172f
         - name: IMAGE_ADDONS_GENERATE
           value: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+        - name: IMAGE_ADDONS_GEN_ENV_FILE
+          value: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       - name: openshift-pipelines-operator-cluster-operations # tektoninstallerset reconciler
         image: ko://github.com/tektoncd/operator/cmd/openshift/operator
         args:

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -145,6 +145,7 @@ image-substitutions:
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_GENERATE
+      - IMAGE_ADDONS_GEN_ENV_FILE
 
 - image: registry.redhat.io/ubi8/ubi-minimal@sha256:3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120
   replaceLocations:
@@ -220,16 +221,6 @@ image-substitutions:
 
 # add third party images which are not replaced by operator
 # but pulled directly by tasks here
-defaultRelatedImages:
-- image: registry.redhat.io/rhel8/buildah@sha256:82aa9592f3262313ec52f7a2335641e2581b0d0d9807980846d0539bb77d0657
-  name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
-- image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:1d5291d00c3f85de57b921b7450e41ceb58d8c3104c36135a242f5993531af5c
-  name: IMAGE_ADDONS_PARAM_KN_IMAGE
-- image: registry.redhat.io/rhel8/skopeo@sha256:3f16176d50e8132dd447aa5a513466a48d84e724bbb194d30501ae620a58172f
-  name: IMAGE_ADDONS_SKOPEO_COPY
-- image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
-  name: IMAGE_ADDONS_GENERATE
-- image: registry.redhat.io/ubi8/ubi-minimal@sha256:3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120
-  name: IMAGE_ADDONS_MVN_SETTINGS
+defaultRelatedImages: []
 #- image: "" ##<imagename>:<tag> or <imagename>@<sha>
 #  name: "" # ENV key name value


### PR DESCRIPTION
Add an env to replace s2i-java env step and make default
related images empty as they are getting appended as part of
script

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add env to replace the s2i-java env step
```