### PR TITLE
[Cherry-pick] Increasing QPS limit to 50 to improve installation

### DIFF
--- a/pkg/reconciler/platform/platform.go
+++ b/pkg/reconciler/platform/platform.go
@@ -105,6 +105,7 @@ func contextWithPlatformName(ctx context.Context, pName string) context.Context 
 func startMain(p Platform, ctrls ControllerMap) {
 	pParams := p.PlatformParams()
 	cfg := injection.ParseAndGetRESTConfigOrDie()
+	cfg.QPS = 50
 	ctx, _ := injection.EnableInjectionOrDie(signals.NewContext(), cfg)
 	ctx = contextWithPlatformName(ctx, pParams.Name)
 	installer.InitTektonInstallerSetClient(ctx)


### PR DESCRIPTION
by deafult QPS is 5, and in operator we have many CRD so
the limit is reached very easily from start which is affecting
installation time for components.
setting up at 50 same as kubectl
https://github.com/kubernetes/kubernetes/pull/105520/files

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
