### PR TITLE
[cherry-pick] Combining the 3 steps of buildah and all s2i task to use single step

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -47,6 +47,9 @@ spec:
     description: Extra parameters passed for the push command when pushing images.
     type: string
     default: ""
+  - name: SKIP_PUSH
+    description: Skip pushing the built image
+    default: "false"
   workspaces:
   - name: source
 
@@ -55,7 +58,7 @@ spec:
     description: Digest of the image just built.
 
   steps:
-  - name: build
+  - name: build-and-push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
     script: |
@@ -63,32 +66,19 @@ spec:
         $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
         -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-    volumeMounts:
-    - name: varlibcontainers
-      mountPath: /var/lib/containers
-    securityContext:
-      capabilities:
-        add: ["SETFCAP"]
 
-  - name: push
-    image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    script: |
+      [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
+      cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
     securityContext:
       capabilities:
         add: ["SETFCAP"]
-
-  - name: digest-to-results
-    image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
-
   volumes:
   - name: varlibcontainers
     emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: IMAGE
       description: Location of the repo where image has to be pushed
       type: string
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,19 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      workingDir: $(workspaces.source.path)
-      image: $(params.BUILDER_IMAGE)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,19 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      workingDir: $(workspaces.source.path)
-      image: $(params.BUILDER_IMAGE)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
@@ -48,6 +48,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -100,10 +103,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -112,19 +124,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      image: $(params.BUILDER_IMAGE)
-      workingDir: $(workspaces.source.path)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,19 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      image: $(params.BUILDER_IMAGE)
-      workingDir: $(workspaces.source.path)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,19 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      workingDir: $(workspaces.source.path)
-      image: $(params.BUILDER_IMAGE)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,18 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      image: $(params.BUILDER_IMAGE)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,20 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-
-      workingDir: $(workspaces.source.path)
-      image: $(params.BUILDER_IMAGE)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
@@ -36,6 +36,9 @@ spec:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
       default: registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+    - name: SKIP_PUSH
+      description: Skip pushing the built image
+      default: "false"
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -50,10 +53,19 @@ spec:
       env:
         - name: HOME
           value: /tekton/home
-    - name: build
+    - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
-      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      script: |
+        buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+           --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+        [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+        buildah push --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+
+        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -62,19 +74,6 @@ spec:
       securityContext:
         capabilities:
           add: ["SETFCAP"]
-    - name: push
-      image: $(params.BUILDER_IMAGE)
-      workingDir: $(workspaces.source.path)
-      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--digestfile=$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
-      volumeMounts:
-        - name: varlibcontainers
-          mountPath: /var/lib/containers
-      securityContext:
-        capabilities:
-          add: ["SETFCAP"]
-    - name: digest-to-results
-      image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
   volumes:
     - name: varlibcontainers
       emptyDir: {}


### PR DESCRIPTION

1. Combining the 3 steps of buildah and all s2i task to use single step to save
       memory
2. Adding SKIP_PUSH parameter for buildah and all s2i tasks


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
