### PR TITLE
[Cherry-pick] Updates the hub api secret by setting the AUTH_BASE_URL from Hub status

### DIFF
--- a/pkg/reconciler/openshift/tektonhub/extension.go
+++ b/pkg/reconciler/openshift/tektonhub/extension.go
@@ -404,6 +404,20 @@ func (oe openshiftExtension) SetAuthBaseURL(ctx context.Context, th *v1alpha1.Te
 			return err
 		}
 		th.Status.SetAuthRoute(fmt.Sprintf("https://%s", authRoute))
+
+		if secret.Data == nil || string(secret.Data["AUTH_BASE_URL"]) != th.Status.AuthRouteUrl {
+
+			if secret.StringData == nil {
+				secret.StringData = make(map[string]string)
+			}
+
+			secret.StringData["AUTH_BASE_URL"] = th.Status.AuthRouteUrl
+
+			_, err = oe.kubeClientSet.CoreV1().Secrets(th.Spec.GetTargetNamespace()).Update(ctx, secret, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		th.Status.SetAuthRoute("")
 	}


### PR DESCRIPTION
Currently if user creates the Hub api secret, then Auth url was not set,
and hence Hub login was failing

Hence, this patch updates the value of AUTH_BASE_URL from the hub api
secret from the Hub status when user creates the secret

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
