### PR TITLE
Add support for --local for ko

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -230,7 +230,8 @@ If the files in `pkg/apis` are updated we need to run `codegen` scripts
 ```
 
 ### Setup
-- Set `KO_DOCKER_ENV` environment variable ([ko#usage](https://github.com/google/ko#usage))
+- Set `KO_DOCKER_REPO` environment variable ([ko#usage](https://github.com/google/ko#usage))
+- If you want to use local image rather than pushing image to registry you can set flags with `KO_FLAGS=--local` when you run operator
 
 ### Run operator
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ get-releases: |
 apply: | $(KO) $(KUSTOMIZE) get-releases ; $(info $(M) ko apply on $(TARGET)) @ ## Apply config to the current cluster
 	@ ## --load-restrictor LoadRestrictionsNone is needed in kustomize build as files which not in child tree of kustomize base are pulled
 	@ ## https://github.com/kubernetes-sigs/kustomize/issues/766
-	$Q $(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/$(TARGET)/overlays/default | $(KO) apply $(PLATFORM) -f -
+	$Q $(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/$(TARGET)/overlays/default | $(KO) apply $(KO_FLAGS) $(PLATFORM) -f -
 
 .PHONY: apply-cr
 apply-cr: | ; $(info $(M) apply CRs on $(TARGET)) @ ## Apply the CRs to the current cluster


### PR DESCRIPTION
When try to run operator with code you must set ENV KO_DOCKER_REPO
while it is not convenient for developer.

Now adding a flags that will be used by ko when you run `make apply`.
So you can add any flags you want to ko now.

Issue: https://github.com/tektoncd/operator/issues/950

Signed-off-by: yuzhipeng <yuzp1996@qq.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
