### PR TITLE
fix secret detach from SA

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -68,6 +68,19 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 	openshiftTrigger.SetDefault(&config.Spec.Trigger.TriggersProperties)
 	r.setDefault()
 
+	// below code helps to retain state of pre-existing SA at the time of upgrade
+	if existingSAWithOwnerRef(r.tektonConfig) {
+		if err := removeOwnerRefFromPreExistingSA(ctx, r.kubeClientSet); err != nil {
+			return err
+		}
+		tcLabels := config.GetLabels()
+		tcLabels[serviceAccountCreationLabel] = "true"
+		config.SetLabels(tcLabels)
+		if _, err := oe.operatorClientSet.OperatorV1alpha1().TektonConfigs().Update(ctx, config, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+
 	createRBACResource := true
 	for _, v := range config.Spec.Params {
 		// check for param name and if its matches to createRbacResource
@@ -131,4 +144,30 @@ func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonC
 // configOwnerRef returns owner reference pointing to passed instance
 func configOwnerRef(tc v1alpha1.TektonInstallerSet) metav1.OwnerReference {
 	return *metav1.NewControllerRef(&tc, tc.GetGroupVersionKind())
+}
+
+func removeOwnerRefFromPreExistingSA(ctx context.Context, kc kubernetes.Interface) error {
+	allSAs, err := kc.CoreV1().ServiceAccounts("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, sa := range allSAs.Items {
+		if sa.Name == "pipeline" && !nsRegex.MatchString(sa.Namespace) {
+			sa.SetOwnerReferences([]metav1.OwnerReference{})
+			if _, err := kc.CoreV1().ServiceAccounts(sa.Namespace).Update(ctx, &sa, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// existingSAWithOwnerRef checks if openshift-pipelines.tekton.dev/sa-created label is present on tektonconfig
+// we add this label from pipelines 1.8, and do not add tektoninstaller set as owner of serviceaccount created
+// if label not present it means SA was created earlier and we need to remove ownerRef before we do the update
+// this helps us to keep pre-existing SA as it is.
+func existingSAWithOwnerRef(tc *v1alpha1.TektonConfig) bool {
+	tcLabels := tc.GetLabels()
+	_, ok := tcLabels[serviceAccountCreationLabel]
+	return !ok
 }

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -354,17 +354,23 @@ func (r *rbac) ensureSA(ctx context.Context, ns *corev1.Namespace) (*corev1.Serv
 	}
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("creating sa ", pipelineSA, " ns", ns.Name)
-		return createSA(ctx, saInterface, ns.Name, r.tektonConfig)
+		return createSA(ctx, saInterface, ns.Name, *r.tektonConfig)
 	}
+
+	// set tektonConfig ownerRef
+	tcOwnerRef := tektonConfigOwnerRef(*r.tektonConfig)
+	sa.SetOwnerReferences([]metav1.OwnerReference{tcOwnerRef})
 
 	return saInterface.Update(ctx, sa, metav1.UpdateOptions{})
 }
 
-func createSA(ctx context.Context, saInterface v1.ServiceAccountInterface, ns string, tc *v1alpha1.TektonConfig) (*corev1.ServiceAccount, error) {
+func createSA(ctx context.Context, saInterface v1.ServiceAccountInterface, ns string, tc v1alpha1.TektonConfig) (*corev1.ServiceAccount, error) {
+	tcOwnerRef := tektonConfigOwnerRef(tc)
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pipelineSA,
-			Namespace: ns,
+			Name:            pipelineSA,
+			Namespace:       ns,
+			OwnerReferences: []metav1.OwnerReference{tcOwnerRef},
 		},
 	}
 

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -45,15 +45,16 @@ const (
 	pipelineRoleBindingOld  = "edit"
 	rbacInstallerSetNameOld = "rbac-resources"
 	// --------------------
-	serviceCABundleConfigMap   = "config-service-cabundle"
-	trustedCABundleConfigMap   = "config-trusted-cabundle"
-	clusterInterceptors        = "openshift-pipelines-clusterinterceptors"
-	namespaceVersionLabel      = "openshift-pipelines.tekton.dev/namespace-reconcile-version"
-	createdByValue             = "RBAC"
-	componentNameRBAC          = "rhosp-rbac"
-	rbacInstallerSetType       = "rhosp-rbac"
-	rbacInstallerSetNamePrefix = "rhosp-rbac-"
-	rbacParamName              = "createRbacResource"
+	serviceCABundleConfigMap    = "config-service-cabundle"
+	trustedCABundleConfigMap    = "config-trusted-cabundle"
+	clusterInterceptors         = "openshift-pipelines-clusterinterceptors"
+	namespaceVersionLabel       = "openshift-pipelines.tekton.dev/namespace-reconcile-version"
+	createdByValue              = "RBAC"
+	componentNameRBAC           = "rhosp-rbac"
+	rbacInstallerSetType        = "rhosp-rbac"
+	rbacInstallerSetNamePrefix  = "rhosp-rbac-"
+	rbacParamName               = "createRbacResource"
+	serviceAccountCreationLabel = "openshift-pipelines.tekton.dev/sa-created"
 )
 
 var (
@@ -353,21 +354,17 @@ func (r *rbac) ensureSA(ctx context.Context, ns *corev1.Namespace) (*corev1.Serv
 	}
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("creating sa ", pipelineSA, " ns", ns.Name)
-		return createSA(ctx, saInterface, ns.Name, r.ownerRef)
+		return createSA(ctx, saInterface, ns.Name, r.tektonConfig)
 	}
-
-	// set owner reference if not set or update owner reference if different owners are set
-	sa.SetOwnerReferences(r.updateOwnerRefs(sa.GetOwnerReferences()))
 
 	return saInterface.Update(ctx, sa, metav1.UpdateOptions{})
 }
 
-func createSA(ctx context.Context, saInterface v1.ServiceAccountInterface, ns string, ownerRef metav1.OwnerReference) (*corev1.ServiceAccount, error) {
+func createSA(ctx context.Context, saInterface v1.ServiceAccountInterface, ns string, tc *v1alpha1.TektonConfig) (*corev1.ServiceAccount, error) {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            pipelineSA,
-			Namespace:       ns,
-			OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Name:      pipelineSA,
+			Namespace: ns,
 		},
 	}
 
@@ -376,6 +373,9 @@ func createSA(ctx context.Context, saInterface v1.ServiceAccountInterface, ns st
 		return nil, err
 	}
 
+	tektonConfigLabels := tc.GetLabels()
+	tektonConfigLabels[serviceAccountCreationLabel] = "true"
+	tc.SetLabels(tektonConfigLabels)
 	return sa, nil
 }
 


### PR DESCRIPTION
issue:
  operator creates SA which is used to run pr/tr, where user could
  attach a secret.
  All the SA create by operator have ownerRef of InsterllerSet
  any time there is a version update all the SA get re-creted and
  any of external added secretes to SA get removed.

fix:
  we have removed the ownerRef from the SAs created, which do not
  re-creates the SA with an upgrade.

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
