### PR TITLE
Fix the validation in tektonpipeline and tektontrigger

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -44,10 +44,9 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 func (p *PipelineProperties) validate(path string) (errs *apis.FieldError) {
 
 	if p.EnableApiFields != "" {
-		if p.EnableApiFields == ApiFieldStable || p.EnableApiFields == ApiFieldAlpha {
-			return errs
+		if p.EnableApiFields != ApiFieldStable && p.EnableApiFields != ApiFieldAlpha {
+			errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, path+".enable-api-fields"))
 		}
-		errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, path+".enable-api-fields"))
 	}
 	if p.DefaultTimeoutMinutes != nil {
 		if *p.DefaultTimeoutMinutes == 0 {

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
@@ -39,6 +39,29 @@ func Test_ValidateTektonPipeline_MissingTargetNamespace(t *testing.T) {
 	assert.Equal(t, "missing field(s): spec.targetNamespace", err.Error())
 }
 
+func Test_ValidateTektonPipeline_APIField(t *testing.T) {
+
+	tp := &TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipeline",
+			Namespace: "namespace",
+		},
+		Spec: TektonPipelineSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Pipeline: Pipeline{
+				PipelineProperties: PipelineProperties{
+					EnableApiFields: "prod",
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	assert.Equal(t, "invalid value: prod: spec.enable-api-fields", err.Error())
+}
+
 func Test_ValidateTektonPipeline_OnDelete(t *testing.T) {
 
 	td := &TektonPipeline{

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
@@ -44,10 +44,9 @@ func (tr *TektonTrigger) Validate(ctx context.Context) (errs *apis.FieldError) {
 func (tr *TriggersProperties) validate(path string) (errs *apis.FieldError) {
 
 	if tr.EnableApiFields != "" {
-		if tr.EnableApiFields == ApiFieldStable || tr.EnableApiFields == ApiFieldAlpha {
-			return errs
+		if tr.EnableApiFields != ApiFieldStable && tr.EnableApiFields != ApiFieldAlpha {
+			errs = errs.Also(apis.ErrInvalidValue(tr.EnableApiFields, path+".enable-api-fields"))
 		}
-		errs = errs.Also(apis.ErrInvalidValue(tr.EnableApiFields, path+".enable-api-fields"))
 	}
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation_test.go
@@ -39,6 +39,29 @@ func Test_ValidateTektonTrigger_MissingTargetNamespace(t *testing.T) {
 	assert.Equal(t, "missing field(s): spec.targetNamespace", err.Error())
 }
 
+func Test_ValidateTektonTrigger_APIField(t *testing.T) {
+
+	tp := &TektonTrigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trigger",
+			Namespace: "namespace",
+		},
+		Spec: TektonTriggerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Trigger: Trigger{
+				TriggersProperties: TriggersProperties{
+					EnableApiFields: "prod",
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	assert.Equal(t, "invalid value: prod: spec.enable-api-fields", err.Error())
+}
+
 func Test_ValidateTektonTrigger_OnDelete(t *testing.T) {
 
 	td := &TektonTrigger{


### PR DESCRIPTION
This will fix the validation in tektonpipeline and tektontrigger
as the current validation is returning from in between

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Fix the validation in tektonpipeline and tektontrigger
```
