### PR TITLE
Run maven and openshift-client as non-root

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/maven/maven-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/maven/maven-task.yaml
@@ -147,3 +147,6 @@ spec:
         - -s
         - $(workspaces.maven-settings.path)/settings.xml
         - "$(params.GOALS)"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/openshift-client/openshift-client-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/openshift-client/openshift-client-task.yaml
@@ -55,3 +55,6 @@ spec:
         export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
 
         $(params.SCRIPT)
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532


### PR DESCRIPTION
# Changes

This PR aims at running tasks as nonroot unless root is required. When tasks are deployed on a Kubernetes cluster (or on OpenShift with anyuid SCC), they run as the root user which is not ideal from a security perspective as it leaves the node exposed to attacks if a bad actor is able to escape the pod.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
maven and openshift-client cluster tasks are now run as non root
```