### PR TITLE
[Cherry-pick] [OpenShit] fix secret detach from SA 

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -69,7 +69,7 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 
 	// below code helps to retain state of pre-existing SA at the time of upgrade
 	if existingSAWithOwnerRef(r.tektonConfig) {
-		if err := removeOwnerRefFromPreExistingSA(ctx, r.kubeClientSet); err != nil {
+		if err := changeOwnerRefOfPreExistingSA(ctx, r.kubeClientSet, *config); err != nil {
 			return err
 		}
 		tcLabels := config.GetLabels()
@@ -144,14 +144,21 @@ func configOwnerRef(tc v1alpha1.TektonInstallerSet) metav1.OwnerReference {
 	return *metav1.NewControllerRef(&tc, tc.GetGroupVersionKind())
 }
 
-func removeOwnerRefFromPreExistingSA(ctx context.Context, kc kubernetes.Interface) error {
+// tektonConfigOwnerRef returns owner reference of tektonConfig
+func tektonConfigOwnerRef(tc v1alpha1.TektonConfig) metav1.OwnerReference {
+	return *metav1.NewControllerRef(&tc, tc.GetGroupVersionKind())
+}
+
+func changeOwnerRefOfPreExistingSA(ctx context.Context, kc kubernetes.Interface, tc v1alpha1.TektonConfig) error {
 	allSAs, err := kc.CoreV1().ServiceAccounts("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, sa := range allSAs.Items {
 		if sa.Name == "pipeline" && !nsRegex.MatchString(sa.Namespace) {
-			sa.SetOwnerReferences([]metav1.OwnerReference{})
+			// set tektonconfig ownerRef
+			tcOwnerRef := tektonConfigOwnerRef(tc)
+			sa.SetOwnerReferences([]metav1.OwnerReference{tcOwnerRef})
 			if _, err := kc.CoreV1().ServiceAccounts(sa.Namespace).Update(ctx, &sa, metav1.UpdateOptions{}); err != nil {
 				return err
 			}


### PR DESCRIPTION
fix secret detach from SA
issue:
operator creates SA which is used to run pr/tr, where user could
attach a secret.
All the SA create by operator have ownerRef of InsterllerSet
any time there is a version update all the SA get re-creted and
any of external added secretes to SA get removed.

fix:
we have removed the ownerRef from the SAs created, which do not
re-creates the SA with an upgrade.

Signed-off-by: Pradeep Kumar [pradkuma@redhat.com](mailto:pradkuma@redhat.com)
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
