### PR TITLE
Merge in changes from builah catalog task 0.4

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -78,7 +78,7 @@ spec:
       [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
-        -digestfile /tmp/image-digest $(params.IMAGE) \
+        --digestfile /tmp/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat /tmp/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -61,6 +61,8 @@ spec:
   results:
   - name: IMAGE_DIGEST
     description: Digest of the image just built.
+  - name: IMAGE_URL
+    description: Image repository where the built image would be pushed to
 
   steps:
   - name: build-and-push
@@ -76,9 +78,10 @@ spec:
       [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
-        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        -digestfile /tmp/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
-      cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+      cat /tmp/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers


### PR DESCRIPTION
Merge some of the changes from tektoncd/catalog#983
* Store image-digest outside of workspace, to allow for readonly workspaces (eg. ConfigMap)
* Add IMAGE_URL (for Chains compatability)

@vdemeester @vinamra28 

Why aren't the Tasks exactly the same?

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
