### PR TITLE
docs: add keep-since to TektonConfig docs

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -151,7 +151,10 @@ pruner:
 
 - `resources`: supported resources for auto prune are `taskrun` and `pipelinerun`
 - `keep`: maximum number of resources to keep while deleting removing
+- `keep-since`: retain the resources younger than the specified value in minutes
 - `schedule`: how often to clean up resources. User can understand the schedule syntax [here][schedule].
+
+**NOTE**: `keep` and `keep-since` are mutually exclusive. Specify only one of them.
 
 This is an `Optional` section.
 


### PR DESCRIPTION
# Changes

- Adds keep-since to TektonConfig docs
- Type Declaration: https://github.com/tektoncd/operator/blob/main/pkg/apis/operator/v1alpha1/tektonconfig_types.go#L58-L61
- Mutually exclusive keep and keep-since: https://github.com/tektoncd/operator/blob/main/pkg/apis/operator/v1alpha1/tektonconfig_validation.go#L77-L81
- Fixes tektoncd/website#419, RHDEVDOCS-4312
- Blocked by #1025 

Signed-off-by: Avinal Kumar <avinal@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes