### PR TITLE
Bump golangci-lint to v1.47.2 to support Go 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ tags
 
 ### idea/goland ###
 .idea/*
+
+.bin/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TARGET        = kubernetes
 CR            = config/basic
 PLATFORM := $(if $(PLATFORM),--platform $(PLATFORM))
 
-GOLANGCI_VERSION  = v1.30.0
+GOLANGCI_VERSION  = v1.47.2
 
 BIN      = $(CURDIR)/.bin
 
@@ -148,9 +148,9 @@ test-unit: ## Run unit tests
 lint: lint-go lint-yaml ## run all linters
 
 .PHONY: lint-go
-lint-go: ## runs go linter on all go files
+lint-go: | $(GOLANGCILINT) ## runs go linter on all go files
 	@echo "Linting go files..."
-	@golangci-lint run ./... --modules-download-mode=vendor \
+	@$(GOLANGCILINT) run ./... --modules-download-mode=vendor \
 							--max-issues-per-linter=0 \
 							--max-same-issues=0 \
 							--deadline 5m


### PR DESCRIPTION
# Changes

We're moving `test-runner` to Go 1.18.3, and therefore need to bump golangci-lint to v1.47.2, since the version currently used here fails in a bunch of ways due to lack of support for Go 1.18+.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
