### PR TITLE
Set HOME to /tekton/home for nonroot tasks

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/maven/maven-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/maven/maven-task.yaml
@@ -74,6 +74,12 @@ spec:
   steps:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      env:
+      - name: HOME
+        value: /tekton/home
       script: |
         #!/usr/bin/env bash
 
@@ -140,6 +146,9 @@ spec:
         fi
 
     - name: mvn-goals
+      env:
+      - name: HOME
+        value: /tekton/home
       image: $(params.MAVEN_IMAGE)
       workingDir: $(workspaces.source.path)/$(params.CONTEXT_DIR)
       command: ["/usr/bin/mvn"]

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/openshift-client/openshift-client-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/openshift-client/openshift-client-task.yaml
@@ -43,6 +43,9 @@ spec:
       default: "latest"
   steps:
     - name: oc
+      env:
+      - name: HOME
+        value: /tekton/home
       image: image-registry.openshift-image-registry.svc:5000/openshift/cli:$(params.VERSION)
       script: |
         #!/usr/bin/env bash


### PR DESCRIPTION
# Changes

In an effort to reduce permissions for certain tasks, the HOME
directory was either set to /home/nonroot or was unchanged. This
caused the tasks to fail when being run under limited permissions as
they could not create /home/nonroot or write to / in some cases.

This commit sets HOME to /tekton/home so that the task can perform
actions in it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
HOME variable is set to /tekton/home in ClusterTasks
```