### PR TITLE
Define keep and keep-since simultaneously

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -146,11 +146,13 @@ pruner:
     - taskrun
     - pipelinerun
   keep: 3
+  keep-since: 1440
   schedule: "* * * * *"
 ```
 
 - `resources`: supported resources for auto prune are `taskrun` and `pipelinerun`
-- `keep`: maximum number of resources to keep while deleting removing
+- `keep`: maximum number of resources to keep while deleting or removing resources
+- `keep-since`: retain the resources younger than the specified value in minutes
 - `schedule`: how often to clean up resources. User can understand the schedule syntax [here][schedule].
 
 This is an `Optional` section.

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -74,15 +74,14 @@ func (p Prune) validate() *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("spec.pruner.resources"))
 	}
 
-	if p.Keep != nil && p.KeepSince != nil {
-		errs = errs.Also(apis.ErrMultipleOneOf("spec.pruner.keep", "spec.pruner.keep-since"))
-	}
 	if p.Keep == nil && p.KeepSince == nil {
 		errs = errs.Also(apis.ErrMissingOneOf("spec.pruner.keep", "spec.pruner.keep-since"))
-	} else if p.Keep != nil && *p.Keep == 0 {
+	}
+	if p.Keep != nil && *p.Keep == 0 {
 		errs = errs.Also(apis.ErrInvalidValue(*p.Keep, "spec.pruner.keep"))
-	} else if p.KeepSince != nil && *p.KeepSince == 0 {
-		errs = errs.Also(apis.ErrInvalidValue(*p.Keep, "spec.pruner.keep-since"))
+	}
+	if p.KeepSince != nil && *p.KeepSince == 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*p.KeepSince, "spec.pruner.keep-since"))
 	}
 
 	if p.Schedule == "" {

--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -398,20 +398,24 @@ func createCronJob(ctx context.Context, kc kubernetes.Interface, cronName, targe
 // ns-one;--keep=5;pipelinerun
 // ns-two;--keep=3;pipelinerun,taskrun
 // ns-three;--keep=2;taskrun
+// ns-four;--keep=4 --keep-since=300; pipelinerun
 // these configs are passed as space seperated string argument to pod container spec
 // for each of this namespaced config below commands are generated
 // tkn pipelinerun delete --keep=5 -n=ns-one -f ;
 // tkn pipelinerun delete --keep=3 -n=ns-two -f ;
 // tkn taskrun delete --keep=3 -n=ns-two -f ;
 // tkn taskrun delete --keep=3 -n=ns-three -f ;
+// tkn pipelinerun delete --keep=4 --keep-since=300 -n=ns-four -f ;
 func generatePruneConfigPerNamespace(pru *pruneConfigPerNS, ns string) string {
-	var keepCmd string
+	keepCmd := ""
 	if pru.config.Keep != nil {
-		keepCmd = "--keep=" + fmt.Sprint(*pru.config.Keep)
+		keepCmd = keepCmd + "--keep=" + fmt.Sprint(*pru.config.Keep)
 	}
-	if pru.config.Keep == nil && pru.config.KeepSince != nil {
-		keepCmd = "--keep-since=" + fmt.Sprint(*pru.config.KeepSince)
+	if pru.config.KeepSince != nil {
+		keepCmd = keepCmd + " --keep-since=" + fmt.Sprint(*pru.config.KeepSince)
+
 	}
+	keepCmd = strings.TrimSpace(keepCmd)
 	cmdArgs := ns + ";" + keepCmd + ";"
 	var resources string
 	for i, resource := range pru.config.Resources {


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
- `keep` and `keep-since` can be defined simultaneously in the pruning
configuration.
- the required functionality is already present in the tekton CLI
- Refer: tektoncd/cli#1471 tektoncd/cli#1533
- Fixes tektoncd/operator#974, tektoncd/website#419, RHDEVDOCS-4312

Signed-off-by: Avinal Kumar <avinal@redhat.com>
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) tektoncd/operator#966
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
