### PR TITLE
fix(resolutionrequests): aggregate-to-view so non-admin users can run…

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -803,4 +803,20 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "tekton-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: tekton-info-aggregate-view
+rules:
+  - apiGroups:
+      - resolution.tekton.dev
+    resources:
+      - resolutionrequests
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}


### PR DESCRIPTION
 aggregate-to-view for resolutionrequests resoure so non-admin user can run `kubectl get all` 

# Changes

The PR add a new ClusterRole that will aggregate-to-view for the resolutionrequests resource.  Without this non-admin cluster get an error when running `kubectl get all` (see below).  This new ClusterRole avoids that that errol 

```
$ kubectl get all
NAME                  TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)             AGE
service/ace-hub-api   ClusterIP   10.43.8.16   <none>        8080/TCP,9102/TCP   76d
Error from server (Forbidden): resolutionrequests.resolution.tekton.dev is forbidden: User "https://git.act3-ace.com#17" cannot list resource "resolutionrequests" in API group "resolution.tekton.dev" in the namespace "tgilkerson-workspace"


$ kubectl auth can-i get resolutionrequests -n acedev-workspace
no
```


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
 Add ClusterRole that will `aggregate-to-view` for `resolutionrequests` resource so that a non-admin user can run `kubectl get all` without seeing an error
```

