### PR TITLE
TektonInstallerSet: filter resources at once, removes predicates 

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/controller.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/controller.go
@@ -19,7 +19,6 @@ package tektoninstallerset
 import (
 	"context"
 
-	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
@@ -50,12 +49,10 @@ func NewExtendedController() injection.ControllerConstructor {
 		if err != nil {
 			logger.Fatalw("Error creating client from injected config", zap.Error(err))
 		}
-		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
 
 		c := &Reconciler{
 			operatorClientSet: operatorclient.Get(ctx),
 			mfClient:          mfclient,
-			mfLogger:          mflogger,
 		}
 		impl := tektonInstallerReconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install_test.go
@@ -59,13 +59,9 @@ func TestEnsureResources_CreateResource(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-		MfClient: fakeClient,
-		Logger:   logger,
-	}
+	i := NewInstaller(&manifest, fakeClient, logger)
 
-	err = i.ensureResources(&manifest)
+	err = i.EnsureNamespaceScopedResources()
 	assert.NilError(t, err)
 
 	res, err := fakeClient.Get(&serviceAccount)
@@ -94,13 +90,9 @@ func TestEnsureResources_UpdateResource(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-		MfClient: fakeClient,
-		Logger:   logger,
-	}
+	i := NewInstaller(&manifest, fakeClient, logger)
 
-	err = i.ensureResources(&manifest)
+	err = i.EnsureNamespaceScopedResources()
 	assert.NilError(t, err)
 
 	res, err := fakeClient.Get(&serviceAccount)
@@ -225,9 +217,9 @@ func TestControllerReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsControllerReady()
 	if err != nil {
@@ -244,9 +236,9 @@ func TestControllerNotReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsControllerReady()
 	if err == nil {
@@ -263,9 +255,9 @@ func TestWebhookReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsWebhookReady()
 	if err != nil {
@@ -282,9 +274,9 @@ func TestWebhookNotReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsWebhookReady()
 	if err == nil {
@@ -301,9 +293,9 @@ func TestAllDeploymentsReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.AllDeploymentsReady()
 	if err != nil {
@@ -320,9 +312,9 @@ func TestAllDeploymentsNotReady(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.AllDeploymentsReady()
 	if err == nil {
@@ -339,9 +331,9 @@ func TestJobCompleted(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsJobCompleted(context.Background(), nil, "")
 	if err != nil {
@@ -358,9 +350,9 @@ func TestJobFailed(t *testing.T) {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
 
-	i := installer{
-		Manifest: manifest,
-	}
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	i := NewInstaller(&manifest, client, logger)
 
 	err = i.IsJobCompleted(context.Background(), nil, "")
 	if err == nil {

--- a/third_party/github.com/hashicorp/go-rootcerts/rootcerts_base.go
+++ b/third_party/github.com/hashicorp/go-rootcerts/rootcerts_base.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package rootcerts

--- a/third_party/github.com/hashicorp/go-sockaddr/ifaddrs.go
+++ b/third_party/github.com/hashicorp/go-sockaddr/ifaddrs.go
@@ -1214,14 +1214,13 @@ func parseDefaultIfNameFromIPCmd(routeOut string) (string, error) {
 // Android.
 func parseDefaultIfNameFromIPCmdAndroid(routeOut string) (string, error) {
 	parsedLines := parseIfNameFromIPCmd(routeOut)
-	if (len(parsedLines) > 0) {
+	if len(parsedLines) > 0 {
 		ifName := strings.TrimSpace(parsedLines[0][4])
 		return ifName, nil
 	}
 
 	return "", errors.New("No default interface found")
 }
-
 
 // parseIfNameFromIPCmd parses interfaces from ip(8) for
 // Linux.

--- a/third_party/github.com/hashicorp/go-sockaddr/route_info_android.go
+++ b/third_party/github.com/hashicorp/go-sockaddr/route_info_android.go
@@ -25,7 +25,6 @@ func (ri routeInfo) GetDefaultInterfaceName() (string, error) {
 		return "", err
 	}
 
-
 	var ifName string
 	if ifName, err = parseDefaultIfNameFromIPCmdAndroid(string(out)); err != nil {
 		return "", errors.New("No default interface found")

--- a/third_party/github.com/hashicorp/go-sockaddr/route_info_bsd.go
+++ b/third_party/github.com/hashicorp/go-sockaddr/route_info_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
 // +build darwin dragonfly freebsd netbsd openbsd
 
 package sockaddr

--- a/third_party/github.com/hashicorp/go-sockaddr/route_info_default.go
+++ b/third_party/github.com/hashicorp/go-sockaddr/route_info_default.go
@@ -1,3 +1,4 @@
+//go:build android || nacl || plan9
 // +build android nacl plan9
 
 package sockaddr

--- a/third_party/github.com/hashicorp/go-sockaddr/route_info_linux.go
+++ b/third_party/github.com/hashicorp/go-sockaddr/route_info_linux.go
@@ -1,3 +1,4 @@
+//go:build !android
 // +build !android
 
 package sockaddr

--- a/third_party/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/third_party/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -34,6 +34,6 @@ type LRUCache interface {
 	// Clears all cache entries.
 	Purge()
 
-  // Resizes cache, returning number evicted
-  Resize(int) int
+	// Resizes cache, returning number evicted
+	Resize(int) int
 }


### PR DESCRIPTION
the order in which resources are applied is imp, for eg. namespace
should be created before configmap and other ns scoped resources.
but we don't need to keep list, hence removing predicates and filtering
resources at first and then applying.

if a new resource kind is added in release yaml, dont need add a predicate
now.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
