### PR TITLE
[Openshift] Add clustertriggerbinding for bitbucket cloud

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/01-clustertriggerbindings/bitbucket-cloud.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/01-clustertriggerbindings/bitbucket-cloud.yaml
@@ -1,0 +1,52 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: bitbucket-cloud-pullreq
+spec:
+  params:
+    - name: gitrepo-url
+      value: $(body.pullrequest.source.repository.links.html.href)
+    - name: pullreq-sha
+      value: $(body.pullrequest.source.commit.hash)
+    - name: pullreq-state
+      value: $(body.pullrequest.state)
+    - name: pullreq-number
+      value: $(body.pullrequest.id)
+    - name: pullreq-repo-name
+      value: $(body.pullrequest.destination.repository.name)
+    - name: pullreq-html-url
+      value: $(body.pullrequest.links.html.href)
+    - name: pullreq-title
+      value: $(body.pullrequest.title)
+    - name: user-type
+      value: $(body.pullrequest.author.display_name)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: bitbucket-cloud-push
+spec:
+  params:
+    - name: git-revision
+      value: $(body.push.changes[0].new.name)
+    - name: gitrepo-url
+      value: $(body.repository.links.html.href)
+    - name: git-repo-name
+      value: $(body.repository.name)
+    - name: pusher-name
+      value: $(body.actor.display_name)
+
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterTriggerBinding
+metadata:
+  name: bitbucket-cloud-pullreq-add-comment
+spec:
+  params:
+    - name: comment
+      value: $(body.comment.content.raw)
+    - name: comment-user-login
+      value: $(body.comment.user.display_name)
+    - name: pullreq-number
+      value: $(body.comment.pullrequest.id)


### PR DESCRIPTION
# Changes

* As part of this PR Operator now add support of clustertriggerbinding for bitbucket cloud

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Operator supports bitbucket cloud clustertriggerbinding
```