### PR TITLE
Use the correct repository URL for openshift CSV

### DIFF
--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -10,7 +10,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.2
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonhubs.operator.tekton.dev", "tektonchains.operator.tekton.dev"]'
-    repository: https://github.com/openshift/tektoncd-operator
+    repository: https://github.com/tektoncd/operator
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported


### PR DESCRIPTION

# Changes

The current value "https://github.com/openshift/tektoncd-operator" is
not correct as it is a read-only repository that does not reflect
where the operator lives from now on.

Fixing this by using tektoncd/operator as repository url.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @nikhil-thomas @sm43 @concaf 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix the repository url to the correct one : https://github.com/tektoncd/operator
```
