### PR TITLE
[s2i tasks] -  support env vars to be set during build time

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/dotnet:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/dotnet:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,13 +56,30 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/golang:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/golang:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       env:
         - name: HOME
           value: /tekton/home
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
     - name: build-and-push
       image: $(params.BUILDER_IMAGE)
       workingDir: /gen-source
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
@@ -61,51 +61,38 @@ spec:
         The file should be placed at the root of the Workspace with name config.json.
       optional: true
   steps:
-    - name: gen-env-file
-      image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
-      workingDir: /env-params
-      command:
-        - '/bin/sh'
-        - '-c'
-      args:
-        - |-
-          echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > env-file
-
-          [[ '$(params.MAVEN_ARGS_APPEND)' != "" ]] &&
-            echo "MAVEN_ARGS_APPEND=$(params.MAVEN_ARGS_APPEND)" >> env-file
-
-          [[ '$(params.MAVEN_MIRROR_URL)' != "" ]] &&
-            echo "MAVEN_MIRROR_URL=$(params.MAVEN_MIRROR_URL)" >> env-file
-
-          echo "Generated Env file"
-          echo "------------------------------"
-          cat env-file
-          echo "------------------------------"
-      volumeMounts:
-        - name: envparams
-          mountPath: /env-params
-      env:
-        - name: HOME
-          value: /tekton/home
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command:
-        - 's2i'
-        - 'build'
-        - '$(params.PATH_CONTEXT)'
-        - 'image-registry.openshift-image-registry.svc:5000/openshift/java:$(params.VERSION)'
-        - '--image-scripts-url'
-        - 'image:///usr/local/s2i'
-        - '--as-dockerfile'
-        - '/gen-source/Dockerfile.gen'
-        - '--environment-file'
-        - '/env-params/env-file'
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+          echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > /env-vars/env-file
+
+          [[ '$(params.MAVEN_ARGS_APPEND)' != "" ]] &&
+            echo "MAVEN_ARGS_APPEND=$(params.MAVEN_ARGS_APPEND)" >> /env-vars/env-file
+
+          [[ '$(params.MAVEN_MIRROR_URL)' != "" ]] &&
+            echo "MAVEN_MIRROR_URL=$(params.MAVEN_MIRROR_URL)" >> /env-vars/env-file
+
+          echo "Processing Build Environment Variables"
+          for var in "$@"
+          do
+            echo "$var" >> /env-vars/env-file
+          done
+
+          echo "Generated Build Env Var file"
+          echo "------------------------------"
+          cat /env-vars/env-file
+          echo "------------------------------"
+
+          s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/java:$(params.VERSION) \
+          --image-scripts-url image:///usr/local/s2i \
+          --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
-        - name: envparams
-          mountPath: /env-params
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -136,5 +123,5 @@ spec:
       emptyDir: {}
     - name: gen-source
       emptyDir: {}
-    - name: envparams
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/perl:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/perl:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/php:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/php:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/python:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/python:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
@@ -39,6 +39,10 @@ spec:
     - name: SKIP_PUSH
       description: Skip pushing the built image
       default: "false"
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
   workspaces:
     - name: source
       mountPath: /workspace/source
@@ -52,10 +56,27 @@ spec:
     - name: generate
       image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
       workingDir: $(workspaces.source.path)
-      command: ['s2i', 'build', '$(params.PATH_CONTEXT)', 'image-registry.openshift-image-registry.svc:5000/openshift/ruby:$(params.VERSION)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      args: ["$(params.ENV_VARS[*])"]
+      script: |
+        echo "Processing Build Environment Variables"
+        echo "" > /env-vars/env-file
+        for var in "$@"
+        do
+            echo "$var" >> /env-vars/env-file
+        done
+
+        echo "Generated Build Env Var file"
+        echo "------------------------------"
+        cat /env-vars/env-file
+        echo "------------------------------"
+
+        s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/ruby:$(params.VERSION) \
+        --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: env-vars
+          mountPath: /env-vars
       env:
         - name: HOME
           value: /tekton/home
@@ -85,4 +106,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: env-vars
       emptyDir: {}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

Added support for Env Variables to be set during a build time for all S2I tasks, follow the same that is being done in upstream catalog: https://github.com/tektoncd/catalog/pull/1055


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

```release-note
[s2i tasks] -  support env vars to be set during build time
```
