### PR TITLE
Exit script with PIPESTATUS instead of exit code

### DIFF
--- a/operatorhub/tools/bundle.py
+++ b/operatorhub/tools/bundle.py
@@ -199,7 +199,7 @@ def genBundleCmd(config):
                 --kustomize-dir manifests \
                 --overwrite \
                 --package {packagename} \
-                --version {version}
+                --version {version}; exit $((${{PIPESTATUS[0]}} + ${{PIPESTATUS[1]}}))
     '''.format(
         operator_sdk=OPERATOR_SDK,
         resource_gen=aggregate_resources,


### PR DESCRIPTION
# Changes

Since we piping output of kustomize to operator-sdk, the exit status
only applies to the operator-sdk command and that of kustomize is not
taken into account while exiting. This has been causing errors since
errors related to kustomize do not surface in the logs.

This commit exits with $PIPESTATUS which contains the exit status of all
the commands involved in the execution.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```