### PR TITLE
Add ApplyCABundles transformer to PAC

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinesascode.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/client-go/route/clientset/versioned/scheme"
 	"github.com/tektoncd/operator/pkg/reconciler/openshift"
@@ -170,6 +172,8 @@ func (r *Reconciler) getManifest(ctx context.Context, ta *v1alpha1.TektonAddon) 
 		common.InjectOperandNameLabelOverwriteExisting(openshift.OperandOpenShiftPipelineAsCode),
 		common.DeploymentImages(images),
 		common.AddConfiguration(ta.Spec.Config),
+		common.ApplyProxySettings,
+		occommon.ApplyCABundles,
 	}
 
 	if err := r.addonTransform(ctx, &pacManifest, ta, tfs...); err != nil {


### PR DESCRIPTION
# Changes

`ApplyCABundles` transformer mounts the user supplied certs to the
resources it applies to, which is currently all the Tekton components
and the workloads as well so as to provide access to the certs. This
transformer has been missing from PAC pods which makes certs
inaccessible from inside the controller and other pods.

This commit fixes that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
User supplied certs are now mounted in PAC pods as well
```