### PR TITLE
Move platform defaulting to webhook and avoid api calls in reconciler 

### DIFF
--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -51,6 +51,8 @@ spec:
           value: tekton-operator-webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/operator
+        - name: PLATFORM
+          value: "openshift"
         ports:
         - name: https-webhook
           containerPort: 8443

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"os"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
@@ -97,4 +99,8 @@ func ParseParams(params []Param) map[string]string {
 		paramsMap[p.Name] = p.Value
 	}
 	return paramsMap
+}
+
+func IsOpenShiftPlatform() bool {
+	return os.Getenv("PLATFORM") == "openshift"
 }

--- a/pkg/apis/operator/v1alpha1/tektontrigger_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_defaults.go
@@ -22,14 +22,28 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 )
 
+var (
+	// DefaultOpenshiftSA is the default service account for openshift
+	DefaultOpenshiftSA = "pipeline"
+)
+
 func (tt *TektonTrigger) SetDefaults(ctx context.Context) {
 	tt.Spec.TriggersProperties.setDefaults()
 }
 
 func (p *TriggersProperties) setDefaults() {
-
 	if p.EnableApiFields == "" {
 		p.EnableApiFields = config.DefaultEnableAPIFields
 	}
 
+	// run platform specific defaulting
+	if IsOpenShiftPlatform() {
+		p.openshiftDefaulting()
+	}
+}
+
+func (p *TriggersProperties) openshiftDefaulting() {
+	if p.DefaultServiceAccount == "" {
+		p.DefaultServiceAccount = DefaultOpenshiftSA
+	}
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/openshift/tektonconfig/extension"
 	openshiftPipeline "github.com/tektoncd/operator/pkg/reconciler/openshift/tektonpipeline"
-	openshiftTrigger "github.com/tektoncd/operator/pkg/reconciler/openshift/tektontrigger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -65,7 +64,6 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 
 	// set openshift specific defaults
 	openshiftPipeline.SetDefault(&config.Spec.Pipeline)
-	openshiftTrigger.SetDefault(&config.Spec.Trigger.TriggersProperties)
 	r.setDefault()
 
 	// below code helps to retain state of pre-existing SA at the time of upgrade

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -21,22 +21,15 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
-	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
-	ext := openshiftExtension{
-		operatorClientSet: operatorclient.Get(ctx),
-	}
-	return ext
+	return openshiftExtension{}
 }
 
-type openshiftExtension struct {
-	operatorClientSet versioned.Interface
-}
+type openshiftExtension struct{}
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{
@@ -48,10 +41,6 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	}
 }
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
-	tt := tc.(*v1alpha1.TektonTrigger)
-
-	SetDefault(&tt.Spec.TriggersProperties)
-
 	return nil
 }
 func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
@@ -59,12 +48,4 @@ func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonCompo
 }
 func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
 	return nil
-}
-
-func SetDefault(properties *v1alpha1.TriggersProperties) {
-
-	// Set default service account as pipeline
-	if properties.DefaultServiceAccount == "" {
-		properties.DefaultServiceAccount = common.DefaultSA
-	}
 }


### PR DESCRIPTION
after #1070 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
