### PR TITLE
tektonconfig/{pipeline,trigger} should not take TektonConfig as args.

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -113,7 +113,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	tc.Status.MarkPreInstallComplete()
 
 	// Ensure if the pipeline CR already exists, if not create Pipeline CR
-	if _, err := pipeline.EnsureTektonPipelineExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), tc); err != nil {
+	tektonpipeline := pipeline.GetTektonPipelineCR(tc)
+	// Ensure it exists
+	if _, err := pipeline.EnsureTektonPipelineExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), tektonpipeline); err != nil {
 		tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonPipeline: %s", err.Error()))
 		if err == v1alpha1.RECONCILE_AGAIN_ERR {
 			return v1alpha1.REQUEUE_EVENT_AFTER
@@ -123,7 +125,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 
 	// Create TektonTrigger CR if the profile is all or basic
 	if tc.Spec.Profile == v1alpha1.ProfileAll || tc.Spec.Profile == v1alpha1.ProfileBasic {
-		if _, err := trigger.EnsureTektonTriggerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), tc); err != nil {
+		tektontrigger := trigger.GetTektonTriggerCR(tc)
+		if _, err := trigger.EnsureTektonTriggerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), tektontrigger); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -34,37 +34,37 @@ import (
 func TestEnsureTektonTriggerExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	tConfig := GetTektonConfig()
+	tt := GetTektonTriggerCR(GetTektonConfig())
 
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
-	_, err := EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	_, err := EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
 	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// make upgrade checks pass
 	makeUpgradeCheckPass(t, ctx, c.OperatorV1alpha1().TektonTriggers())
 
 	// next invocation should return RECONCILE_AGAIN_ERR as Dashboard is waiting for installation (prereconcile, postreconcile, installersets...)
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// mark the instance ready
 	markTriggersReady(t, ctx, c.OperatorV1alpha1().TektonTriggers())
 
 	// next invocation should return nil error as the instance is ready
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, nil)
 
 	// test update propagation from tektonConfig
-	tConfig.Spec.TargetNamespace = "foobar"
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	tt.Spec.TargetNamespace = "foobar"
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, nil)
 }
 
@@ -77,8 +77,8 @@ func TestEnsureTektonTriggerCRNotExists(t *testing.T) {
 	util.AssertEqual(t, err, nil)
 
 	// create an instance for testing other cases
-	tConfig := GetTektonConfig()
-	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tConfig)
+	tt := GetTektonTriggerCR(GetTektonConfig())
+	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// when an instance exists the first invoacation should make the delete API call and

--- a/test/resources/rbac.go
+++ b/test/resources/rbac.go
@@ -4,15 +4,11 @@ import (
 	"context"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/tektoncd/operator/test/utils"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // EnsureTestNamespaceExists creates a Test Namespace


### PR DESCRIPTION


# Changes

Instead, let's create a TektonPipeline and TektonTrigger object from TektonConfig and reconciliate on those.

This makes it easier to use `pipeline` and `trigger` package independently of the `TektonConfig` object.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @sm43 @savitaashture @concaf 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
