### PR TITLE
removing printing of env-vars from S2i tasks

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-dotnet/s2i-dotnet-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/dotnet:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-go/s2i-go-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/golang:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       env:

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-java/s2i-java-task.yaml
@@ -80,11 +80,6 @@ spec:
             echo "$var" >> /env-vars/env-file
           done
 
-          echo "Generated Build Env Var file"
-          echo "------------------------------"
-          cat /env-vars/env-file
-          echo "------------------------------"
-
           s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/java:$(params.VERSION) \
           --image-scripts-url image:///usr/local/s2i \
           --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-nodejs/s2i-nodejs-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-perl/s2i-perl-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/perl:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-php/s2i-php-task.yaml
@@ -65,10 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
 
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/php:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-python/s2i-python-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/python:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/s2i-ruby/s2i-ruby-task.yaml
@@ -65,11 +65,6 @@ spec:
             echo "$var" >> /env-vars/env-file
         done
 
-        echo "Generated Build Env Var file"
-        echo "------------------------------"
-        cat /env-vars/env-file
-        echo "------------------------------"
-
         s2i build $(params.PATH_CONTEXT) image-registry.openshift-image-registry.svc:5000/openshift/ruby:$(params.VERSION) \
         --as-dockerfile /gen-source/Dockerfile.gen --environment-file /env-vars/env-file
       volumeMounts:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
