### PR TITLE
Fix postgres:13 sha256 image with multi-arched image

### DIFF
--- a/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
+++ b/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: tekton-hub-db
-          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
+          image: postgres:13
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
+++ b/pkg/reconciler/openshift/tektonhub/testdata/update-db-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: tekton-hub-db
-          image: postgres:13
+          image: postgres:13@sha256:7cc1c1a6a9df06df9e775eccdd77e45a868cb197e8e0981e23a2a814aaf56906
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432

--- a/test/e2e/common/testdata/db.yaml
+++ b/test/e2e/common/testdata/db.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
         - name: tekton-hub-db
-          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
+          image: postgres:13
           resources:
             requests:
               cpu: 100m

--- a/test/e2e/common/testdata/db.yaml
+++ b/test/e2e/common/testdata/db.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
         - name: tekton-hub-db
-          image: postgres:13
+          image: postgres:13@sha256:7cc1c1a6a9df06df9e775eccdd77e45a868cb197e8e0981e23a2a814aaf56906
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
# Changes

The CI Tekton/Operator builds are failing due to Postgres db container:-
https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-p/pipelineruns/tekton-operator-ppc64le-nightly-run-4ccfr?pipelineTask=e2e-test-operator&step=run-e2e-tests&retry=0

```
Finished run, return code is 0
XML report written to /tmp/tmp.biaUBzpey0/junit_i8rTAjte.xml
Test log written to /tmp/tmp.biaUBzpey0/go_test_i8rTAjte.log
***************************************
***         E2E TEST FAILED         ***
***    Start of information dump    ***
***************************************
>>> All resources:
NAMESPACE         NAME                                                 READY   STATUS             RESTARTS        AGE
db                pod/tekton-hub-db-75c4f48b7b-fdvks                   0/1     CrashLoopBackOff   13 (2m6s ago)   44m
default           pod/nfs-client-provisioner-7df86c59f8-b224w          1/1     Running            0               86m
kube-flannel      pod/kube-flannel-ds-fldfp                            1/1     Running            0               86m
kube-flannel      pod/kube-flannel-ds-vqvft                            1/1     Running            0               86m
kube-system       pod/coredns-78fcd69978-lctw2                         1/1     Running            0               86m
kube-system       pod/coredns-78fcd69978-tvs26                         1/1     Running            0               86m
kube-system       pod/etcd-tekton-ci-zmaster-node                      1/1     Running            0               86m
kube-system       pod/kube-apiserver-tekton-ci-zmaster-node            1/1     Running            0               86m
kube-system       pod/kube-controller-manager-tekton-ci-zmaster-node   1/1     Running            0               86m
```

From investigation we found the postgres 13 image used sha256 value that is not multi-arched. Postgres multi-arched image can be used by removing the sha256 part for the YAML file.

Fixes #1114

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix postgres:13 sha256 image with multi-arched image in e2e tests
```
