### PR TITLE
Fix clean manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ ifeq ($(TARGET), openshift)
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-hub
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/pipelines-as-code
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/addons/02-clustertasks/source_external/
+	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/go.yaml
+	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/java.yaml
+	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/nodejs.yaml
+	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/python.yaml
 else
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton*
 endif


### PR DESCRIPTION
make TARGET=openshift clean-manifest is not removing the templates generated for pipelines-as-code on openshift

this fixes removing that

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix clean manifest make target
```