### PR TITLE
Remove seccompprofile from deployments of operands

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
@@ -18,8 +18,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: tkn-cli-serve
           image: docker.io/rupali/serve-tkn:v2

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -101,8 +101,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: tekton-operators-proxy-webhook
       containers:
         - name: proxy

--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -362,9 +362,6 @@ func createCronJob(ctx context.Context, kc kubernetes.Interface, cronName, targe
 							Tolerations:        tC.Spec.Config.Tolerations,
 							SecurityContext: &corev1.PodSecurityContext{
 								RunAsNonRoot: &runAsNonRoot,
-								SeccompProfile: &corev1.SeccompProfile{
-									Type: corev1.SeccompProfileTypeRuntimeDefault,
-								},
 							},
 						},
 					},

--- a/pkg/reconciler/openshift/common/testdata/test-add-psa-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-add-psa-expected.yaml
@@ -30,8 +30,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       volumes:
         - name: catalog-source
           persistentVolumeClaim:

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -139,11 +139,6 @@ func AddDeploymentRestrictedPSA() mf.Transformer {
 		}
 		d.Spec.Template.Spec.SecurityContext.RunAsNonRoot = &runAsNonRoot
 
-		if d.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
-			d.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
-		}
-		d.Spec.Template.Spec.SecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
-
 		for i := range d.Spec.Template.Spec.Containers {
 			c := &d.Spec.Template.Spec.Containers[i]
 			if c.SecurityContext == nil {
@@ -182,11 +177,6 @@ func AddJobRestrictedPSA() mf.Transformer {
 			jb.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
 		}
 		jb.Spec.Template.Spec.SecurityContext.RunAsNonRoot = &runAsNonRoot
-
-		if jb.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
-			jb.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
-		}
-		jb.Spec.Template.Spec.SecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
 
 		for i := range jb.Spec.Template.Spec.Containers {
 			c := &jb.Spec.Template.Spec.Containers[i]


### PR DESCRIPTION
This will remove seccomp profile fields which we added for
all operands created by operator so that operator can work fine
on 4.10 along with 4.11 and 4.12

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove seccompprofile from deployments of operands
```
