### PR TITLE
fix deletion of resource which is breaking the pod

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -450,3 +450,17 @@ func isJobCompleted(d *batchv1.Job) bool {
 	}
 	return false
 }
+
+func (i *installer) DeleteResources() error {
+	for _, u := range i.Manifest.Resources() {
+		resource, err := i.Manifest.Client.Get(&u)
+		if err != nil {
+			continue
+		}
+		err = i.Manifest.Client.Delete(resource)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -52,13 +52,15 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, installerSet *v1alpha1.Te
 		return err
 	}
 
-	// Delete all resources except CRDs and Namespace as they are own by owner of
-	// TektonInstallerSet
-	// They will be deleted when the component CR is deleted
-	deleteManifests = deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs, pvcPred)))
-	err = deleteManifests.Delete()
+	// Delete all resources except CRDs, Namespace & PVC as they are own by owner of
+	// TektonInstallerSet. They will be deleted when the component CR is deleted
+	installer := installer{
+		Manifest: deleteManifests.Filter(mf.Not(mf.Any(namespacePred, mf.CRDs, pvcPred))),
+	}
+
+	err = installer.DeleteResources()
 	if err != nil {
-		logger.Error("failed to delete resources")
+		logger.Error("failed to delete resources: ", err)
 		return err
 	}
 


### PR DESCRIPTION
manifestival is breaking while deleting a resource: during deletion it first fetch the resource, if there occurs any error it still tries to access the resources which is causing
```
panic: runtime error: invalid memory address or nil pointer dereferenc
```
https://github.com/tektoncd/operator/blob/main/vendor/github.com/manifestival/manifestival/manifestival.go#L175 here when error is not nil, current is nil and then further it tries to access the resource kind which breaks the pod.

so we write our own delete func, which first fetch the resource, if not error occurs then calls delete.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
