### PR TITLE
Update pipeline-scc to not allow privilege escalation

### DIFF
--- a/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
+++ b/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
@@ -13,7 +13,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
 - SETFCAP


### PR DESCRIPTION
# Changes

This SCC shouldn't allow privilege escalation at all.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
On Openshift, the pipelines-scc doesn't allow privilege escalation anymore
```
