### PR TITLE
[Openshift] Adds transformer to remove RunAsUser from Hub Deployment and Job

### DIFF
--- a/pkg/reconciler/openshift/common/testdata/test-remove-fs-group-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fs-group-expected.yaml
@@ -38,6 +38,7 @@ spec:
           optional: true
       securityContext:
         fsGroup: 101
+        runAsNonRoot: true
       containers:
         - name: tekton-hub-api
           image: quay.io/tekton-hub/api

--- a/pkg/reconciler/openshift/common/testdata/test-remove-fs-group.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fs-group.yaml
@@ -28,6 +28,8 @@ spec:
       labels:
         app: tekton-hub-api
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: catalog-source
         persistentVolumeClaim:

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -19,6 +19,8 @@ package common
 import (
 	mf "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -36,13 +38,8 @@ func RemoveRunAsUser() mf.Transformer {
 			return err
 		}
 
-		for i := range d.Spec.Template.Spec.Containers {
-			c := &d.Spec.Template.Spec.Containers[i]
-			if c.SecurityContext != nil {
-				// Remove runAsUser
-				c.SecurityContext.RunAsUser = nil
-			}
-		}
+		containers := d.Spec.Template.Spec.Containers
+		removeRunAsUser(containers)
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 		if err != nil {
@@ -51,6 +48,41 @@ func RemoveRunAsUser() mf.Transformer {
 		u.SetUnstructuredContent(unstrObj)
 
 		return nil
+	}
+}
+
+// RemoveRunAsUser will remove RunAsUser from all container in a job
+func RemoveRunAsUserForJob() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Job" {
+			return nil
+		}
+
+		jb := &batchv1.Job{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, jb)
+		if err != nil {
+			return err
+		}
+
+		containers := jb.Spec.Template.Spec.Containers
+		removeRunAsUser(containers)
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jb)
+		if err != nil {
+			return err
+		}
+		u.SetUnstructuredContent(unstrObj)
+		return nil
+	}
+}
+
+func removeRunAsUser(containers []v1.Container) {
+	for i := range containers {
+		c := &containers[i]
+		if c.SecurityContext != nil {
+			// Remove runAsUser
+			c.SecurityContext.RunAsUser = nil
+		}
 	}
 }
 
@@ -99,8 +131,8 @@ func RemoveFsGroup(obj string) mf.Transformer {
 		}
 
 		if d.Name == obj {
-			if d.Spec.Template.Spec.SecurityContext != nil {
-				d.Spec.Template.Spec.SecurityContext = nil
+			if d.Spec.Template.Spec.SecurityContext.FSGroup != nil {
+				d.Spec.Template.Spec.SecurityContext.FSGroup = nil
 			}
 
 			unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)

--- a/pkg/reconciler/openshift/tektonhub/extension.go
+++ b/pkg/reconciler/openshift/tektonhub/extension.go
@@ -97,6 +97,8 @@ type openshiftExtension struct {
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	return []mf.Transformer{
 		UpdateDbDeployment(),
+		openshiftCommon.RemoveRunAsUser(),
+		openshiftCommon.RemoveRunAsUserForJob(),
 		openshiftCommon.RemoveFsGroup(api),
 	}
 }

--- a/test/e2e/common/05_tektonhubdeployment_test.go
+++ b/test/e2e/common/05_tektonhubdeployment_test.go
@@ -120,7 +120,6 @@ func TestTektonHubDeploymentWithExternalDatabase(t *testing.T) {
 }
 
 func TestTektonHubDeployment(t *testing.T) {
-	t.Skip()
 	crNames := utils.ResourceNames{
 		TektonConfig:    "config",
 		TektonHub:       "hub",


### PR DESCRIPTION
- With Hub v1.11.0 SecurityContext of RunAsUser
with value 65532 is added to avoid the error

```
(pod: "tekton-hub-db-79b58c96bf-4nvsw_tekton-pipelines(88103f65-9bba-4ab2-a9a1-7fa5bb32c5a1)",
 container: tekton-hub-db)'
```

- But in case of openshift, the securityContext RunAsUser
is not required, hence this patch adds a transformer to 
remove `runAsUser` from Hub Deployment and Job

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
