### PR TITLE
Fix some little thing in e2e scripts.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,11 +20,11 @@
 # flag, causes all tests to be executed, in the right order.
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
+set -e
 
 # Helper functions for E2E tests.
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
-source $(dirname $0)/config.sh
 
 function install_operator_resources() {
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,6 +16,7 @@
 
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
+set -e
 
 source $(dirname $0)/e2e-common.sh
 
@@ -25,14 +26,22 @@ TARGET=${TARGET:-kubernetes}
 KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
 KUBECONFIG_PARAM=${KUBECONFIG:+"--kubeconfig $KUBECONFIG"}
 
+E2E_SKIP_CLUSTER_CREATION=${E2E_SKIP_CLUSTER_CREATION:="false"}
+E2E_SKIP_OPERATOR_INSTALLATION=${E2E_SKIP_OPERATOR_INSTALLATION="false"}
+
 echo "Running tests on ${TARGET}"
 
-[[ -z ${E2E_SKIP_CLUSTER_CREATION} ]] && initialize $@
-failed=0
+header "Provision a cluster"
+if [ "${E2E_SKIP_CLUSTER_CREATION}" != "true" ]; then
+    initialize $@
+fi
 
 header "Setting up environment"
-[[ -z ${E2E_SKIP_OPERATOR_INSTALLATION} ]] && install_operator_resources
+if [ "${E2E_SKIP_OPERATOR_INSTALLATION}" != "true" ]; then
+    install_operator_resources $@
+fi
 
+failed=0
 tektonconfig_ready_wait
 
 header "Running Go e2e tests"


### PR DESCRIPTION

# Changes

- Do not source `config.sh` anymore (it doesn't exist anymore)
- Set some bash flag to fail "early" on e2e

Fixes #1178

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

