### PR TITLE
e2e: use kind to run tests on the CI

### DIFF
--- a/test/e2e-tests-kind-prow.env
+++ b/test/e2e-tests-kind-prow.env
@@ -1,0 +1,3 @@
+E2E_SKIP_CLUSTER_CREATION=true
+KO_DOCKER_REPO=registry.local:5000
+ARTIFACTS=/workspace/source/artifacts


### PR DESCRIPTION


# Changes

This change with one in tektoncd/plumbing should make run e2e tests on operator by default on kind.

Needs https://github.com/tektoncd/plumbing/pull/1285.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sm43 @piyush-garg 
/hold
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
