### PR TITLE
.github/workflows: fix bump-payload-on-releases

### DIFF
--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -12,7 +12,8 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        echo="branches=$(git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | grep -v 'v0.2\.*\|v0.5\.*\|v0.60\|v0.61' | awk '{ print $2 }' | cut -d/ -f3- | tr '\n' ' ')" >> $GITHUB_OUTPUT
+        git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | grep -v 'v0.2\.*\|v0.5\.*\|v0.60\|v0.61' | awk '{ print $2 }' | cut -d/ -f3- | jq -cRs 'split("\n")[:-1]'
+        echo="branches=$(git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | grep -v 'v0.2\.*\|v0.5\.*\|v0.60\|v0.61' | awk '{ print $2 }' | cut -d/ -f3- | jq -cRs 'split(\"\n\")[:-1]'" >> $GITHUB_OUTPUT
     outputs:
       branches: ${{ steps.set-matrix.outputs.branches }}
   bump-payloads:


### PR DESCRIPTION

# Changes

The output `branches` of `set-matrix` needs to be a json array, not a
list of strings.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

