### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -86,8 +85,7 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 			},
 		},
 	}
-	assert.NilError(t, os.Setenv("PLATFORM", "openshift"))
-	defer os.Clearenv()
+	t.Setenv("PLATFORM", "openshift")
 
 	tc.SetDefaults(context.TODO())
 	if len(tc.Spec.Addon.Params) != 3 {
@@ -122,8 +120,7 @@ func Test_SetDefaults_Triggers_Properties(t *testing.T) {
 }
 
 func Test_SetDefaults_PipelineAsCode(t *testing.T) {
-	assert.NilError(t, os.Setenv("PLATFORM", "openshift"))
-	defer os.Clearenv()
+	t.Setenv("PLATFORM", "openshift")
 
 	// PAC disabled through addon
 	tc := &TektonConfig{

--- a/pkg/apis/operator/v1alpha1/tektonhub_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_default_test.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +25,7 @@ import (
 
 func TestSetDefault(t *testing.T) {
 
-	os.Setenv("DEFAULT_TARGET_NAMESPACE", "tekton-pipelines")
-	defer os.Unsetenv("DEFAULT_TARGET_NAMESPACE")
+	t.Setenv("DEFAULT_TARGET_NAMESPACE", "tekton-pipelines")
 	th := &TektonHub{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hub",

--- a/pkg/reconciler/common/prune_test.go
+++ b/pkg/reconciler/common/prune_test.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 
@@ -109,8 +108,7 @@ func TestCompleteFlowPrune(t *testing.T) {
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-three", Annotations: anno1}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-four", Annotations: anno4}},
 	)
-	os.Setenv(JobsTKNImageName, "some")
-	defer os.Unsetenv(JobsTKNImageName)
+	t.Setenv(JobsTKNImageName, "some")
 
 	err := Prune(context.TODO(), client, config)
 	if err != nil {
@@ -211,8 +209,7 @@ func TestAnnotationCmd(t *testing.T) {
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-ten", Annotations: annoResourceTrPr}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-thirteen", Annotations: annoStrategyKeep}},
 	)
-	os.Setenv(JobsTKNImageName, "some")
-	defer os.Unsetenv(JobsTKNImageName)
+	t.Setenv(JobsTKNImageName, "some")
 
 	err := Prune(context.TODO(), client, config)
 	if err != nil {
@@ -284,8 +281,7 @@ func TestConfigChange(t *testing.T) {
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-api"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-one", Annotations: anno1}},
 	)
-	os.Setenv(JobsTKNImageName, "some")
-	defer os.Unsetenv(JobsTKNImageName)
+	t.Setenv(JobsTKNImageName, "some")
 
 	err := Prune(context.TODO(), client, config)
 	if err != nil {
@@ -389,8 +385,7 @@ func TestNodeSelectorOrTolerationsChange(t *testing.T) {
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-two", Annotations: annoUniqueSchedule}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-three", Annotations: annoUniqueSchedule2}},
 	)
-	os.Setenv(JobsTKNImageName, "some")
-	defer os.Unsetenv(JobsTKNImageName)
+	t.Setenv(JobsTKNImageName, "some")
 
 	// Pruning with the nodes and Tolerations
 	err := Prune(context.TODO(), client, config1)

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"os"
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
@@ -31,8 +30,7 @@ const (
 
 func TestGetLatestRelease(t *testing.T) {
 	koPath := "testdata/kodata"
-	os.Setenv(KoEnvKey, koPath)
-	defer os.Unsetenv(KoEnvKey)
+	t.Setenv(KoEnvKey, koPath)
 
 	version := latestRelease(&v1alpha1.TektonTrigger{})
 	util.AssertEqual(t, version, VERSION)
@@ -40,8 +38,7 @@ func TestGetLatestRelease(t *testing.T) {
 
 func TestListReleases(t *testing.T) {
 	koPath := "testdata/kodata"
-	os.Setenv(KoEnvKey, koPath)
-	defer os.Unsetenv(KoEnvKey)
+	t.Setenv(KoEnvKey, koPath)
 	expectedVersionList := []string{"0.15.2", "0.14.3", "0.13.2"}
 
 	version, err := allReleases(&v1alpha1.TektonTrigger{})

--- a/pkg/reconciler/common/stages_test.go
+++ b/pkg/reconciler/common/stages_test.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
@@ -30,8 +29,7 @@ import (
 )
 
 func TestDeleteObsoleteResources(t *testing.T) {
-	os.Setenv(KoEnvKey, "testdata/kodata")
-	defer os.Unsetenv(KoEnvKey)
+	t.Setenv(KoEnvKey, "testdata/kodata")
 	client := fake.New()
 	manifest, err := mf.NewManifest("testdata/test_delete_obsolete_resources/dummy.release.notags.yaml", mf.UseClient(client))
 	if err != nil {

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"os"
 	"path"
 	"testing"
 
@@ -97,7 +96,7 @@ func TestCommonTransformers(t *testing.T) {
 }
 
 func TestImagesFromEnv(t *testing.T) {
-	os.Setenv("IMAGE_PIPELINES_CONTROLLER", "docker.io/pipeline")
+	t.Setenv("IMAGE_PIPELINES_CONTROLLER", "docker.io/pipeline")
 	data := ImagesFromEnv(PipelinesImagePrefix)
 	if !cmp.Equal(data, map[string]string{"CONTROLLER": "docker.io/pipeline"}) {
 		t.Fatalf("Unexpected ImageFromEnv: %s", cmp.Diff(data, map[string]string{"CONTROLLER": "docker.io/pipeline"}))

--- a/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension/dashboard_test.go
@@ -18,7 +18,6 @@ package extension
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
@@ -109,14 +108,16 @@ func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonDashboar
 	// set necessary version labels to make upgrade check pass
 	dashboard, err := c.Get(ctx, v1alpha1.DashboardResourceName, metav1.GetOptions{})
 	util.AssertEqual(t, err, nil)
-	setDummyVersionLabel(dashboard)
+	setDummyVersionLabel(t, dashboard)
 	_, err = c.Update(ctx, dashboard, metav1.UpdateOptions{})
 	util.AssertEqual(t, err, nil)
 }
 
-func setDummyVersionLabel(td *v1alpha1.TektonDashboard) {
+func setDummyVersionLabel(t *testing.T, td *v1alpha1.TektonDashboard) {
+	t.Helper()
+
 	oprVersion := "v1.2.3"
-	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+	t.Setenv(v1alpha1.VersionEnvKey, oprVersion)
 
 	labels := td.GetLabels()
 	if labels == nil {

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
@@ -18,7 +18,6 @@ package extension
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
@@ -110,14 +109,16 @@ func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonAddonInt
 	// set necessary version labels to make upgrade check pass
 	addon, err := c.Get(ctx, v1alpha1.AddonResourceName, metav1.GetOptions{})
 	util.AssertEqual(t, err, nil)
-	setDummyVersionLabel(addon)
+	setDummyVersionLabel(t, addon)
 	_, err = c.Update(ctx, addon, metav1.UpdateOptions{})
 	util.AssertEqual(t, err, nil)
 }
 
-func setDummyVersionLabel(ta *v1alpha1.TektonAddon) {
+func setDummyVersionLabel(t *testing.T, ta *v1alpha1.TektonAddon) {
+	t.Helper()
+
 	oprVersion := "v1.2.3"
-	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+	t.Setenv(v1alpha1.VersionEnvKey, oprVersion)
 
 	labels := ta.GetLabels()
 	if labels == nil {

--- a/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode_test.go
@@ -18,13 +18,10 @@ package extension
 
 import (
 	"context"
-	"os"
 	"testing"
 
-	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
-	"gotest.tools/v3/assert"
-
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
@@ -38,8 +35,7 @@ func TestEnsureOpenShiftPipelinesAsCodeExists(t *testing.T) {
 	c := fake.Get(ctx)
 	tConfig := pipeline.GetTektonConfig()
 
-	assert.NilError(t, os.Setenv("PLATFORM", "openshift"))
-	defer os.Clearenv()
+	t.Setenv("PLATFORM", "openshift")
 
 	tConfig.SetDefaults(ctx)
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
@@ -71,8 +67,7 @@ func TestEnsureOpenShiftPipelinesAsCodeCRNotExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
 
-	assert.NilError(t, os.Setenv("PLATFORM", "openshift"))
-	defer os.Clearenv()
+	t.Setenv("PLATFORM", "openshift")
 
 	// when no instance exists, nil error is returned immediately
 	err := EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
@@ -18,7 +18,6 @@ package pipeline
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,14 +107,16 @@ func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonPipeline
 	// set necessary version labels to make upgrade check pass
 	pipeline, err := c.Get(ctx, v1alpha1.PipelineResourceName, metav1.GetOptions{})
 	util.AssertEqual(t, err, nil)
-	setDummyVersionLabel(pipeline)
+	setDummyVersionLabel(t, pipeline)
 	_, err = c.Update(ctx, pipeline, metav1.UpdateOptions{})
 	util.AssertEqual(t, err, nil)
 }
 
-func setDummyVersionLabel(tp *v1alpha1.TektonPipeline) {
+func setDummyVersionLabel(t *testing.T, tp *v1alpha1.TektonPipeline) {
+	t.Helper()
+
 	oprVersion := "v1.2.3"
-	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+	t.Setenv(v1alpha1.VersionEnvKey, oprVersion)
 
 	labels := tp.GetLabels()
 	if labels == nil {

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -18,7 +18,6 @@ package trigger
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
@@ -109,14 +108,16 @@ func makeUpgradeCheckPass(t *testing.T, ctx context.Context, c op.TektonTriggerI
 	// set necessary version labels to make upgrade check pass
 	trigger, err := c.Get(ctx, v1alpha1.TriggerResourceName, metav1.GetOptions{})
 	util.AssertEqual(t, err, nil)
-	setDummyVersionLabel(trigger)
+	setDummyVersionLabel(t, trigger)
 	_, err = c.Update(ctx, trigger, metav1.UpdateOptions{})
 	util.AssertEqual(t, err, nil)
 }
 
-func setDummyVersionLabel(tr *v1alpha1.TektonTrigger) {
+func setDummyVersionLabel(t *testing.T, tr *v1alpha1.TektonTrigger) {
+	t.Helper()
+
 	oprVersion := "v1.2.3"
-	os.Setenv(v1alpha1.VersionEnvKey, oprVersion)
+	t.Setenv(v1alpha1.VersionEnvKey, oprVersion)
 
 	labels := tr.GetLabels()
 	if labels == nil {

--- a/pkg/webhook/webhook_init_test.go
+++ b/pkg/webhook/webhook_init_test.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,10 +19,7 @@ func TestCreateWebhookResources(t *testing.T) {
 		testdataPath := filepath.Join("testdata", "validating-defaulting-webhook")
 		m, err := mf.ManifestFrom(mf.Path(testdataPath))
 		assert.NilError(t, err)
-		os.Setenv(POD_NAMESPACE_ENV_KEY, namespace_new)
-		defer func() {
-			os.Unsetenv(POD_NAMESPACE_ENV_KEY)
-		}()
+		t.Setenv(POD_NAMESPACE_ENV_KEY, namespace_new)
 		mOut, err := manifestTransform(&m)
 		assert.NilError(t, err)
 		for _, res := range mOut.Resources() {


### PR DESCRIPTION
# Changes

/kind cleanup

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)

	assert.NoError(t, os.Setenv(key, "new value"))
	defer assert.NoError(t, os.Setenv(key, originalEnv))
	
	// after
	t.Setenv(key, "new value")
}
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
