### PR TITLE
Installerset client: fixes custom set update case

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/update.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/update.go
@@ -32,32 +32,22 @@ import (
 func (i *InstallerSetClient) update(ctx context.Context, comp v1alpha1.TektonComponent, toBeUpdatedIS []v1alpha1.TektonInstallerSet, manifest *mf.Manifest, filterAndTransform FilterAndTransform, isType string) ([]v1alpha1.TektonInstallerSet, error) {
 	logger := logging.FromContext(ctx).With("kind", i.resourceKind, "type", isType)
 
-	switch isType {
-	case InstallerTypeMain:
+	if isType == InstallerTypeMain {
 		sets, err := i.updateMainSets(ctx, comp, toBeUpdatedIS, manifest, filterAndTransform)
 		if err != nil {
 			logger.Errorf("installer set update failed for main type: %v", err)
 			return sets, err
 		}
 		return sets, nil
-
-	case InstallerTypePre, InstallerTypePost:
-		logger.Infof("updating installer set: %v", toBeUpdatedIS[0].GetName())
-		updatedSet, err := i.updateSet(ctx, comp, toBeUpdatedIS[0], manifest, filterAndTransform)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update installerset : %v", err)
-		}
-		logger.Infof("updated installer set: %v", toBeUpdatedIS[0].GetName())
-		return []v1alpha1.TektonInstallerSet{*updatedSet}, nil
-
-	case InstallerTypeCustom:
-	// TODO
-
-	default:
-		return nil, fmt.Errorf("invalid installer set type")
 	}
 
-	return nil, nil
+	logger.Infof("updating installer set: %v", toBeUpdatedIS[0].GetName())
+	updatedSet, err := i.updateSet(ctx, comp, toBeUpdatedIS[0], manifest, filterAndTransform)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update installerset : %v", err)
+	}
+	logger.Infof("updated installer set: %v", toBeUpdatedIS[0].GetName())
+	return []v1alpha1.TektonInstallerSet{*updatedSet}, nil
 }
 
 func (i *InstallerSetClient) updateMainSets(ctx context.Context, comp v1alpha1.TektonComponent, toBeUpdatedIS []v1alpha1.TektonInstallerSet, manifest *mf.Manifest, filterAndTransform FilterAndTransform) ([]v1alpha1.TektonInstallerSet, error) {

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/update_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/update_test.go
@@ -66,6 +66,27 @@ func TestInstallerSetClient_Update(t *testing.T) {
 		wantErr    error
 	}{
 		{
+			name:    "update custom set",
+			setType: InstallerTypeCustom,
+			existingIS: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "addon-custom-set-asdas",
+						Annotations: map[string]string{
+							v1alpha1.LastAppliedHashKey: "custom",
+						},
+					},
+					Spec: v1alpha1.TektonInstallerSetSpec{
+						Manifests: []unstructured.Unstructured{
+							serviceAccount, deployment,
+						},
+					},
+				},
+			},
+			resources: []unstructured.Unstructured{serviceAccount, deployment},
+			wantErr:   nil,
+		},
+		{
 			name:    "update pre set",
 			setType: InstallerTypePre,
 			existingIS: []v1alpha1.TektonInstallerSet{


### PR DESCRIPTION
failed to handle update case for custom installer set so it was returning invalid installer set type.
this fixes that.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
