### PR TITLE
Fix tranformers are getting applied on reconciler resources

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/clustertTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTask.go
@@ -28,8 +28,9 @@ import (
 )
 
 func (r *Reconciler) EnsureClusterTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+	manifest := *r.clusterTaskManifest
 	if enable == "true" {
-		if err := r.installerSetClient.CustomSet(ctx, ta, ClusterTaskInstallerSet, r.clusterTaskManifest, filterAndTransformClusterTask()); err != nil {
+		if err := r.installerSetClient.CustomSet(ctx, ta, ClusterTaskInstallerSet, &manifest, filterAndTransformClusterTask()); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/reconciler/openshift/tektonaddon/clustertTaskVersioned.go
+++ b/pkg/reconciler/openshift/tektonaddon/clustertTaskVersioned.go
@@ -26,8 +26,9 @@ import (
 )
 
 func (r *Reconciler) EnsureVersionedClusterTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+	manifest := *r.clusterTaskManifest
 	if enable == "true" {
-		if err := r.installerSetClient.VersionedClusterTaskSet(ctx, ta, VersionedClusterTaskInstallerSet, r.clusterTaskManifest, filterAndTransformVersionedClusterTask(r.operatorVersion)); err != nil {
+		if err := r.installerSetClient.VersionedClusterTaskSet(ctx, ta, VersionedClusterTaskInstallerSet, &manifest, filterAndTransformVersionedClusterTask(r.operatorVersion)); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
+++ b/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
@@ -41,8 +41,9 @@ func (r *Reconciler) EnsureCommunityClusterTask(ctx context.Context, enable stri
 	if len(r.communityClusterTaskManifest.Resources()) == 0 {
 		return nil
 	}
+	manifest := *r.communityClusterTaskManifest
 	if enable == "true" {
-		if err := r.installerSetClient.CustomSet(ctx, ta, CommunityClusterTaskInstallerSet, r.communityClusterTaskManifest, filterAndTransformCommunityClusterTask()); err != nil {
+		if err := r.installerSetClient.CustomSet(ctx, ta, CommunityClusterTaskInstallerSet, &manifest, filterAndTransformCommunityClusterTask()); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/reconciler/openshift/tektonaddon/consolecli.go
+++ b/pkg/reconciler/openshift/tektonaddon/consolecli.go
@@ -37,10 +37,11 @@ func (r *Reconciler) EnsureConsoleCLI(ctx context.Context, ta *v1alpha1.TektonAd
 	if err != nil {
 		return err
 	}
-	if err := consoleCLITransform(ctx, r.consoleCLIManifest, routeHost); err != nil {
+	manifest := *r.consoleCLIManifest
+	if err := consoleCLITransform(ctx, &manifest, routeHost); err != nil {
 		return err
 	}
-	if err := r.installerSetClient.CustomSet(ctx, ta, ConsoleCLIInstallerSet, r.consoleCLIManifest, filterAndTransformOCPResources()); err != nil {
+	if err := r.installerSetClient.CustomSet(ctx, ta, ConsoleCLIInstallerSet, &manifest, filterAndTransformOCPResources()); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/openshift/tektonaddon/pipelinetemplate.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinetemplate.go
@@ -28,8 +28,9 @@ import (
 )
 
 func (r *Reconciler) EnsurePipelineTemplates(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+	manifest := *r.pipelineTemplateManifest
 	if enable == "true" {
-		if err := r.installerSetClient.CustomSet(ctx, ta, PipelinesTemplateInstallerSet, r.pipelineTemplateManifest, filterAndTransformCommon()); err != nil {
+		if err := r.installerSetClient.CustomSet(ctx, ta, PipelinesTemplateInstallerSet, &manifest, filterAndTransformCommon()); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/reconciler/openshift/tektonaddon/triggers.go
+++ b/pkg/reconciler/openshift/tektonaddon/triggers.go
@@ -25,7 +25,8 @@ import (
 )
 
 func (r *Reconciler) EnsureTriggersResources(ctx context.Context, ta *v1alpha1.TektonAddon) error {
-	if err := r.installerSetClient.CustomSet(ctx, ta, TriggersResourcesInstallerSet, r.triggersResourcesManifest, filterAndTransformCommon()); err != nil {
+	manifest := *r.triggersResourcesManifest
+	if err := r.installerSetClient.CustomSet(ctx, ta, TriggersResourcesInstallerSet, &manifest, filterAndTransformCommon()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Because of the recent refactoring, changes happened in code so tranformer are getting applied on reconciler resources and in every reconcile it is getting applied on tranformed resources which is ending up in issues like version append in name for clustertask is happening again and again in resource like tkn-1-9-0-1-9-0-1-9-0

This fixes the issue to pass copy of reconciler resources in tranformer and installerset creation and not do tranformation on reconciler resources

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix tranformers are getting applied on reconciler resources
```