### PR TITLE
Bump payloads (pipeline -> 0.42) and fix rbac.

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,15 +1,15 @@
 chains:
   github: tektoncd/chains
-  version: v0.13.0
+  version: v0.14.0
 dashboard:
   github: tektoncd/dashboard
-  version: v0.30.0
+  version: v0.31.0
 hub:
   github: tektoncd/hub
   version: v1.11.1
 pipeline:
   github: tektoncd/pipeline
-  version: v0.41.0
+  version: v0.42.0
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code
   version: v0.15.0

--- a/config/base/role.yaml
+++ b/config/base/role.yaml
@@ -238,6 +238,9 @@ rules:
   - runs
   - runs/status
   - runs/finalizers
+  - customruns
+  - customruns/status
+  - customruns/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION

# Changes

There is new CRDs in Pipeline (CustomRun), and the operator need to
have the rights on it to be able to create the pipeline payload.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Bump tektoncd/pipeline to 0.42.0, tektoncd/chains to v0.14.0 and tektoncd/dashboard to v0.31.0.
```

