### PR TITLE
PAC: fixes service monitor target namespace

### DIFF
--- a/pkg/reconciler/openshift/common/testdata/test-inject-ns-in-servicemonitor-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-inject-ns-in-servicemonitor-expected.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pipelines-as-code-monitor
+  namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "v0.15.0"
+    app.kubernetes.io/part-of: pipelines-as-code
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+spec:
+  endpoints:
+    - interval: 10s
+      port: http-metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - its-me-ns
+  selector:
+    matchLabels:
+      app: pipelines-as-code-watcher

--- a/pkg/reconciler/openshift/common/testdata/test-inject-ns-in-servicemonitor.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-inject-ns-in-servicemonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pipelines-as-code-monitor
+  namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "v0.15.0"
+    app.kubernetes.io/part-of: pipelines-as-code
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+spec:
+  endpoints:
+    - interval: 10s
+      port: http-metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - pipelines-as-code
+  selector:
+    matchLabels:
+      app: pipelines-as-code-watcher

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -170,3 +170,17 @@ func RemoveFsGroupForJob() mf.Transformer {
 		return nil
 	}
 }
+
+func UpdateServiceMonitorTargetNamespace(targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "ServiceMonitor" {
+			return nil
+		}
+		nsSelector, found, err := unstructured.NestedFieldNoCopy(u.Object, "spec", "namespaceSelector")
+		if !found || err != nil {
+			return err
+		}
+		nsSelector.(map[string]interface{})["matchNames"].([]interface{})[0] = targetNamespace
+		return nil
+	}
+}

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -147,3 +147,21 @@ func TestRemoveFsGroup(t *testing.T) {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
 	}
 }
+
+func TestUpdateServiceMonitorTargetNamespace(t *testing.T) {
+	targetNs := "its-me-ns"
+	testData := path.Join("testdata", "test-inject-ns-in-servicemonitor.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	updatedManifest, err := manifest.Transform(UpdateServiceMonitorTargetNamespace(targetNs))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-inject-ns-in-servicemonitor-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	if d := cmp.Diff(updatedManifest.Resources()[0], expectedManifest.Resources()[0]); d != "" {
+		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
+	}
+}

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -46,6 +46,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.ApplyProxySettings,
 			occommon.ApplyCABundles,
 			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
+			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
 		}
 
 		allTfs := append(tfs, extension.Transformers(pac)...)


### PR DESCRIPTION
this adds a transformer to replace the target namespace for pac service monitor.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
