### PR TITLE
Fix RBAC

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -414,6 +414,7 @@ rules:
 - apiGroups:
     - extensions
     - apps
+    - networking.k8s.io
   resources:
     - ingresses
     - ingresses/status
@@ -610,6 +611,9 @@ rules:
     - runs
     - runs/status
     - runs/finalizers
+    - customruns
+    - customruns/status
+    - customruns/finalizers
   verbs:
     - get
     - list
@@ -712,6 +716,7 @@ rules:
     - batch
   resources:
     - cronjobs
+    - jobs
   verbs:
     - delete
     - create
@@ -759,18 +764,18 @@ rules:
     - update
     - watch
 - apiGroups:
-  - resolution.tekton.dev
+    - resolution.tekton.dev
   resources:
-  - resolutionrequests
-  - resolutionrequests/status
+    - resolutionrequests
+    - resolutionrequests/status
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - update
-  - patch
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
 {{- end }}
 
 ---


### PR DESCRIPTION
# Changes

Add RBAC found in official operator release.yaml not found when using the operator's helm chart.

Missing RBAC prevents the proper Service Accounts from being created and may cause other issues.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Helm chart now includes additional permissions to mirror release.yaml.
```
