### PR TITLE
Bump dashboard to 0.32.0 and fix release url

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,7 +3,7 @@ chains:
   version: v0.14.0
 dashboard:
   github: tektoncd/dashboard
-  version: v0.31.0
+  version: v0.32.0
 hub:
   github: tektoncd/hub
   version: v1.11.2

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -22,11 +22,11 @@ release_yaml() {
     fi
 
     if [[ $comp == "dashboard" ]]; then
-      if [[ ${releaseFileName} == "tekton-dashboard-release" ]]; then
+      if [[ ${releaseFileName} == "release-full" ]]; then
         dir="dashboard/tekton-dashboard-fullaccess"
       fi
 
-      if [[ ${releaseFileName} == "tekton-dashboard-release-readonly" ]]; then
+      if [[ ${releaseFileName} == "release" ]]; then
         dir="dashboard/tekton-dashboard-readonly"
       fi
     fi
@@ -251,8 +251,8 @@ main() {
   if [[ ${TARGET} != "openshift" ]]; then
     d_version=$(${OPERATORTOOL} -config ${CONFIG} component-version dashboard)
     # get release YAML for Dashboard
-    release_yaml dashboard tekton-dashboard-release 00-dashboard ${d_version}
-    release_yaml dashboard tekton-dashboard-release-readonly 00-dashboard ${d_version}
+    release_yaml dashboard release-full 00-dashboard ${d_version}
+    release_yaml dashboard release 00-dashboard ${d_version}
 
     r_version=$(${OPERATORTOOL} -config ${CONFIG} component-version results)
     # get release YAML for Results


### PR DESCRIPTION

# Changes

The URL for fetching the released payload for the operator changed
starting with 0.32.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Updating dasbhoard to v0.32.0
```

