### PR TITLE
add development environment support to podman runtime

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,22 +9,32 @@
 
 ## Getting started
 
-1. [Ramp up on kubernetes and CRDs](#ramp-up-on-crds)
-1. [Ramp Tekton Pipelines](#ramp-up-on-tekton-pipelines)
-1. Create [a GitHub account](https://github.com/join)
-1. Setup
-   [GitHub access via SSH](https://help.github.com/articles/connecting-to-github-with-ssh/)
-1. [Create and checkout a repo fork](#checkout-your-fork)
-1. Set up your [shell environment](#environment-setup)
-1. Install [requirements](#requirements)
-1. [Set up a Kubernetes cluster](#kubernetes-cluster)
-1. [Configure kubectl to use your cluster](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-1. [Set up a docker repository you can push to](https://github.com/knative/serving/blob/master/docs/setting-up-a-docker-registry.md)
-1. [Install Tekton Operator](#install-operator)
-1. [Iterate!](#iterating)
-1. [Running Codegen](#running-codegen)
-1. [Running Operator](#running-operator-development)
-1. [Running Tests](#running-tests)
+- [Development Guide](#development-guide)
+  - [Development Prerequisites](#development-prerequisites)
+  - [Getting started](#getting-started)
+    - [Ramp up](#ramp-up)
+      - [Ramp up on CRDs](#ramp-up-on-crds)
+      - [Ramp up on Tekton Pipelines](#ramp-up-on-tekton-pipelines)
+      - [Ramp up on Kubernetes Operators](#ramp-up-on-kubernetes-operators)
+    - [Checkout your fork](#checkout-your-fork)
+    - [Requirements](#requirements)
+  - [Kubernetes cluster](#kubernetes-cluster)
+  - [Environment Setup](#environment-setup)
+  - [Iterating](#iterating)
+    - [Install Operator](#install-operator)
+  - [Accessing logs](#accessing-logs)
+  - [Updating the clustertasks in OpenShift addons](#updating-the-clustertasks-in-openshift-addons)
+  - [Running Codegen](#running-codegen)
+  - [Setup development environment on localhost](#setup-development-environment-on-localhost)
+    - [Pre-requests](#pre-requests)
+    - [setup with docker runtime](#setup-with-docker-runtime)
+    - [setup with podman runtime](#setup-with-podman-runtime)
+  - [Running Operator (Development)](#running-operator-development)
+    - [Reset (Clean) Cluster](#reset-clean-cluster)
+    - [Setup](#setup)
+    - [Run operator](#run-operator)
+    - [Install Tekton components](#install-tekton-components)
+  - [Running Tests](#running-tests)
 
 ### Ramp up
 
@@ -214,6 +224,40 @@ If the files in `pkg/apis` are updated we need to run `codegen` scripts
 ```shell script
 ./hack/update-codegen.sh
 ```
+
+## Setup development environment on localhost
+Here are the steps to setup development environment on your localhost with local registry
+
+### Pre-requests
+   - either `docker` or `podman` runtime
+   - [kind](https://github.com/kubernetes-sigs/kind)
+
+### setup with docker runtime
+```bash
+export KO_DOCKER_REPO="localhost:5000"
+
+make dev-setup
+```
+kubernetes cluster ports used
+* `8443` - cluster api access
+* `80` - ingress http
+* `443` - ingress https
+
+### setup with podman runtime
+`podman` is a daemonless container engine. You have to setup a socket service on user space.
+```bash
+$ export KO_DOCKER_REPO="localhost:5000"
+$ export CONTAINER_RUNTIME=podman
+$ systemctl --user start podman.socket
+$ export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+
+$ make dev-setup
+```
+kubernetes cluster ports used
+* `8443` - cluster api access
+* `7080` - ingress http
+* `7443` - ingress https
+
 
 ## Running Operator (Development)
 

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ lint-yaml: ${YAML_FILES} ## runs yamllint on all yaml files
 	@yamllint -c .yamllint $(YAML_FILES)
 
 
-# Prerequisite: docker and kind
+# Prerequisite: docker [or] podman and kind
 # this will deploy a local registry using docker and create a kind cluster
 # configuring with the registry
 # then does make apply to deploy the operator

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -3,6 +3,7 @@
 set -euf
 cd $(dirname $(readlink -f ${0}))
 
+export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind}
 export KUBECONFIG=${HOME}/.kube/config.${KIND_CLUSTER_NAME}
 export TARGET=kubernetes
@@ -14,32 +15,48 @@ TMPD=$(mktemp -d /tmp/.GITXXXX)
 REG_PORT='5000'
 REG_NAME='kind-registry'
 SUDO=sudo
+HOST_HTTP_PORT=80
+HOST_HTTPS_PORT=443
 
 [[ $(uname -s) == "Darwin" ]] && {
     SUDO=
 }
+
+CONTAINER_RUNTIME_ARGS=""
+CONTAINER_RUNTIME_CONFIG="${HOME}/.docker/config.json"
+if [ "$CONTAINER_RUNTIME" = "podman" ]; then
+    SUDO=
+    # https://github.com/containers/podman/issues/15664
+    CONTAINER_RUNTIME_ARGS="--net=kind"
+    CONTAINER_RUNTIME_CONFIG="${XDG_RUNTIME_DIR}/containers/auth.json"
+    HOST_HTTP_PORT=7080
+    HOST_HTTPS_PORT=7443
+fi
 
 # cleanup on exit (useful for running locally)
 cleanup() { rm -rf ${TMPD} ;}
 trap cleanup EXIT
 
 function start_registry() {
-    running="$(docker inspect -f '{{.State.Running}}' ${REG_NAME} 2>/dev/null || echo false)"
+    running="$(${CONTAINER_RUNTIME} inspect -f '{{.State.Running}}' ${REG_NAME} 2>/dev/null || echo false)"
 
     if [[ ${running} != "true" ]];then
-        docker rm -f kind-registry || true
-        docker run \
-               -d --restart=always -p "127.0.0.1:${REG_PORT}:5000" \
-               --name "${REG_NAME}" \
-               registry:2
+        ${CONTAINER_RUNTIME} rm -f kind-registry || true
+        ${CONTAINER_RUNTIME} run \
+            ${CONTAINER_RUNTIME_ARGS} \
+            -d --restart=always -p "127.0.0.1:${REG_PORT}:5000" \
+            --name "${REG_NAME}" \
+            registry:2
     fi
 }
 
 function reinstall_kind() {
 	${SUDO} $kind delete cluster --name ${KIND_CLUSTER_NAME} || true
-	sed "s,%DOCKERCFG%,${HOME}/.docker/config.json,"  kind.yaml > ${TMPD}/kconfig.yaml
+  sed "s,_DOCKERCFG_,${CONTAINER_RUNTIME_CONFIG},"  kind.yaml > ${TMPD}/kconfig.yaml
+  sed -i "s,_HOST_HTTP_PORT_,${HOST_HTTP_PORT}," ${TMPD}/kconfig.yaml
+  sed -i "s,_HOST_HTTPS_PORT_,${HOST_HTTPS_PORT}," ${TMPD}/kconfig.yaml
 
-       cat <<EOF >> ${TMPD}/kconfig.yaml
+  cat <<EOF >> ${TMPD}/kconfig.yaml
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REG_PORT}"]
@@ -50,9 +67,11 @@ EOF
 	mkdir -p $(dirname ${KUBECONFIG})
 	${SUDO} ${kind} --name ${KIND_CLUSTER_NAME} get kubeconfig > ${KUBECONFIG}
 
-
-    docker network connect "kind" "${REG_NAME}" 2>/dev/null || true
-    cat <<EOF | kubectl apply -f -
+  # https://github.com/containers/podman/issues/15664
+  if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    ${CONTAINER_RUNTIME} network connect "kind" "${REG_NAME}" 2>/dev/null || true
+  fi
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/hack/dev/kind/kind.yaml
+++ b/hack/dev/kind/kind.yaml
@@ -13,11 +13,11 @@ nodes:
         node-labels: "ingress-ready=true"
   extraMounts:
     - containerPath: /var/lib/kubelet/config.json
-      hostPath: "%DOCKERCFG%"
+      hostPath: "_DOCKERCFG_"
   extraPortMappings:
   - containerPort: 80
-    hostPort: 80
+    hostPort: _HOST_HTTP_PORT_
     protocol: TCP
   - containerPort: 443
-    hostPort: 443
+    hostPort: _HOST_HTTPS_PORT_
     protocol: TCP


### PR DESCRIPTION
Signed-off-by: Jeeva Kandasamy <jkandasa@redhat.com>

# Changes
This PR adds `podman` engine support to local development environment

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
