### PR TITLE
fix proxy update reconcile issue

### DIFF
--- a/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
+++ b/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
@@ -389,7 +389,6 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	chainImages := common.ToLowerCaseKeys(common.ImagesFromEnv(common.ChainsImagePrefix))
 	extra := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdChains),
-		common.ApplyProxySettings,
 		common.DeploymentImages(chainImages),
 		common.AddConfiguration(instance.Spec.Config),
 		common.AddConfigMapValues(ChainsConfig, instance.Spec.Chain),

--- a/pkg/reconciler/kubernetes/tektondashboard/transform.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/transform.go
@@ -35,7 +35,6 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		trns := extension.Transformers(dashboard)
 		extra := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdDashboard),
-			common.ApplyProxySettings,
 			common.AddConfiguration(dashboard.Spec.Config),
 			common.AddDeploymentRestrictedPSA(),
 		}

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -51,7 +51,6 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfigMapValues(ConfigDefaults, pipeline.Spec.OptionalPipelineProperties),
 			common.AddConfigMapValues(ConfigMetrics, pipeline.Spec.PipelineMetricsProperties),
 			common.AddConfigMapValues(ResolverFeatureFlag, pipeline.Spec.Resolvers),
-			common.ApplyProxySettings,
 			common.DeploymentImages(images),
 			common.InjectLabelOnNamespace(proxyLabel),
 			common.AddConfiguration(pipeline.Spec.Config),

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -308,7 +308,6 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	targetNs := comp.GetSpec().GetTargetNamespace()
 	extra := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdPipeline),
-		common.ApplyProxySettings,
 		common.ReplaceNamespaceInDeploymentArgs(targetNs),
 		common.ReplaceNamespaceInDeploymentEnv(targetNs),
 		common.AddDeploymentRestrictedPSA(),

--- a/pkg/reconciler/kubernetes/tektontrigger/transform.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/transform.go
@@ -42,7 +42,6 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdTriggers),
 			common.AddConfigMapValues(ConfigDefaults, trigger.Spec.OptionalTriggersProperties),
 			common.AddConfigMapValues(FeatureFlag, trigger.Spec.TriggersProperties),
-			common.ApplyProxySettings,
 			common.DeploymentImages(triggerImages),
 			common.AddConfiguration(trigger.Spec.Config),
 		}

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -43,7 +43,6 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.InjectOperandNameLabelOverwriteExisting(openshift.OperandOpenShiftPipelineAsCode),
 			common.DeploymentImages(images),
 			common.AddConfiguration(pac.Spec.Config),
-			common.ApplyProxySettings,
 			occommon.ApplyCABundles,
 			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),


### PR DESCRIPTION
Signed-off-by: Jeeva Kandasamy <jkandasa@redhat.com>

# Changes
* Adding a `operator.tekton.dev/proxy-aware=true` annotation in `TektonInstallerSet` deployment manifest from `tekton-operator-lifecycle` container
* Updating proxy settings in deployment containers environment on reconcile time of `TektonInstallerSet` from `tekton-operator-cluster-operations` container, if  `operator.tekton.dev/proxy-aware` annotation set to `true`
* fixes: [SRVKP-2282](https://issues.redhat.com/browse/SRVKP-2282)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```
