### PR TITLE
Add HA and deployment override configuration

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -156,6 +156,49 @@ type Config struct {
 	// PriorityClassName holds the priority class to be set to pod template
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// HighAvailability allows specification of HA control plane.
+	// +optional
+	HighAvailability HighAvailability `json:"highAvailability,omitempty"`
+	// DeploymentOverride overrides Deployment configurations such as resource.
+	// +optional
+	DeploymentOverride []DeploymentOverride `json:"deployments,omitempty"`
+}
+
+// HighAvailability specifies options for deploying Tekton Pipeline Deployment
+type HighAvailability struct {
+	// Replicas is the number of replicas that HA parts of the control plane
+	// will be scaled to.
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
+// DeploymentOverride specifies resource override for deployment
+type DeploymentOverride struct {
+	// Name is the name of the deployment to override.
+	Name string `json:"name"`
+	// Resources overrides resources for the containers.
+	// +optional
+	Containers []ContainerOverride `json:"containers,omitempty"`
+	// Replicas is the number of replicas that this deployment will scaled to.
+	// It has a higher priority than HighAvailability.Replicas
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
+// ContainerOverride enables the user to override any container's
+// configuration specified in the embedded manifest
+type ContainerOverride struct {
+	// Name represent container name
+	Name string `json:"name"`
+	// Resource represent the desired ResourceRequirements
+	// +optional
+	Resource corev1.ResourceRequirements `json:"resource,omitempty"`
+	// Env represent the env that will replace the existing one or append if not existed
+	// +optional
+	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Args represent the args will append to the existing args
+	// +optional
+	Args []string `json:"args,omitempty"`
 }
 
 type Platforms struct {

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -29,6 +29,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -512,6 +514,109 @@ func TestAddConfiguration(t *testing.T) {
 	assert.Equal(t, d.Spec.Template.Spec.NodeSelector["foo"], config.NodeSelector["foo"])
 	assert.Equal(t, d.Spec.Template.Spec.Tolerations[0].Key, config.Tolerations[0].Key)
 	assert.Equal(t, d.Spec.Template.Spec.PriorityClassName, config.PriorityClassName)
+}
+
+func TestHighAvailabilityDeploymentResourceTransform(t *testing.T) {
+
+	testData := path.Join("testdata", "test-add-configurations.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assertNoEror(t, err)
+
+	replicasNum := int32(3)
+	containerOverride := []v1alpha1.ContainerOverride{
+		{
+			Name: "controller-deployment",
+			Env: []corev1.EnvVar{
+				{
+					Name:  "KUBERNETES_MIN_VERSION",
+					Value: "v1.23.0",
+				},
+			},
+			Args: []string{
+				"-kube-api-qps", "50",
+			},
+			Resource: corev1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("2"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("4"),
+				},
+			},
+		},
+	}
+
+	config := v1alpha1.Config{
+		HighAvailability: v1alpha1.HighAvailability{
+			Replicas: &replicasNum,
+		},
+		DeploymentOverride: []v1alpha1.DeploymentOverride{
+			{
+				Name:       "controller",
+				Containers: containerOverride,
+			},
+		},
+	}
+
+	manifest, err = manifest.Transform(HighAvailabilityTransform(config.HighAvailability))
+	assertNoEror(t, err)
+	manifest, err = manifest.Transform(DeploymentOverrideTransform(config.DeploymentOverride))
+	assertNoEror(t, err)
+
+	d := &v1beta1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
+	assertNoEror(t, err)
+
+	assert.Equal(t, *d.Spec.Replicas, int32(replicasNum))
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU], resource.MustParse("1"))
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU], resource.MustParse("2"))
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory], resource.MustParse("2"))
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory], resource.MustParse("4"))
+
+	assert.Equal(t, len(d.Spec.Template.Spec.Containers[0].Args), 5)
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Args[3], "-kube-api-qps")
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Args[4], "50")
+
+	assert.Equal(t, d.Spec.Template.Spec.Containers[0].Env[0], corev1.EnvVar{
+		Name:  "KUBERNETES_MIN_VERSION",
+		Value: "v1.23.0",
+	})
+}
+
+func TestDeploymentReplicasOverrideTransform(t *testing.T) {
+
+	testData := path.Join("testdata", "test-add-configurations.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assertNoEror(t, err)
+
+	HAreplicas := int32(3)
+	overReplicas := int32(2)
+
+	config := v1alpha1.Config{
+		HighAvailability: v1alpha1.HighAvailability{
+			Replicas: &HAreplicas,
+		},
+		DeploymentOverride: []v1alpha1.DeploymentOverride{
+			{
+				Name:     "controller",
+				Replicas: &overReplicas,
+			},
+		},
+	}
+
+	manifest, err = manifest.Transform(HighAvailabilityTransform(config.HighAvailability))
+	assertNoEror(t, err)
+	manifest, err = manifest.Transform(DeploymentOverrideTransform(config.DeploymentOverride))
+	assertNoEror(t, err)
+
+	d := &v1beta1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
+	assertNoEror(t, err)
+
+	assert.Equal(t, *d.Spec.Replicas, overReplicas)
+
 }
 
 func TestAddPSA(t *testing.T) {

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -57,6 +57,8 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.DeploymentImages(images),
 			common.InjectLabelOnNamespace(proxyLabel),
 			common.AddConfiguration(pipeline.Spec.Config),
+			common.HighAvailabilityTransform(pipeline.Spec.Config.HighAvailability),
+			common.DeploymentOverrideTransform(pipeline.Spec.Config.DeploymentOverride),
 			common.CopyConfigMap(bundleResolverConfig, pipeline.Spec.BundlesResolverConfig),
 			common.CopyConfigMap(hubResolverConfig, pipeline.Spec.HubResolverConfig),
 			common.CopyConfigMap(clusterResolverConfig, pipeline.Spec.ClusterResolverConfig),


### PR DESCRIPTION
Add HA configuration replicas for tektonPipeline.

Add deploymet override configuration for tektonPipeline components for example resource env and args override.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
