### PR TITLE
update runAsUser to postgres StatefulSet and unskip tektonResult e2e tests

### DIFF
--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -37,7 +37,6 @@ import (
 
 // TestTektonResultDeployment verifies the TektonResult creation, deployment recreation, and TektonResult deletion.
 func TestTektonResultDeployment(t *testing.T) {
-	t.Skip()
 	platform := os.Getenv("PLATFORM")
 	if platform == "linux/ppc64le" || platform == "linux/s390x" {
 		t.Skipf("Tekton Result is not available for %q", platform)


### PR DESCRIPTION
# Changes
* fixes https://github.com/tektoncd/operator/issues/1148
* updates the `runAsUser` to `postgres` `StatefulSet`
* enables `TektonResult` e2e tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

