### PR TITLE
[Openshift] Add generic template to pipelines-as-code-templates configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ ifeq ($(TARGET), openshift)
 	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/java.yaml
 	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/nodejs.yaml
 	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/python.yaml
+	rm -rf ./cmd/openshift/operator/kodata/tekton-addon/pipelines-as-code-templates/generic.yaml
 else
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton*
 endif

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -149,7 +149,7 @@ release_yaml_pac() {
          echo ""
      fi
 
-    runtime=( go java nodejs python )
+    runtime=( go java nodejs python generic )
     for run in "${runtime[@]}"
     do
       echo "fetching PipelineRun template for runtime: $run"


### PR DESCRIPTION
# Changes

Currently Openshift Console UI have hardcoded PipelineRun template as a fallback template if a template for runtime (go, java, python, nodejs) is not found in the **Openshift** namespace.

The ask from console team is It would be nice if a default PipelineRun template(Generic) should be provided in a ConfigMap `pipelines-as-code-template-default` by the OSP operator so that console can rely on that instead of hardcoded PipelineRun template.

Fixes : https://issues.redhat.com/browse/SRVKP-2859




<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
