### PR TITLE
add make cmd to generate alm-examples in csv

### DIFF
--- a/alm-examples/pipeline.yaml
+++ b/alm-examples/pipeline.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonPipeline
+metadata:
+  name: pipeline
+spec:
+  targetNamespace: operators
+  config:
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+    nodeSelector:
+        kubernetes.io/os: linux

--- a/operatorhub/kubernetes/manifests/bases/tektoncd-operator.clusterserviceversion.template.yaml
+++ b/operatorhub/kubernetes/manifests/bases/tektoncd-operator.clusterserviceversion.template.yaml
@@ -2,7 +2,9 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    # NOTE: Please do not manually modify the alm-examples annotation, you should modify the alm-examples/*yaml file
+    alm-examples: |-
+      '[]'
     capabilities: Basic Install
     categories: Developer Tools, Integration & Delivery
     certified: "false"


### PR DESCRIPTION
# Changes

add make cmd to generate csv annotations.alm-examples of kubernetes base manifestes

# Release Notes
```release-note
NONE
```
