### PR TITLE
dependabot: do not update k8s.io/* major/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
@@ -12,3 +11,8 @@ updates:
     labels:
     - "ok-to-test"
     - "dependencies"
+    - "kind/misc"
+    - "release-note-none"
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
# Changes

This makes dependabot ignore major and minor updates to k8s.io/* modules. It will still update patch release though (0.25.1 to 0.25.2).

The reason to ignore those (major/minor) is because they are usually tied to `knative/pkg` and this means, we usually only want to update those *when* `knative/pkg` dependencies are updated as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
