### PR TITLE
Ensure operator always sets targetNamespace label

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -251,10 +251,9 @@ func (r *Reconciler) addTargetNamespaceLabel(ctx context.Context, targetNamespac
 	}
 	labels := ns.GetLabels()
 	if labels == nil {
-		labels = map[string]string{
-			"operator.tekton.dev/targetNamespace": "true",
-		}
+		labels = map[string]string{}
 	}
+	labels["operator.tekton.dev/targetNamespace"] = "true"
 	ns.SetLabels(labels)
 	_, err = r.kubeClientSet.CoreV1().Namespaces().Update(ctx, ns, v1.UpdateOptions{})
 	return err


### PR DESCRIPTION
# Changes

Previously, the Tekton operator only set the "targetNamespace" label *if the list of labels was empty* (nil).
This patch adjusts the behavior so the "targetNamespace" label is always set, also when the the initial list is not empty.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [x] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

