### PR TITLE
remove pruner container user and fsGroup ids in OpenShift platform

### DIFF
--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -33,6 +33,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -362,8 +363,15 @@ func createCronJob(ctx context.Context, kc kubernetes.Interface, cronName, targe
 	backOffLimit := int32(3)
 	ttlSecondsAfterFinished := int32(3600)
 	runAsNonRoot := true
-	runAsUser := int64(65532)
-	fsGroup := int64(65532)
+	runAsUser := ptr.Int64(65532)
+	fsGroup := ptr.Int64(65532)
+
+	// if it is a openshift platform remove the user and fsGroup ids
+	// those ids will be allocated dynamically
+	if v1alpha1.IsOpenShiftPlatform() {
+		runAsUser = nil
+		fsGroup = nil
+	}
 
 	cj := &batchv1.CronJob{
 		TypeMeta: v1.TypeMeta{
@@ -397,8 +405,8 @@ func createCronJob(ctx context.Context, kc kubernetes.Interface, cronName, targe
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},
-								RunAsUser: &runAsUser,
-								FSGroup:   &fsGroup,
+								RunAsUser: runAsUser,
+								FSGroup:   fsGroup,
 							},
 						},
 					},


### PR DESCRIPTION
# Changes

* Fixes [SRVKP-2963](https://issues.redhat.com/browse/SRVKP-2963)

failed to created a pruner pod in OpenShift environment with the following error,
```
Error creating: pods "tekton-resource-pruner-xs478-28001280-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider "pipelines-scc": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{65532}: 65532 is not an allowed group, spec.containers[0].securityContext.runAsUser: Invalid value: 65532: must be in the ranges: [1000680000, 1000689999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, pod.metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]: Forbidden: seccomp may not be set, pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/pruner-tkn-openshift-pipelines-7hkvk]: Forbidden: seccomp may not be set, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount] 
```

version:
```
tkn version                                                           
Client version: 0.30.0
Pipeline version: v0.44.0
Triggers version: v0.23.0
Operator version: v0.65.1
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```