### PR TITLE
Set "disable-ha=true" because HA is not enabled.

### DIFF
--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -195,7 +195,7 @@ func MainWithContext(ctx context.Context, component string, ctors ...injection.C
 	}
 
 	// TODO(mattmoor): Remove this once HA is stable.
-	disableHighAvailability := flag.Bool("disable-ha", false,
+	disableHighAvailability := flag.Bool("disable-ha", true,
 		"Whether to disable high-availability functionality for this component.  This flag will be deprecated "+
 			"and removed when we have promoted this feature to stable, so do not pass it without filing an "+
 			"issue upstream!")


### PR DESCRIPTION
HA tekton is not yet enabled, no need to enable it, now.  

The default has been incorrectly set to "false," i.e., it's _enabling_ HA. This is impacting customer pipelines.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
