### PR TITLE
revert pruner keep and keep-since simultaneous support

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -74,6 +74,14 @@ func (p Prune) validate() *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("spec.pruner.resources"))
 	}
 
+	// tkn cli supports both "keep" and "keep-since", even though there is an issue with the logic
+	// when we supply both "keep" and "keep-since", the outcome always equivalent to "keep", "keep-since" ignored
+	// hence we strict with a single flag support until the issue is fixed in tkn cli
+	// cli issue: https://github.com/tektoncd/cli/issues/1990
+	if p.Keep != nil && p.KeepSince != nil {
+		errs = errs.Also(apis.ErrMultipleOneOf("spec.pruner.keep", "spec.pruner.keep-since"))
+	}
+
 	if p.Keep == nil && p.KeepSince == nil {
 		errs = errs.Also(apis.ErrMissingOneOf("spec.pruner.keep", "spec.pruner.keep-since"))
 	}


### PR DESCRIPTION
# Changes
tkn cli supports both "keep" and "keep-since", even though there is an issue with the logic
when we supply both "keep" and "keep-since",  the outcome always equivalent to "keep", "keep-since" ignored
hence we strict with a single flag support until the issue is fixed in tkn cli
cli issue: https://github.com/tektoncd/cli/issues/1990

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
