### PR TITLE
allow to disable global pruner job and completely disable pruner feature

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -51,6 +51,7 @@ The TektonConfig CR provides the following features
       require-git-ssh-secret-known-hosts: false
       running-in-environment-with-injected-sidecars: true
     pruner:
+      disabled: false
       resources:
       - taskrun
       - pipelinerun
@@ -142,6 +143,7 @@ Pruner provides auto clean up feature for the Tekton resources.
 Example:
 ```yaml
 pruner:
+  disabled: false
   resources:
     - taskrun
     - pipelinerun
@@ -149,14 +151,31 @@ pruner:
   keep-since: 1440
   schedule: "* * * * *"
 ```
+- `disabled` : if the value set as `true`, pruner feature will be disabled (default: `false`)
 - `prune-per-resource`: if the value set as `true` (default value `false`), the `keep` and `keep-since` applied to each resource. example: `tkn pipelinerun delete --pipeline=my-pipeline --keep=10`
 - `resources`: supported resources for auto prune are `taskrun` and `pipelinerun`
 - `keep`: maximum number of resources to keep while deleting or removing resources
 - `keep-since`: retain the resources younger than the specified value in minutes
 - `schedule`: how often to clean up resources. User can understand the schedule syntax [here][schedule].
 
-This is an `Optional` section.
+> ### Note:
+> if `disabled: false` and `schedule: ` with empty value, global pruner job will be disabled.
+> however, if there is a prune schedule (`operator.tekton.dev/prune.schedule`) annotation present with a value in a namespace. a namespace wide pruner jobs will be created
 
+#### Pruner Namespace annotations
+By default pruner job will be created from the global pruner config (`spec.pruner`), though user can customize a pruner config to a specific namespace with the following annotations. If some of the annotations are not present or has invalid value, for that value, falls back to global value or skipped the namespace.
+- `operator.tekton.dev/prune.skip` - pruner job will be skipped to a namespace, if the value set as `true`
+- `operator.tekton.dev/prune.schedule` - pruner job will be created on a specific schedule
+- `operator.tekton.dev/prune.keep` - maximum number of resources will be kept
+- `operator.tekton.dev/prune.keep-since` - retain the resources younger than the specified value in minutes
+- `operator.tekton.dev/prune.prune-per-resource` - the `keep` and `keep-since` applied to each resource
+- `operator.tekton.dev/prune.resources` - can be `taskrun` and/or `pipelinerun`, both value can be specified with comma separated. example: `taskrun,pipelinerun`
+- `operator.tekton.dev/prune.strategy` - allowed values: either `keep` or `keep-since`
+
+> ### Note: 
+> if a global value is not present the following values will be consider as default value <br> 
+> `resources: pipelinerun` <br>
+> `keep: 100` <br>
 ### Addon
 
 TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few ClusterTasks, PipelineTemplates.

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -54,6 +54,10 @@ const (
 	Reinstalling   = "reinstalling"
 
 	RequeueDelay = 10 * time.Second
+
+	// pruner default schedule, used in auto generate tektonConfig
+	PrunerDefaultSchedule = "0 8 * * *"
+	PrunerDefaultKeep     = uint(100)
 )
 
 var (
@@ -87,6 +91,11 @@ var (
 
 	PruningResource = []string{
 		"taskrun",
+		"pipelinerun",
+	}
+
+	// pruner default resource, used in auto generate tektonConfig
+	PruningDefaultResources = []string{
 		"pipelinerun",
 	}
 

--- a/pkg/apis/operator/v1alpha1/tektonconfig_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"strings"
 
 	"knative.dev/pkg/ptr"
 )
@@ -59,19 +60,28 @@ func (tc *TektonConfig) SetDefaults(ctx context.Context) {
 		tc.Spec.Platforms.OpenShift = OpenShift{}
 	}
 
-	// before adding webhook we had default value for pruner's keep as 1
-	// but we expect user to define all values now otherwise webhook reject
-	// request so if a user has installed prev version and has not enabled
-	// pruner then `keep` will have a value 1 and after upgrading
-	// to newer version webhook will fail if keep has a value and
-	// other fields are not defined
-	// this handles that case by removing the default for keep if
-	// other pruner fields are not defined
-	if len(tc.Spec.Pruner.Resources) == 0 {
-		tc.Spec.Pruner.Keep = nil
-		tc.Spec.Pruner.Schedule = ""
-	} else if tc.Spec.Pruner.Schedule == "" {
-		tc.Spec.Pruner.Keep = nil
-		tc.Spec.Pruner.Resources = []string{}
+	// earlier pruner was disabled with empty schedule or empty resources
+	// now empty schedule, disables only the global cron job,
+	// if a namespace has prune schedule annotation, a cron job will be created for that
+	// to disable the pruner feature, "disabled" should be set as "true"
+	if !tc.Spec.Pruner.Disabled {
+		// if keep and keep-since is nil, update default keep value
+		if tc.Spec.Pruner.Keep == nil && tc.Spec.Pruner.KeepSince == nil {
+			keep := PrunerDefaultKeep
+			tc.Spec.Pruner.Keep = &keep
+		}
+
+		// if empty resources, update default resources
+		if len(tc.Spec.Pruner.Resources) == 0 {
+			tc.Spec.Pruner.Resources = PruningDefaultResources
+		}
+
+		// trim space and to lower case resource names
+		for index := range tc.Spec.Pruner.Resources {
+			value := tc.Spec.Pruner.Resources[index]
+			value = strings.TrimSpace(value)
+			value = strings.ToLower(value)
+			tc.Spec.Pruner.Resources[index] = value
+		}
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -49,6 +49,8 @@ func (tp *TektonConfig) GetStatus() TektonComponentStatus {
 
 // Prune defines the pruner
 type Prune struct {
+	// enable or disable pruner feature
+	Disabled bool `json:"disabled"`
 	// apply the prune job to the individual resources
 	// +optional
 	PrunePerResource bool `json:"prune-per-resource,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -44,9 +44,8 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
-	if !tc.Spec.Pruner.IsEmpty() {
-		errs = errs.Also(tc.Spec.Pruner.validate())
-	}
+	// validate pruner specifications
+	errs = errs.Also(tc.Spec.Pruner.validate())
 
 	if !tc.Spec.Addon.IsEmpty() {
 		errs = errs.Also(validateAddonParams(tc.Spec.Addon.Params, "spec.addon.params"))
@@ -63,6 +62,11 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 func (p Prune) validate() *apis.FieldError {
 	var errs *apis.FieldError
+
+	// if pruner job disable no validation required
+	if p.Disabled {
+		return errs
+	}
 
 	if len(p.Resources) != 0 {
 		for i, r := range p.Resources {
@@ -82,10 +86,6 @@ func (p Prune) validate() *apis.FieldError {
 	}
 	if p.KeepSince != nil && *p.KeepSince == 0 {
 		errs = errs.Also(apis.ErrInvalidValue(*p.KeepSince, "spec.pruner.keep-since"))
-	}
-
-	if p.Schedule == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.pruner.schedule"))
 	}
 
 	return errs

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -53,7 +53,9 @@ func Test_ValidateTektonConfig_MissingTargetNamespace(t *testing.T) {
 			Name:      "config",
 			Namespace: "namespace",
 		},
-		Spec: TektonConfigSpec{},
+		Spec: TektonConfigSpec{
+			Pruner: Prune{Disabled: true},
+		},
 	}
 
 	err := tc.Validate(context.TODO())
@@ -72,6 +74,7 @@ func Test_ValidateTektonConfig_InvalidProfile(t *testing.T) {
 				TargetNamespace: "namespace",
 			},
 			Profile: "test",
+			Pruner:  Prune{Disabled: true},
 		},
 	}
 
@@ -80,7 +83,6 @@ func Test_ValidateTektonConfig_InvalidProfile(t *testing.T) {
 }
 
 func Test_ValidateTektonConfig_InvalidPruningResource(t *testing.T) {
-
 	tc := &TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "config",
@@ -99,7 +101,7 @@ func Test_ValidateTektonConfig_InvalidPruningResource(t *testing.T) {
 	}
 
 	err := tc.Validate(context.TODO())
-	assert.Equal(t, "expected exactly one, got neither: spec.pruner.keep, spec.pruner.keep-since\ninvalid value: task: spec.pruner.resources[0]\nmissing field(s): spec.pruner.schedule", err.Error())
+	assert.Equal(t, "expected exactly one, got neither: spec.pruner.keep, spec.pruner.keep-since\ninvalid value: task: spec.pruner.resources[0]", err.Error())
 }
 
 func Test_ValidateTektonConfig_MissingKeepKeepsinceSchedule(t *testing.T) {
@@ -121,30 +123,7 @@ func Test_ValidateTektonConfig_MissingKeepKeepsinceSchedule(t *testing.T) {
 	}
 
 	err := tc.Validate(context.TODO())
-	assert.Equal(t, "expected exactly one, got neither: spec.pruner.keep, spec.pruner.keep-since\nmissing field(s): spec.pruner.schedule", err.Error())
-}
-
-func Test_ValidateTektonConfig_MissingSchedule(t *testing.T) {
-	keep := uint(2)
-	tc := &TektonConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config",
-			Namespace: "namespace",
-		},
-		Spec: TektonConfigSpec{
-			CommonSpec: CommonSpec{
-				TargetNamespace: "namespace",
-			},
-			Profile: "all",
-			Pruner: Prune{
-				Keep:      &keep,
-				Resources: []string{"taskrun"},
-			},
-		},
-	}
-
-	err := tc.Validate(context.TODO())
-	assert.Equal(t, "missing field(s): spec.pruner.schedule", err.Error())
+	assert.Equal(t, "expected exactly one, got neither: spec.pruner.keep, spec.pruner.keep-since", err.Error())
 }
 
 func Test_ValidateTektonConfig_InvalidAddonParam(t *testing.T) {
@@ -167,6 +146,7 @@ func Test_ValidateTektonConfig_InvalidAddonParam(t *testing.T) {
 					},
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 
@@ -194,6 +174,7 @@ func Test_ValidateTektonConfig_InvalidAddonParamValue(t *testing.T) {
 					},
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 
@@ -218,6 +199,7 @@ func Test_ValidateTektonConfig_InvalidPipelineProperties(t *testing.T) {
 					EnableApiFields: "test",
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 
@@ -242,6 +224,7 @@ func Test_ValidateTektonConfig_InvalidTriggerProperties(t *testing.T) {
 					EnableApiFields: "test",
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 

--- a/pkg/apis/operator/v1alpha1/tektonhub_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_validation_test.go
@@ -44,6 +44,7 @@ func Test_ValidateTektonConfig_InvalidHubParam(t *testing.T) {
 					},
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 
@@ -71,6 +72,7 @@ func Test_ValidateTektonConfig_InvalidHubParamValue(t *testing.T) {
 					},
 				},
 			},
+			Pruner: Prune{Disabled: true},
 		},
 	}
 

--- a/pkg/reconciler/shared/tektonconfig/instance.go
+++ b/pkg/reconciler/shared/tektonconfig/instance.go
@@ -99,7 +99,7 @@ func (tc tektonConfig) ensureInstance(ctx context.Context) {
 }
 
 func (tc tektonConfig) createInstance(ctx context.Context) error {
-	pruneKeep := uint(100)
+	pruneKeep := v1alpha1.PrunerDefaultKeep
 	tcCR := &v1alpha1.TektonConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: v1alpha1.ConfigResourceName,
@@ -110,10 +110,11 @@ func (tc tektonConfig) createInstance(ctx context.Context) error {
 				TargetNamespace: tc.namespace,
 			},
 			Pruner: v1alpha1.Prune{
-				Resources: []string{"pipelinerun"},
+				Disabled:  false,
+				Resources: v1alpha1.PruningDefaultResources,
 				Keep:      &pruneKeep,
 				KeepSince: nil,
-				Schedule:  "0 8 * * *",
+				Schedule:  v1alpha1.PrunerDefaultSchedule,
 			},
 		},
 	}

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -152,7 +152,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	}
 
 	// reconcile pruner installerSet
-	if !tc.Spec.Pruner.IsEmpty() {
+	if !tc.Spec.Pruner.Disabled {
 		err := r.reconcilePrunerInstallerSet(ctx, tc)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Changes

Without this PR, If we disable global pruner jobs (`config.pruner.schedule=""`), disables all the jobs, even though there is  a namespace with custom schedule with an annotation (example: `operator.tekton.dev/prune.schedule=0 2 * * *`).

With this PR, If we disable global pruner jobs (`config.pruner.schedule=""`), disables only the global job. If there is a namespace with custom schedule with an annotation (example: `operator.tekton.dev/prune.schedule=0 2 * * *`), there will be a running job for that. To disable the pruner feature completely, user has to add `config.pruner.disabled=true`

* Fixes: [SRVKP-1764](https://issues.redhat.com/browse/SRVKP-1764)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
To disable the pruner feature completely, update `config.pruner.disabled=true`
```

