### PR TITLE
allow beta in pipeline validation in enable-api-fields

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -21,7 +21,12 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
+)
+
+var (
+	validatePipelineAllowedApiFields = sets.NewString("", config.AlphaAPIFields, config.BetaAPIFields, config.StableAPIFields)
 )
 
 func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) {
@@ -44,11 +49,10 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 
 func (p *PipelineProperties) validate(path string) (errs *apis.FieldError) {
 
-	if p.EnableApiFields != "" {
-		if p.EnableApiFields != config.StableAPIFields && p.EnableApiFields != config.AlphaAPIFields {
-			errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, path+".enable-api-fields"))
-		}
+	if !validatePipelineAllowedApiFields.Has(p.EnableApiFields) {
+		errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, fmt.Sprintf("%s.enable-api-fields", path)))
 	}
+
 	if p.DefaultTimeoutMinutes != nil {
 		if *p.DefaultTimeoutMinutes == 0 {
 			errs = errs.Also(apis.ErrInvalidValue(p.DefaultTimeoutMinutes, path+".default-timeout-minutes"))


### PR DESCRIPTION
# Changes

pipeline validation blocks `beta` in `enable-api-fields`. With this PR allowed values are `alpha`, `beta`, and `stable`.

Error:
```
error: tektonconfigs.operator.tekton.dev "config" could not be patched: admission webhook "validation.webhook.operator.tekton.dev" denied the request: validation failed: invalid value: beta: spec.pipeline.enable-api-fields
You can run `oc replace -f /tmp/oc-edit-2900317078.yaml` to try this update again.
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```
