### PR TITLE
restrict openshift-operators namespace in openshift environment

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -108,6 +108,8 @@ This allows user to choose a namespace to install the Tekton Components such as 
 
 By default, namespace would be `tekton-pipelines` for Kubernetes and `openshift-pipelines` for OpenShift.
 
+**Note:** Namespace `openshift-operators` is not allowed in `OpenShift` as a `targetNamespace`.
+
 ### Profile
 
 This allows user to choose which all components to install on the cluster.

--- a/pkg/apis/operator/v1alpha1/common_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/common_validation_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateCommonTargetNamespace(t *testing.T) {
+	cs := &CommonSpec{TargetNamespace: ""}
+
+	tests := []struct {
+		name            string
+		targetNamespace string
+		err             string
+		isOpenshift     bool
+	}{
+		{name: "empty-value", targetNamespace: "", err: "missing field(s): spec.targetNamespace", isOpenshift: false},
+		{name: "ns-tekton-pipelines", targetNamespace: "tekton-pipelines", err: "", isOpenshift: false},
+		{name: "ns-hello", targetNamespace: "hello", err: "", isOpenshift: false},
+		{name: "ns-default", targetNamespace: "default", err: "", isOpenshift: false},
+		{name: "ns-openshift-operators", targetNamespace: "openshift-operators", err: "", isOpenshift: false},
+		{name: "openshift-ns-openshift-operators", targetNamespace: "openshift-operators", err: "invalid value: openshift-operators: spec.targetNamespace\n'openshift-operators' namespace is not allowed", isOpenshift: true},
+		{name: "openshift-ns-openshift-pipelines", targetNamespace: "openshift-pipelines", err: "", isOpenshift: true},
+		{name: "openshift-ns-openshift-xyz", targetNamespace: "openshift-xyz", err: "", isOpenshift: true},
+		{name: "openshift-ns-tekton-pipelines", targetNamespace: "tekton-pipelines", err: "", isOpenshift: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.isOpenshift {
+				t.Setenv("PLATFORM", "openshift")
+			}
+			cs.TargetNamespace = test.targetNamespace
+			errs := cs.validate("spec")
+			assert.Equal(t, test.err, errs.Error())
+		})
+	}
+}

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
@@ -23,14 +23,19 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func (pac *OpenShiftPipelinesAsCode) Validate(ctx context.Context) (errs *apis.FieldError) {
+func (pac *OpenShiftPipelinesAsCode) Validate(ctx context.Context) *apis.FieldError {
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	if err := validatePACSetting(pac.Spec.PACSettings); err != nil {
-		return err
-	}
-	return nil
+
+	var errs *apis.FieldError
+
+	// execute common spec validations
+	errs = errs.Also(pac.Spec.CommonSpec.validate("spec"))
+
+	errs = errs.Also(validatePACSetting(pac.Spec.PACSettings))
+
+	return errs
 }
 
 func validatePACSetting(pacSettings PACSettings) *apis.FieldError {

--- a/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
@@ -34,9 +34,8 @@ func (ta *TektonAddon) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(ta.GetName(), errMsg))
 	}
 
-	if ta.Spec.TargetNamespace == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
-	}
+	// execute common spec validations
+	errs = errs.Also(ta.Spec.CommonSpec.validate("spec"))
 
 	if len(ta.Spec.Params) != 0 {
 		errs = errs.Also(validateAddonParams(ta.Spec.Params, "spec.params"))

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -45,9 +45,8 @@ func (tc *TektonChain) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(tc.GetName(), errMsg))
 	}
 
-	if tc.Spec.TargetNamespace == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
-	}
+	// execute common spec validations
+	errs = errs.Also(tc.Spec.CommonSpec.validate("spec"))
 
 	return errs.Also(tc.Spec.ValidateControllerEnv(), tc.Spec.ValidateChainConfig("spec"))
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -34,9 +34,8 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(tc.GetName(), errMsg))
 	}
 
-	if tc.Spec.TargetNamespace == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
-	}
+	// execute common spec validations
+	errs = errs.Also(tc.Spec.CommonSpec.validate("spec"))
 
 	if tc.Spec.Profile != "" {
 		if isValid := isValueInArray(Profiles, tc.Spec.Profile); !isValid {

--- a/pkg/apis/operator/v1alpha1/tektonhub_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_validation.go
@@ -45,6 +45,9 @@ func (th *TektonHub) Validate(ctx context.Context) (errs *apis.FieldError) {
 		return nil
 	}
 
+	// execute common spec validations
+	errs = errs.Also(th.Spec.CommonSpec.validate("spec"))
+
 	// validate database secret name
 	if th.Spec.Db.DbSecretName != "" && th.Spec.Db.DbSecretName != HubDbSecretName {
 		errs = errs.Also(apis.ErrInvalidValue(th.Spec.Db.DbSecretName, "spec.db.secret"))

--- a/pkg/apis/operator/v1alpha1/tektonhub_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_validation_test.go
@@ -88,6 +88,9 @@ func Test_ValidateTektonHub_InvalidDbSecretName(t *testing.T) {
 			Namespace: "namespace",
 		},
 		Spec: TektonHubSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
 			Db: DbSpec{
 				DbSecretName: "invalid-value",
 			},
@@ -109,6 +112,9 @@ func Test_ValidateTektonHub_InvalidApiSecretName(t *testing.T) {
 			Namespace: "namespace",
 		},
 		Spec: TektonHubSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
 			Db: DbSpec{
 				DbSecretName: "tekton-hub-db",
 			},

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -41,9 +41,8 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 		errs = errs.Also(apis.ErrInvalidValue(tp.GetName(), errMsg))
 	}
 
-	if tp.Spec.TargetNamespace == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
-	}
+	// execute common spec validations
+	errs = errs.Also(tp.Spec.CommonSpec.validate("spec"))
 
 	return errs.Also(tp.Spec.PipelineProperties.validate("spec"))
 }

--- a/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_validation.go
@@ -35,9 +35,8 @@ func (tr *TektonTrigger) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(tr.GetName(), errMsg))
 	}
 
-	if tr.Spec.TargetNamespace == "" {
-		errs = errs.Also(apis.ErrMissingField("spec.targetNamespace"))
-	}
+	// execute common spec validations
+	errs = errs.Also(tr.Spec.CommonSpec.validate("spec"))
 
 	return errs.Also(tr.Spec.TriggersProperties.validate("spec"))
 }


### PR DESCRIPTION
# Changes

Restricts the namespace `openshift-operators` in OpenShift environment.

* Fixes: [SRVKP-2868](https://issues.redhat.com/browse/SRVKP-2868) - Using openshift-operators as a targetNamespace should not be allowed
* Changes related this issue https://github.com/tektoncd/operator/pull/1454 
    - by filtering the [namespace from the manifests](https://github.com/tektoncd/operator/pull/1454/files#diff-36721e6ebc27f10e75eb0b872116c6ed86090f81c08dae204b05b3f0478da760R106), owner reference may be removed

## Comments from the issue mentioned above: 
The openshift-operators namespace had an annotation: security.kubernetes.io/enforce: restricted which was causing the ACS Operator to try start with the restricted SCC instead of the anyuid SCC.

On the namespace, we could see an ownerRef to TektonPipeline and last-applied-configuration that had the pod-security.kubernetes.io annotation listed:

```
  name: openshift-operators
  ownerReferences:
  - apiVersion: operator.tekton.dev/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: TektonPipeline
    name: pipeline
    uid: e5d4b464-4bc2-4a44-b39a-65000351db55 
kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"operator.tekton.dev/last-applied-hash":"bc2754f647df676d8155d80fa7526811ca2c6b9837625ab27b3e6928437c5bcd"},"labels":{"app.kubernetes.io/component":"resolvers","app.kubernetes.io/instance":"default","app.kubernetes.io/part-of":"tekton-pipelines","openshift.io/cluster-monitoring":"true","operator.tekton.dev/disable-proxy":"true","operator.tekton.dev/operand-name":"tektoncd-pipelines","pod-security.kubernetes.io/enforce":"restricted"},"name":"openshift-operators","ownerReferences":[{"apiVersion":"operator.tekton.dev/v1alpha1","blockOwnerDeletion":true,"controller":true,"kind":"TektonPipeline","name":"pipeline","uid":"e5d4b464-4bc2-4a44-b39a-65000351db55"}]}} 
```
Tracing that back to Tekton, we found the customer had set targetNamespace: openshift-operators in their TektonConfig.

```
apiVersion: operator.tekton.dev/v1alpha1
kind: TektonConfig
metadata:
  name: config
  namespace: openshift-operators
spec:
  targetNamespace: openshift-operators
The targetNamespace then gets all of the Tekton namespace configs applied to it which include setting pod-security.kubernetes.io/enforce":"restricted
```
It's unclear why it randomly works / doesn't work because all of the clusters have the same config and annotation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
action required: `targetNamespace` restriction introduced in OpenShift environment. `openshift-operators` namespace is not allowed as `targetNamespace`. If you are have configured `openshift-operators` as targetNamespace, change the targetNamespace to different one, then upgrade your tekton operator instance. If you upgrade with your pipeline components on `openshift-operators`, after upgrade you are not allowed to change anything in our TektonConfig CR (except targetNamespace)
```