### PR TITLE
fix incorrect conversion between integer types

### DIFF
--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -429,7 +429,7 @@ func (pr *Pruner) getMapUint(data map[string]string, key string, defaultValue *u
 	if !found {
 		return defaultValueCloned, nil
 	}
-	uintValue, err := strconv.ParseUint(value, 10, 64)
+	uintValue, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
 		return defaultValueCloned, err
 	}


### PR DESCRIPTION
# Changes

CodeQL reported an issue on pruner go file. Fixed that by parsing with 32-bit Unsigned integer.
* https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```