### PR TITLE
add openshift monitoring label to targetNamespace

### DIFF
--- a/pkg/reconciler/common/targetnamespace.go
+++ b/pkg/reconciler/common/targetnamespace.go
@@ -18,33 +18,150 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/logging"
 )
 
-func CreateTargetNamespace(ctx context.Context, labels map[string]string, obj v1alpha1.TektonComponent, kubeClientSet kubernetes.Interface) error {
-	ownerRef := *metav1.NewControllerRef(obj, obj.GroupVersionKind())
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: obj.GetSpec().GetTargetNamespace(),
-			Labels: map[string]string{
-				"operator.tekton.dev/targetNamespace": "true",
-			},
-			OwnerReferences: []metav1.OwnerReference{ownerRef},
-		},
+const (
+	labelKeyTargetNamespace = "operator.tekton.dev/targetNamespace"
+)
+
+func ReconcileTargetNamespace(ctx context.Context, labels map[string]string, tektonComponent v1alpha1.TektonComponent, kubeClientSet kubernetes.Interface) error {
+	// get logger
+	logger := logging.FromContext(ctx)
+
+	logger.Debugw("reconciling target namespace",
+		"targetNamespace", tektonComponent.GetSpec().GetTargetNamespace(),
+	)
+
+	// ensure only one namespace with the specified targetNamespace label
+	nsList, err := kubeClientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=true", labelKeyTargetNamespace)})
+	if err != nil {
+		logger.Errorw("error on listing namespaces",
+			"targetNamespace", tektonComponent.GetSpec().GetTargetNamespace(),
+			err,
+		)
+		return err
 	}
 
-	if len(labels) > 0 {
-		for key, value := range labels {
-			namespace.Labels[key] = value
+	var targetNamespace *corev1.Namespace
+	namespaceDeletionInProgress := false
+	for _, namespace := range nsList.Items {
+		if namespace.Name == tektonComponent.GetSpec().GetTargetNamespace() && namespace.DeletionTimestamp == nil {
+			_targetNamespace := namespace.DeepCopy()
+			targetNamespace = _targetNamespace
+		} else {
+			// delete irrelevant namespaces
+			// if deletionTimestamp is not nil, that indicates, the namespace is in deletion state
+			if namespace.DeletionTimestamp == nil {
+				if err := kubeClientSet.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{}); err != nil {
+					logger.Errorw("error on deleting a namespace",
+						"namespace", namespace.Name,
+						err,
+					)
+					return err
+				}
+			} else {
+				logger.Infof("'%v' namespace is in deletion state", namespace.Name)
+				namespaceDeletionInProgress = true
+			}
 		}
 	}
 
-	if _, err := kubeClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{}); err != nil {
-		return err
+	// if some of the namespaces are in deletion state, requeue and try again on next reconcile cycle
+	if namespaceDeletionInProgress {
+		return v1alpha1.REQUEUE_EVENT_AFTER
 	}
+
+	// verify the target namespace exists, now get with targetNamespace name
+	if targetNamespace == nil {
+		_targetNamespace, err := kubeClientSet.CoreV1().Namespaces().Get(ctx, tektonComponent.GetSpec().GetTargetNamespace(), metav1.GetOptions{})
+		if err == nil {
+			if _targetNamespace.DeletionTimestamp != nil {
+				logger.Infof("'%v' namespace is in deletion state", tektonComponent.GetSpec().GetTargetNamespace())
+				return v1alpha1.REQUEUE_EVENT_AFTER
+			}
+			targetNamespace = _targetNamespace
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	// owner reference used for target namespace
+	ownerRef := *metav1.NewControllerRef(tektonComponent, tektonComponent.GroupVersionKind())
+
+	// update required labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[labelKeyTargetNamespace] = "true" // include target namespace label
+
+	// if a namespace found, update the required fields
+	if targetNamespace != nil {
+		// verify the existing namespace has the required fields, if not update
+		updateRequired := false
+
+		// update owner reference, if no one is owned
+		if len(targetNamespace.GetOwnerReferences()) == 0 {
+			targetNamespace.OwnerReferences = []metav1.OwnerReference{ownerRef}
+			updateRequired = true
+		}
+
+		// update labels
+		for expectedLabelKey, expectedLabelValue := range labels {
+			expectedLabelFound := false
+			for actualLabelKey, actualLabelValue := range targetNamespace.GetLabels() {
+				if expectedLabelKey == actualLabelKey && expectedLabelValue == actualLabelValue {
+					expectedLabelFound = true
+					break
+				}
+			}
+			// update label if not found
+			if !expectedLabelFound {
+				if targetNamespace.Labels == nil {
+					targetNamespace.Labels = map[string]string{}
+				}
+				targetNamespace.Labels[expectedLabelKey] = expectedLabelValue
+				updateRequired = true
+			}
+		}
+
+		// update the namespace, if required
+		if updateRequired {
+			_, err = kubeClientSet.CoreV1().Namespaces().Update(ctx, targetNamespace, metav1.UpdateOptions{})
+			if err != nil {
+				logger.Errorw("error on updating target namespace",
+					"targetNamespace", tektonComponent.GetSpec().GetTargetNamespace(),
+					err,
+				)
+			}
+			return err
+		}
+
+	} else {
+		// create target namespace
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            tektonComponent.GetSpec().GetTargetNamespace(),
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+		}
+
+		if _, err := kubeClientSet.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{}); err != nil {
+			logger.Errorw("error on creating target namespace",
+				"targetNamespace", tektonComponent.GetSpec().GetTargetNamespace(),
+				err,
+			)
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/reconciler/common/targetnamespace_test.go
+++ b/pkg/reconciler/common/targetnamespace_test.go
@@ -19,49 +19,285 @@ package common
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestCreateTargetNamespace(t *testing.T) {
-	targetNamespace := "test-ns"
-	component := &v1alpha1.TektonPipeline{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-name",
-		},
-		Spec: v1alpha1.TektonPipelineSpec{
-			CommonSpec: v1alpha1.CommonSpec{
-				TargetNamespace: targetNamespace,
+func TestReconcileTargetNamespace(t *testing.T) {
+	namespaceTektonPipelines := "tekton-pipelines"
+
+	tests := []struct {
+		name             string
+		component        v1alpha1.TektonComponent
+		additionalLabels map[string]string
+		ownerReferences  []metav1.OwnerReference
+		preFunc          func(t *testing.T, fakeClientset *fake.Clientset)                              // preFunc used to update namespace details before reconcile
+		err              error                                                                          // error if any from ReconcileTargetNamespace function
+		postFunc         func(t *testing.T, fakeClientset *fake.Clientset, namespace *corev1.Namespace) // postFunc used to verify additional fields
+	}{
+		{
+			name: "verify-tekton-config",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
 			},
+			err: nil,
+		},
+		{
+			name: "verify-tekton-hub",
+			component: &v1alpha1.TektonHub{
+				ObjectMeta: metav1.ObjectMeta{Name: "hub"},
+				Spec:       v1alpha1.TektonHubSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			err: nil,
+		},
+		{
+			name: "verify-custom-target-namespace",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: "hello123"}},
+			},
+			err: nil,
+		},
+		{
+			name: "verify-with-additional-labels",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			additionalLabels: map[string]string{
+				"openshift.io/cluster-monitoring": "true",
+			},
+			err: nil,
+		},
+		{
+			name: "verify-with-expected-labels",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				// create a namespace with "operator.tekton.dev/targetNamespace" label
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceTektonPipelines,
+					Labels: map[string]string{
+						// one of expected label
+						labelKeyTargetNamespace: "true",
+					},
+				}}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			err: nil,
+		},
+		{
+			name: "verify-existing-non-target-namespace-deleted",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: "hello123"}},
+			},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				// create a namespace with different name and with "operator.tekton.dev/targetNamespace" label
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-ns",
+					Labels: map[string]string{
+						labelKeyTargetNamespace: "true",
+					},
+				}}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			postFunc: func(t *testing.T, fakeClientset *fake.Clientset, namespace *corev1.Namespace) {
+				// verify "custom-ns" is removed
+				_, err := fakeClientset.CoreV1().Namespaces().Get(context.TODO(), "custom-ns", metav1.GetOptions{})
+				assert.Equal(t, true, errors.IsNotFound(err), "'custom-ns' namespace should be deleted, but still found")
+			},
+			err: nil,
+		},
+		{
+			name: "verify-namespace-in-deletion-state",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				// create a namespace with deletionTimestamp, it means the namespace is in deletion state
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:              namespaceTektonPipelines,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				}}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			// ReconcileTargetNamespace requeue event for the namespace is in deletion state
+			err: v1alpha1.REQUEUE_EVENT_AFTER,
+		},
+		{
+			name: "verify-non-target-namespace-in-deletion-state",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				// create a namespace with deletionTimestamp, it means the namespace is in deletion state
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name: "custom-ns",
+					Labels: map[string]string{
+						labelKeyTargetNamespace: "true",
+					},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				}}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			// ReconcileTargetNamespace requeue event for the namespace is in deletion state
+			err: v1alpha1.REQUEUE_EVENT_AFTER,
+		},
+		{
+			name: "verify-existing-namespace",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespaceTektonPipelines,
+						// additional labels
+						Labels: map[string]string{
+							"custom": "123",
+							"test":   "hello",
+						},
+						Annotations: map[string]string{
+							"custom-annotations": "tekton",
+							"key123":             "value123",
+						},
+					},
+				}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			postFunc: func(t *testing.T, fakeClientset *fake.Clientset, namespace *corev1.Namespace) {
+				// verify custom labels
+				expectedLabels := map[string]string{
+					"custom": "123",
+					"test":   "hello",
+				}
+				for expectedLabelKey, expectedLabelValue := range expectedLabels {
+					labelFound := false
+					for actualLabelKey, actualLabelValue := range namespace.GetLabels() {
+						if expectedLabelKey == actualLabelKey && expectedLabelValue == actualLabelValue {
+							labelFound = true
+							break
+						}
+					}
+					assert.Equal(t, true, labelFound, "expected labelKey or labelValue not found:[%s=%s]", expectedLabelKey, expectedLabelValue)
+				}
+				// verify existing annotations
+				expectedAnnotations := map[string]string{
+					"custom-annotations": "tekton",
+					"key123":             "value123",
+				}
+				for expectedAnnotationKey, expectedAnnotationValue := range expectedAnnotations {
+					annotationFound := false
+					for actualAnnotationKey, actualAnnotationValue := range namespace.GetAnnotations() {
+						if expectedAnnotationKey == actualAnnotationKey && expectedAnnotationValue == actualAnnotationValue {
+							annotationFound = true
+							break
+						}
+					}
+					assert.Equal(t, true, annotationFound, "expected annotationKey or annotationValue not found:[%s=%s]", expectedAnnotationKey, expectedAnnotationValue)
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "verify-existing-namespace-with-owner-reference",
+			component: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config"},
+				Spec:       v1alpha1.TektonConfigSpec{CommonSpec: v1alpha1.CommonSpec{TargetNamespace: namespaceTektonPipelines}},
+			},
+			additionalLabels: map[string]string{},
+			ownerReferences:  []metav1.OwnerReference{*metav1.NewControllerRef(&corev1.Namespace{}, (&corev1.Namespace{}).GroupVersionKind())},
+			preFunc: func(t *testing.T, fakeClientset *fake.Clientset) {
+				ns := &corev1.Namespace{}
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namespaceTektonPipelines,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ns, ns.GroupVersionKind())},
+					},
+				}
+				_, err := fakeClientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+				assert.NilError(t, err)
+			},
+			err: nil,
 		},
 	}
-	fakeClientset := fake.NewSimpleClientset()
 
-	err := CreateTargetNamespace(context.Background(), nil, component, fakeClientset)
-	assert.Equal(t, err, nil)
+	for _, test := range tests {
+		// execute tests
+		t.Run(test.name, func(t *testing.T) {
+			fakeClientset := fake.NewSimpleClientset()
+			targetNamespace := test.component.GetSpec().GetTargetNamespace()
+			expectedLabels := map[string]string{labelKeyTargetNamespace: "true"}
+			// include additional labels, if any
+			if len(test.additionalLabels) > 0 {
+				for k, v := range test.additionalLabels {
+					expectedLabels[k] = v
+				}
+			}
+			// create expected owner reference for that namespace and compute hash
+			expectedOwnerRef := []metav1.OwnerReference{*metav1.NewControllerRef(test.component, test.component.GroupVersionKind())}
+			if len(test.ownerReferences) > 0 {
+				expectedOwnerRef = test.ownerReferences
+			}
+			expectedHash, err := hash.Compute(expectedOwnerRef)
+			assert.NilError(t, err)
 
-	ns, err := fakeClientset.CoreV1().Namespaces().Get(context.Background(), targetNamespace, metav1.GetOptions{})
-	assert.Equal(t, err, nil)
-	assert.Equal(t, ns.ObjectMeta.Name, targetNamespace)
-}
+			// execute pre function
+			if test.preFunc != nil {
+				test.preFunc(t, fakeClientset)
+			}
 
-func TestTargetNamespaceNotFound(t *testing.T) {
-	component := &v1alpha1.TektonPipeline{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-name",
-		},
-		Spec: v1alpha1.TektonPipelineSpec{
-			CommonSpec: v1alpha1.CommonSpec{},
-		},
+			// call reconciler
+			err = ReconcileTargetNamespace(context.Background(), test.additionalLabels, test.component, fakeClientset)
+			assert.Equal(t, err, test.err)
+
+			if test.err == nil {
+				namespace, err := fakeClientset.CoreV1().Namespaces().Get(context.Background(), targetNamespace, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, namespace.ObjectMeta.Name, targetNamespace)
+
+				// verify labels
+				for expectedLabelKey, expectedLabelValue := range expectedLabels {
+					labelFound := false
+					for actualLabelKey, actualLabelValue := range namespace.GetLabels() {
+						if expectedLabelKey == actualLabelKey && expectedLabelValue == actualLabelValue {
+							labelFound = true
+							break
+						}
+					}
+					assert.Equal(t, true, labelFound, "expected labelKey or labelValue not found:[%s=%s]", expectedLabelKey, expectedLabelValue)
+				}
+
+				// verify owner reference
+				assert.Equal(t, 1, len(namespace.GetOwnerReferences()))
+				actualHash, err := hash.Compute(namespace.GetOwnerReferences())
+				assert.NilError(t, err)
+				assert.Equal(t, expectedHash, actualHash)
+
+				// execute post function
+				if test.postFunc != nil {
+					test.postFunc(t, fakeClientset, namespace)
+				}
+			}
+		})
 	}
-	fakeClientset := fake.NewSimpleClientset()
-
-	err := CreateTargetNamespace(context.Background(), nil, component, fakeClientset)
-	assert.Equal(t, err, nil)
-
-	_, err = fakeClientset.CoreV1().Namespaces().Get(context.Background(), "foo", metav1.GetOptions{})
-	assert.Equal(t, err.Error(), `namespaces "foo" not found`)
 }


### PR DESCRIPTION
# Changes

* Moved reconcile target namespace logic to a common place.
* adds monitoring label into targetNamespace if it is a OpenShift platform
* Fixes: [SRVKP-3139](https://issues.redhat.com/browse/SRVKP-3139) - Metrics not working

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
