### PR TITLE
support custom secret in tekton results

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -110,10 +110,41 @@ spec:
   s3_secret_access_key: sdfjg
   s3_multi_part_size: 888mb
   logging_pvc_name: tekton-logs
+  secret_name: # optional
 ```
 
 These properties are analogous to the one in configmap of tekton results api `tekton-results-api-config` documented at [api.md]:https://github.com/tektoncd/results/blob/4472848a0fb7c1473cfca8b647553170efac78a1/cmd/api/README.md
 
 
 [result]:https://github.com/tektoncd/results
+
+
+### Property "secret_name":
+`secret_name` - name of your custom secret or leave it as empty. It an optional property. The secret should be created by the user on the `targetNamespace`. The secret can contain `S3_` prefixed keys from the [result API properties](https://github.com/tektoncd/results/blob/fded140081468e418aeb860d16aca3306c675d8b/cmd/api/README.md). Please note: the key of the secret should be in UPPER_CASE and values should be in `string` format.
+The following keys are supported by this secret.
+* `S3_BUCKET_NAME`
+* `S3_ENDPOINT`
+* `S3_HOSTNAME_IMMUTABLE`
+* `S3_REGION`
+* `S3_ACCESS_KEY_ID`
+* `S3_SECRET_ACCESS_KEY`
+* `S3_MULTI_PART_SIZE`
+
+#### Sample Secret File
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my_custom_secret
+  namespace: tekton-pipelines
+type: Opaque
+stringData:
+  S3_BUCKET_NAME: foo
+  S3_ENDPOINT: https://example.localhost.com
+  S3_HOSTNAME_IMMUTABLE: "false"
+  S3_REGION: region-1
+  S3_ACCESS_KEY_ID: "1234"
+  S3_SECRET_ACCESS_KEY: secret_key
+  S3_MULTI_PART_SIZE: "5242880"
+```
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -83,6 +83,9 @@ type ResultsAPIProperties struct {
 	S3SecretAccessKey     string `json:"s3_secret_access_key,omitempty"`
 	S3MultiPartSize       int64  `json:"s3_multi_part_size,omitempty"`
 	LoggingPVCName        string `json:"logging_pvc_name"`
+	// name of the secret used to get S3 credentials and
+	// pass it as environment variables to the "tekton-results-api" deployment under "api" container
+	SecretName string `json:"secret_name,omitempty"`
 }
 
 // TektonResultStatus defines the observed state of TektonResult

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/api-deployment.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/api-deployment.yaml
@@ -37,6 +37,8 @@ spec:
                   name: tekton-results-postgres
             - name: DB_NAME
               value: tekton-results
+            - name: S3_BUCKET_NAME  # used to verify that, this value replaced by transformer
+              value: foo
           image: gcr.io/tekton-releases/github.com/tektoncd/results/cmd/api:9f84a1f@sha256:606816e51ebecb58fccc28f5a95699255ed8742470df673294ce25f69ffc451c
           name: api
           securityContext:


### PR DESCRIPTION
# Changes

For now there is no way to supply `S3` credentials into results api pod via secrets. This PR optionally injects those references via environment variable into `tekton-results-api` deployment.
As these values are injected as environment variable takes the higher precedence.

There is an issue in results repository about this: https://github.com/tektoncd/results/issues/469, https://github.com/tektoncd/results/issues/432

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
To get `S3` credentials from secret, a new property called `secret_name` added under TektonResult spec. User can create a secret with `S3` credentials and update the secret name in `secret_name` property.
```
