### PR TITLE
Bump jib-maven to 0.5

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -94,6 +94,8 @@ spec:
           value: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
         - name: IMAGE_ADDONS_GEN_ENV_FILE
           value: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:98d8cb3a255641ca6a1bce854e5e2460c20de9fb9b28e3cc67eb459f122873dd
+        - name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE
+          value: registry.redhat.io/ubi8/openjdk-17@sha256:923b18a62d892ec23b6bbf714ecb237a0a0fa3cd225fbf89d39966dd8d421c72
       - name: openshift-pipelines-operator-cluster-operations  # tektoninstallerset reconciler
         image: ko://github.com/tektoncd/operator/cmd/openshift/operator
         args:

--- a/hack/openshift/update-image-sha.sh
+++ b/hack/openshift/update-image-sha.sh
@@ -50,6 +50,7 @@ declare -A IMAGES=(
   ["skopeo-copy"]="registry.redhat.io/rhel8/skopeo"
   ["s2i"]="registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8"
   ["ubi-minimal"]="registry.redhat.io/ubi8/ubi-minimal"
+  ["java"]="registry.redhat.io/ubi8/openjdk-17"
 )
 
 registry_login() {

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -222,6 +222,14 @@ image-substitutions:
         envKeys:
           - IMAGE_RESULTS_API
 
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:923b18a62d892ec23b6bbf714ecb237a0a0fa3cd225fbf89d39966dd8d421c72
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator-lifecycle
+        envKeys:
+          - IMAGE_ADDONS_PARAM_MAVEN_IMAGE
+
 # add third party images which are not replaced by operator
 # but pulled directly by tasks here
 defaultRelatedImages: []

--- a/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
+++ b/pkg/reconciler/openshift/tektonaddon/communityClusterTasks.go
@@ -27,7 +27,7 @@ import (
 )
 
 var communityResourceURLs = []string{
-	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.4/jib-maven.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.5/jib-maven.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.3/helm-upgrade-from-source.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",


### PR DESCRIPTION
This will bump jib-maven to 0.5 and also
use redhat image on openshift

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Bump jib-maven to 0.5
```
