### PR TITLE
allow extra fields in copy configMap transformer

### DIFF
--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -44,7 +44,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.DeploymentImages(images),
 			common.AddConfiguration(pac.Spec.Config),
 			occommon.ApplyCABundles,
-			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
+			common.CopyConfigMapWithForceUpdate(pipelinesAsCodeCM, pac.Spec.Settings, true),
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
 		}
 


### PR DESCRIPTION
# Changes
Transformer `CopyConfigMap` copies only the known field from the configMap.
PipelineAsCode CR supports free style key value map settings. They want to pass all the fields from the settings to a config map. For some reason extra fields are restricted in the existing `CopyConfigMap`.

To address this, in this PR I am introducing another transformer  called `CopyConfigMapWithForceUpdate`. The existing `CopyConfigMap` uses the new transformer with `forceUpdate=false`, `CopyConfigMapWithForceUpdate(configMapName, expectedValues, false)`.

[There is an issue](https://github.com/tektoncd/operator/issues/1568) to analysis the impact in other components when we change the behavior of `CopyConfigMap` to support extra fields. And later we have to create a PR to remove the `CopyConfigMap` transformer completely.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
