### PR TITLE
Handles chains config map during upgrade and adds provision to enable/disable chains

### DIFF
--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -20,6 +20,7 @@ It is recommended to install the component through [TektonConfig](./TektonConfig
     metadata:
       name: chain
     spec:
+      disabled: false
       targetNamespace: tekton-pipelines
     ```
 
@@ -31,6 +32,7 @@ It is recommended to install the component through [TektonConfig](./TektonConfig
     metadata:
       name: chain
     spec:
+      disabled: false
       targetNamespace: openshift-pipelines
     ```
 
@@ -68,10 +70,11 @@ kind: TektonChain
 metadata:
   name: chain
 spec:
+  disabled: false
   targetNamespace: tekton-pipelines
   controllerEnvs:
     - name: MONGO_SERVER_URL      # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller
-    value: #value               # This can be provided same as env field of container
+      value: #value               # This can be provided same as env field of container
   artifacts.taskrun.format: in-toto
   artifacts.taskrun.storage: tekton,oci (comma separated values)
   artifacts.taskrun.signer: x509

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -38,6 +38,8 @@ The TektonConfig CR provides the following features
       nodeSelector: <>
       tolerations: []
       priorityClassName: system-cluster-critical
+    chain:
+      disabled: false
     pipeline:
       disable-affinity-assistant: false
       disable-creds-init: false
@@ -189,6 +191,7 @@ Example:
 
 ```yaml
 chain:
+  disabled: false                  # - `disabled` : if the value set as `true`, chains feature will be disabled (default: `false`)
   targetNamespace: tekton-pipelines
   controllerEnvs:
     - name: MONGO_SERVER_URL      # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -64,6 +64,8 @@ type TektonChainSpec struct {
 }
 
 type Chain struct {
+	// enable or disable chains feature
+	Disabled        bool `json:"disabled"`
 	ChainProperties `json:",inline"`
 	ControllerEnvs  []corev1.EnvVar `json:"controllerEnvs,omitempty"`
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -151,19 +151,20 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 			return v1alpha1.REQUEUE_EVENT_AFTER
 
 		}
-
-		tektonchain := chain.GetTektonChainCR(tc)
-		if _, err := chain.EnsureTektonChainExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonChains(), tektonchain); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonChain: %s", err.Error()))
-			return v1alpha1.REQUEUE_EVENT_AFTER
-		}
-
 	} else {
 		if err := trigger.EnsureTektonTriggerCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers()); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+	}
 
+	if !tc.Spec.Chain.Disabled {
+		tektonchain := chain.GetTektonChainCR(tc)
+		if _, err := chain.EnsureTektonChainExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonChains(), tektonchain); err != nil {
+			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonChain: %s", err.Error()))
+			return v1alpha1.REQUEUE_EVENT_AFTER
+		}
+	} else {
 		if err := chain.EnsureTektonChainCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonChains()); err != nil {
 			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonChain: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER


### PR DESCRIPTION
- Handles chains config map during upgrade 

  - Previously when user installed chains by adding any of the
supported fields and then when upgraded to the latest version,
where chains is installed through TektonConfig, the data in the
TektonChain CR is overwritten

  - And also the data in the chains-config confimap was not deleted
because the manifestival package appends the latest data, instead of
replacing it

  - Hence, fixing this by creating separate `chains-config` configMap installerset

---
- Adds a provision to enable/disable chains

  - Previously, when operator was installed chains was installed
by default, but there can be a case where user doesn't needs
chains to installed

  - Hence, this patch provides a field with `disabled` where user
can provide a true/false value where user can decide, if we
wants to install chains or not

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

* NOTE:- If user has installed chains in `tekton-pipelines` or `openshift-pipelines` i.e `targetNamespace` then only it's previous data will be preserved on upgrade
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
