### PR TITLE
Remove seccompprofile from containers

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -30,6 +30,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-pipelines-operator
       containers:
       - name: openshift-pipelines-operator-lifecycle  # all reconcilers except tektoninstallerset reconciler

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -32,6 +32,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-pipelines-operator
       containers:
       - name: tekton-operator-webhook

--- a/pkg/reconciler/common/testdata/test-add-psa.yaml
+++ b/pkg/reconciler/common/testdata/test-add-psa.yaml
@@ -47,3 +47,6 @@ spec:
           ports:
             - containerPort: 8000
             - containerPort: 4200
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -630,6 +630,9 @@ func AddDeploymentRestrictedPSA() mf.Transformer {
 			}
 			c.SecurityContext.AllowPrivilegeEscalation = ptr.Bool(allowPrivilegedEscalationValue)
 			c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
+			if c.SecurityContext.SeccompProfile != nil {
+				c.SecurityContext.SeccompProfile = nil
+			}
 		}
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
@@ -673,6 +676,9 @@ func AddStatefulSetRestrictedPSA() mf.Transformer {
 			}
 			c.SecurityContext.AllowPrivilegeEscalation = ptr.Bool(allowPrivilegedEscalationValue)
 			c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
+			if c.SecurityContext.SeccompProfile != nil {
+				c.SecurityContext.SeccompProfile = nil
+			}
 		}
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(s)
@@ -719,6 +725,9 @@ func AddJobRestrictedPSA() mf.Transformer {
 			}
 			if c.SecurityContext.Capabilities == nil {
 				c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
+			}
+			if c.SecurityContext.SeccompProfile != nil {
+				c.SecurityContext.SeccompProfile = nil
 			}
 		}
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jb)


### PR DESCRIPTION
This is to remove seccompprofile from containers also and reverting operator deployment change done wrong in previous commit

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove seccompprofile from containers
```