### PR TITLE
Make operator work on k8s 1.23 and ocp 4.10

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/05-tkncliserve/tkn_cli_serve.yaml
@@ -18,6 +18,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: tkn-cli-serve
           image: docker.io/rupali/serve-tkn:v2

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -101,6 +101,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tekton-operators-proxy-webhook
       containers:
         - name: proxy

--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -402,8 +402,11 @@ func createCronJob(ctx context.Context, kc kubernetes.Interface, cronName, targe
 							Tolerations:        tC.Spec.Config.Tolerations,
 							SecurityContext: &corev1.PodSecurityContext{
 								RunAsNonRoot: &runAsNonRoot,
-								RunAsUser:    runAsUser,
-								FSGroup:      fsGroup,
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+								RunAsUser: runAsUser,
+								FSGroup:   fsGroup,
 							},
 						},
 					},

--- a/pkg/reconciler/common/testdata/test-add-psa-expected-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-add-psa-expected-statefulset.yaml
@@ -24,6 +24,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - envFrom:
             - configMapRef:

--- a/pkg/reconciler/common/testdata/test-add-psa-expected.yaml
+++ b/pkg/reconciler/common/testdata/test-add-psa-expected.yaml
@@ -30,6 +30,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: catalog-source
           persistentVolumeClaim:

--- a/pkg/reconciler/common/testdata/test-add-psa-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-add-psa-statefulset.yaml
@@ -22,10 +22,6 @@ spec:
         app.kubernetes.io/part-of: tekton-results
         app.kubernetes.io/version: v0.4.0
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - envFrom:
             - configMapRef:
@@ -42,9 +38,6 @@ spec:
               name: postgredb
             - mountPath: /docker-entrypoint-initdb.d
               name: sql-initdb
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault
       volumes:
         - configMap:
             name: tekton-results-sql-initdb-config

--- a/pkg/reconciler/common/testdata/test-add-psa.yaml
+++ b/pkg/reconciler/common/testdata/test-add-psa.yaml
@@ -28,10 +28,6 @@ spec:
       labels:
         app: tekton-hub-api
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       volumes:
       - name: catalog-source
         persistentVolumeClaim:
@@ -51,6 +47,3 @@ spec:
           ports:
             - containerPort: 8000
             - containerPort: 4200
-          securityContext:
-            seccompProfile:
-              type: RuntimeDefault

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -619,8 +619,10 @@ func AddDeploymentRestrictedPSA() mf.Transformer {
 			d.Spec.Template.Spec.SecurityContext.RunAsNonRoot = ptr.Bool(runAsNonRootValue)
 		}
 
-		if d.Spec.Template.Spec.SecurityContext.SeccompProfile != nil {
-			d.Spec.Template.Spec.SecurityContext.SeccompProfile = nil
+		if d.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
+			d.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			}
 		}
 
 		for i := range d.Spec.Template.Spec.Containers {
@@ -630,9 +632,6 @@ func AddDeploymentRestrictedPSA() mf.Transformer {
 			}
 			c.SecurityContext.AllowPrivilegeEscalation = ptr.Bool(allowPrivilegedEscalationValue)
 			c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
-			if c.SecurityContext.SeccompProfile != nil {
-				c.SecurityContext.SeccompProfile = nil
-			}
 		}
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
@@ -665,8 +664,10 @@ func AddStatefulSetRestrictedPSA() mf.Transformer {
 			s.Spec.Template.Spec.SecurityContext.RunAsNonRoot = ptr.Bool(runAsNonRootValue)
 		}
 
-		if s.Spec.Template.Spec.SecurityContext.SeccompProfile != nil {
-			s.Spec.Template.Spec.SecurityContext.SeccompProfile = nil
+		if s.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
+			s.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			}
 		}
 
 		for i := range s.Spec.Template.Spec.Containers {
@@ -676,9 +677,6 @@ func AddStatefulSetRestrictedPSA() mf.Transformer {
 			}
 			c.SecurityContext.AllowPrivilegeEscalation = ptr.Bool(allowPrivilegedEscalationValue)
 			c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
-			if c.SecurityContext.SeccompProfile != nil {
-				c.SecurityContext.SeccompProfile = nil
-			}
 		}
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(s)
@@ -711,8 +709,10 @@ func AddJobRestrictedPSA() mf.Transformer {
 			jb.Spec.Template.Spec.SecurityContext.RunAsNonRoot = ptr.Bool(runAsNonRootValue)
 		}
 
-		if jb.Spec.Template.Spec.SecurityContext.SeccompProfile != nil {
-			jb.Spec.Template.Spec.SecurityContext.SeccompProfile = nil
+		if jb.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
+			jb.Spec.Template.Spec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			}
 		}
 
 		for i := range jb.Spec.Template.Spec.Containers {
@@ -725,9 +725,6 @@ func AddJobRestrictedPSA() mf.Transformer {
 			}
 			if c.SecurityContext.Capabilities == nil {
 				c.SecurityContext.Capabilities = &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}
-			}
-			if c.SecurityContext.SeccompProfile != nil {
-				c.SecurityContext.SeccompProfile = nil
 			}
 		}
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jb)

--- a/pkg/reconciler/openshift/common/testdata/test-add-psa-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-add-psa-expected.yaml
@@ -1,0 +1,56 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-hub-api
+  labels:
+    app: tekton-hub-api
+spec:
+  selector:
+    matchLabels:
+      app: tekton-hub-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-hub-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      volumes:
+        - name: catalog-source
+          persistentVolumeClaim:
+            claimName: tekton-hub-api
+        - name: ssh-creds
+          secret:
+            secretName: tekton-hub-api-ssh-crds
+            optional: true
+      containers:
+        - name: tekton-hub-api
+          image: quay.io/tekton-hub/api
+          volumeMounts:
+            - name: catalog-source
+              mountPath: "/tmp/catalog"
+            - name: ssh-creds
+              mountPath: "/home/hub/.ssh"
+          ports:
+            - containerPort: 8000
+            - containerPort: 4200
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-add-psa.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-add-psa.yaml
@@ -1,0 +1,60 @@
+# Copyright © 2022 The Tekton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-hub-api
+  labels:
+    app: tekton-hub-api
+spec:
+  selector:
+    matchLabels:
+      app: tekton-hub-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-hub-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - name: catalog-source
+        persistentVolumeClaim:
+          claimName: tekton-hub-api
+      - name: ssh-creds
+        secret:
+          secretName: tekton-hub-api-ssh-crds
+          optional: true
+      containers:
+        - name: tekton-hub-api
+          image: quay.io/tekton-hub/api
+          volumeMounts:
+          - name: catalog-source
+            mountPath: "/tmp/catalog"
+          - name: ssh-creds
+            mountPath: "/home/hub/.ssh"
+          ports:
+            - containerPort: 8000
+            - containerPort: 4200
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -171,6 +171,72 @@ func RemoveFsGroupForJob() mf.Transformer {
 	}
 }
 
+// RemoveSecCompForDeployment will remove seccomp in a deployment
+func RemoveSecCompForDeployment() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Deployment" {
+			return nil
+		}
+
+		d := &appsv1.Deployment{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, d)
+		if err != nil {
+			return err
+		}
+
+		if d.Spec.Template.Spec.SecurityContext.SeccompProfile != nil {
+			d.Spec.Template.Spec.SecurityContext.SeccompProfile = nil
+		}
+
+		for i := range d.Spec.Template.Spec.Containers {
+			c := &d.Spec.Template.Spec.Containers[i]
+			if c.SecurityContext.SeccompProfile != nil {
+				c.SecurityContext.SeccompProfile = nil
+			}
+		}
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+		if err != nil {
+			return err
+		}
+		u.SetUnstructuredContent(unstrObj)
+		return nil
+	}
+}
+
+// RemoveSecCompForJob will remove seccomp in a job
+func RemoveSecCompForJob() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Job" {
+			return nil
+		}
+
+		jb := &batchv1.Job{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, jb)
+		if err != nil {
+			return err
+		}
+
+		if jb.Spec.Template.Spec.SecurityContext.SeccompProfile != nil {
+			jb.Spec.Template.Spec.SecurityContext.SeccompProfile = nil
+		}
+
+		for i := range jb.Spec.Template.Spec.Containers {
+			c := &jb.Spec.Template.Spec.Containers[i]
+			if c.SecurityContext.SeccompProfile != nil {
+				c.SecurityContext.SeccompProfile = nil
+			}
+		}
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(jb)
+		if err != nil {
+			return err
+		}
+		u.SetUnstructuredContent(unstrObj)
+		return nil
+	}
+}
+
 func UpdateServiceMonitorTargetNamespace(targetNamespace string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() != "ServiceMonitor" {

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -148,6 +148,35 @@ func TestRemoveFsGroup(t *testing.T) {
 	}
 }
 
+func TestRemoveSecComp(t *testing.T) {
+	testData := path.Join("testdata", "test-add-psa.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-add-psa-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(RemoveSecCompForDeployment())
+	assert.NilError(t, err)
+
+	got := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, got)
+	if err != nil {
+		t.Errorf("failed to load deployment yaml")
+	}
+
+	expected := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expected)
+	if err != nil {
+		t.Errorf("failed to load deployment yaml")
+	}
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
+	}
+}
+
 func TestUpdateServiceMonitorTargetNamespace(t *testing.T) {
 	targetNs := "its-me-ns"
 	testData := path.Join("testdata", "test-inject-ns-in-servicemonitor.yaml")

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -47,6 +47,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			occommon.ApplyCABundles,
 			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
+			occommon.RemoveSecCompForDeployment(),
 		}
 
 		allTfs := append(tfs, extension.Transformers(pac)...)

--- a/pkg/reconciler/openshift/tektonaddon/openshiftConsole.go
+++ b/pkg/reconciler/openshift/tektonaddon/openshiftConsole.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -82,6 +83,7 @@ func filterAndTransformOCPResources() client.FilterAndTransform {
 		tfs := []mf.Transformer{
 			common.DeploymentImages(images),
 			common.AddConfiguration(addon.Spec.Config),
+			occommon.RemoveSecCompForDeployment(),
 		}
 		if err := transformers(ctx, manifest, addon, tfs...); err != nil {
 			return nil, err

--- a/pkg/reconciler/openshift/tektonchain/extension.go
+++ b/pkg/reconciler/openshift/tektonchain/extension.go
@@ -43,6 +43,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundles,
+		occommon.RemoveSecCompForDeployment(),
 	}
 }
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {

--- a/pkg/reconciler/openshift/tektonhub/extension.go
+++ b/pkg/reconciler/openshift/tektonhub/extension.go
@@ -101,6 +101,8 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		openshiftCommon.RemoveRunAsUserForJob(),
 		openshiftCommon.RemoveFsGroupForDeployment(),
 		openshiftCommon.RemoveFsGroupForJob(),
+		openshiftCommon.RemoveSecCompForDeployment(),
+		openshiftCommon.RemoveSecCompForJob(),
 	}
 }
 

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -60,6 +60,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	trns := []mf.Transformer{
 		occommon.ApplyCABundles,
 		occommon.RemoveRunAsUser(),
+		occommon.RemoveSecCompForDeployment(),
 	}
 
 	pipeline := comp.(*v1alpha1.TektonPipeline)

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -35,6 +35,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
+		occommon.RemoveSecCompForDeployment(),
 		occommon.ApplyCABundles,
 		replaceDeploymentArgs("-el-security-context", "false"),
 		replaceDeploymentArgs("-el-events", "enable"),


### PR DESCRIPTION
# Changes

[Revert "Make psa changes to run 0.65 on k8s 1.23"](https://github.com/tektoncd/operator/commit/f338e1d350428e9d50c225139ed80288cdab70e2)

[Make operator work on k8s 1.23 and ocp 4.10](https://github.com/tektoncd/operator/commit/5ca16e376942ee2ee09d63d4da7f6219c045144c)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Make operator work on k8s 1.23 and ocp 4.10
```