### PR TITLE
Bump pipeline to v0.47.3 and fix roles

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -9,7 +9,7 @@ hub:
   version: v1.13.0
 pipeline:
   github: tektoncd/pipeline
-  version: v0.47.2
+  version: v0.47.3
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code
   version: v0.19.2

--- a/config/base/role.yaml
+++ b/config/base/role.yaml
@@ -400,3 +400,9 @@ rules:
   - delete
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list

--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -358,3 +358,9 @@ rules:
   - watch
   - create
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -56,6 +56,9 @@ function tektonconfig_ready_wait() {
     sleep 5
     if is_tektonconfig_cr_created && is_tektonconfig_cr_uptodate && is_tektonconfig_cr_ready; then
       TEKTONCONFIG_READY=True
+    elif is_tektonconfig_cr_created; then
+      echo current status of tektonconfig
+      kubectl get tektonconfig config
     fi
   done
   echo "TektonConfig config Ready: True"


### PR DESCRIPTION
# Changes

This will bump pipeline to v0.47.3,
in addition to that added roles(in operator) required to create pipelines controller cluster roles
Pipelines reference PR: https://github.com/tektoncd/pipeline/pull/6863

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Bump pipeline to v0.47.3 and fix roles
```
