### PR TITLE
Fix the order of tranformers for extension

### DIFF
--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -260,7 +260,7 @@ spec:
     - Tekton Triggers: v0.23.1
     - Pipelines as Code: v0.17.4
     - Tekton Chains (tech-preview): v0.15.0
-    - Tekton Hub (tech-preview): v1.12.1
+    - Tekton Hub (tech-preview): v1.12.2
 
     ## Getting Started
     In order to get familiar with _OpenShift Pipelines_ concepts and create your first pipeline, follow the [OpenShift Pipelines Docs](https://docs.openshift.com/container-platform/OPENSHIFT_DOCS_VERSION/cicd/pipelines/creating-applications-with-cicd-pipelines.html).

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -563,8 +563,8 @@ func (r *Reconciler) transform(ctx context.Context, manifest mf.Manifest, th *v1
 	logger := logging.FromContext(ctx)
 
 	images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.HubImagePrefix))
-	trans := r.extension.Transformers(th)
-	extra := []mf.Transformer{
+	extensionTransformers := r.extension.Transformers(th)
+	transformers := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdHub),
 		mf.InjectOwner(th),
 		mf.InjectNamespace(namespace),
@@ -581,9 +581,9 @@ func (r *Reconciler) transform(ctx context.Context, manifest mf.Manifest, th *v1
 		common.AddJobRestrictedPSA(),
 	}
 
-	trans = append(trans, extra...)
+	transformers = append(transformers, extensionTransformers...)
 
-	manifest, err := manifest.Transform(trans...)
+	manifest, err := manifest.Transform(transformers...)
 
 	if err != nil {
 		logger.Error("failed to transform manifest")


### PR DESCRIPTION
This will fix the order of trnaformers for extension of hub

right now extension gets executed first, and then common later reverting the changes is some field maipulation is done in both


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix the order of tranformers for extension for hub
```