### PR TITLE
Pass the args to container as key=value

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -141,19 +142,14 @@ func updatePerformanceFlagsInDeployment(pipelineCR *v1alpha1.TektonPipeline) mf.
 				argStringValue := fmt.Sprintf("%v", flags[flagKey])
 				argUpdated := false
 				for argIndex, existingArg := range container.Args {
-					if existingArg == expectedArg {
-						argValueIndex := argIndex + 1
-						if len(container.Args) > argValueIndex {
-							container.Args[argValueIndex] = argStringValue
-						} else {
-							container.Args = append(container.Args, argStringValue)
-						}
+					if strings.HasPrefix(existingArg, expectedArg) {
+						container.Args[argIndex] = fmt.Sprintf("%s=%s", expectedArg, argStringValue)
 						argUpdated = true
 						break
 					}
 				}
 				if !argUpdated {
-					container.Args = append(container.Args, expectedArg, argStringValue)
+					container.Args = append(container.Args, fmt.Sprintf("%s=%s", expectedArg, argStringValue))
 				}
 			}
 			dep.Spec.Template.Spec.Containers[containerIndex] = container

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
@@ -89,10 +89,10 @@ func TestUpdatePerformanceFlagsInDeployment(t *testing.T) {
 	depExpected.Spec.Template.Spec.Containers[1].Args = []string{
 		"-flag1", "v1",
 		"-flag2", "v2",
-		"-disable-ha", "true",
-		"-kube-api-burst", "33",
-		"-kube-api-qps", "40.03",
-		"-threads-per-controller", "3",
+		"-disable-ha=true",
+		"-kube-api-burst=33",
+		"-kube-api-qps=40.03",
+		"-threads-per-controller=3",
 	}
 
 	// convert to unstructured object


### PR DESCRIPTION
This will fix the issue of args getting passed to container as format 'key value', instead it will now get passed to container as format 'key=value'. This will eliminate the case where 'key value' is not working for boolean flags

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Pass the args to container as key=value
```