### PR TITLE
support TEKTON_HUB_API and ARTIFACT_HUB_API environment in tekton-pipelines-remote-resolvers controller

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -358,7 +358,13 @@ spec:
       server-url: localhost.com
     hub-resolver-config:
       default-tekton-hub-catalog: tekton
+      tekton-hub-api: "https://my-custom-tekton-hub.example.com"
+      artifact-hub-api: "https://my-custom-artifact-hub.example.com"
 ```
+Under the `hub-resolver-config`, the `tekton-hub-api` and `artifact-hub-api` will be passed as environment variable into `tekton-pipelines-remote-resolvers` controller.<br>
+In the deployment the environment name will be converted as follows,
+* `tekton-hub-api` => `TEKTON_HUB_API` 
+* `artifact-hub-api` => `ARTIFACT_HUB_API`
 
 ### OpenShiftPipelinesAsCode
 

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
@@ -22,7 +22,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/pipeline/test/diff"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -128,4 +130,234 @@ func TestGetSortedKeys(t *testing.T) {
 
 	out := getSortedKeys(in)
 	assert.Equal(t, true, reflect.DeepEqual(out, expectedOut))
+}
+
+func TestUpdateResolverConfigEnvironmentsInDeployment(t *testing.T) {
+	pipelineCR := &v1alpha1.TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipeline",
+			Namespace: "xyz",
+		},
+	}
+
+	depInput := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipelinesRemoteResolversControllerDeployment,
+			Namespace: "xyz",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "hello",
+							Image: "xyz",
+						},
+						// the container index 1 is used in tests
+						{
+							Name:  pipelinesRemoteResolverControllerContainer,
+							Image: "xyz",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		getPipelineCR         func() *v1alpha1.TektonPipeline
+		getDeployment         func() *appsv1.Deployment
+		getExpectedDeployment func() *appsv1.Deployment
+	}{
+		// verify with empty config
+		{
+			name:          "test-with-empty",
+			getPipelineCR: func() *v1alpha1.TektonPipeline { return pipelineCR.DeepCopy() },
+			getDeployment: func() *appsv1.Deployment { return depInput.DeepCopy() },
+			getExpectedDeployment: func() *appsv1.Deployment {
+				return depInput.DeepCopy()
+			},
+		},
+
+		// verifies with hub api url
+		{
+			name: "test-with-hup-api-url",
+			getPipelineCR: func() *v1alpha1.TektonPipeline {
+				cr := pipelineCR.DeepCopy()
+				cr.Spec.ResolversConfig.HubResolverConfig = map[string]string{
+					resolverEnvKeyTektonHubApi: "http://localhost:9090/api",
+				}
+				return cr
+			},
+			getDeployment: func() *appsv1.Deployment { return depInput.DeepCopy() },
+			getExpectedDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					{
+						Name:  "TEKTON_HUB_API",
+						Value: "http://localhost:9090/api",
+					},
+				}
+				return dep
+			},
+		},
+
+		// verifies with hub api and artifact api urls
+		{
+			name: "test-with-hup-all-url",
+			getPipelineCR: func() *v1alpha1.TektonPipeline {
+				cr := pipelineCR.DeepCopy()
+				cr.Spec.ResolversConfig.HubResolverConfig = map[string]string{
+					resolverEnvKeyTektonHubApi:   "http://localhost:9090/api",
+					resolverEnvKeyArtifactHubApi: "https://artifact.example.com:8443",
+				}
+				return cr
+			},
+			getDeployment: func() *appsv1.Deployment { return depInput.DeepCopy() },
+			getExpectedDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					// order(name) is important
+					{
+						Name:  "ARTIFACT_HUB_API",
+						Value: "https://artifact.example.com:8443",
+					},
+					{
+						Name:  "TEKTON_HUB_API",
+						Value: "http://localhost:9090/api",
+					},
+				}
+				return dep
+			},
+		},
+
+		// verifies with existing environment
+		{
+			name: "test-with-existing-env-and-hup-url",
+			getPipelineCR: func() *v1alpha1.TektonPipeline {
+				cr := pipelineCR.DeepCopy()
+				cr.Spec.ResolversConfig.HubResolverConfig = map[string]string{
+					resolverEnvKeyTektonHubApi: "http://localhost:9090/api",
+				}
+				return cr
+			},
+			getDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					{
+						Name:  "CUSTOM_ENV",
+						Value: "hello",
+					},
+					{
+						Name:  "TEKTON_HUB_API",
+						Value: "https://hub.tekton.dev",
+					},
+				}
+				return dep
+			},
+			getExpectedDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					{
+						Name:  "CUSTOM_ENV",
+						Value: "hello",
+					},
+					{
+						Name:  "TEKTON_HUB_API",
+						Value: "http://localhost:9090/api",
+					},
+				}
+				return dep
+			},
+		},
+
+		// verifies with existing hub api env in different form
+		{
+			name: "test-with-existing-env-and-hup-url-from-config",
+			getPipelineCR: func() *v1alpha1.TektonPipeline {
+				cr := pipelineCR.DeepCopy()
+				cr.Spec.ResolversConfig.HubResolverConfig = map[string]string{
+					resolverEnvKeyTektonHubApi: "http://localhost:9090/api",
+				}
+				return cr
+			},
+			getDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					{
+						Name:  "CUSTOM_ENV",
+						Value: "hello",
+					},
+					{
+						Name: "TEKTON_HUB_API",
+						ValueFrom: &corev1.EnvVarSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								Key: "tekton-hub-api",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "custom-config-map",
+								},
+							},
+						},
+					},
+					{
+						Name:  "ARTIFACT_HUB_API",
+						Value: "https://artifacthub.io",
+					},
+				}
+				return dep
+			},
+			getExpectedDeployment: func() *appsv1.Deployment {
+				dep := depInput.DeepCopy()
+				dep.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{
+					{
+						Name:  "CUSTOM_ENV",
+						Value: "hello",
+					},
+					{
+						Name:  "TEKTON_HUB_API",
+						Value: "http://localhost:9090/api",
+					},
+					{
+						Name:  "ARTIFACT_HUB_API",
+						Value: "https://artifacthub.io",
+					},
+				}
+				return dep
+			},
+		},
+	}
+
+	// execute tests
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pipelineCR := test.getPipelineCR()
+			depInput := test.getDeployment()
+
+			// convert to unstructured object
+			jsonBytes, err := json.Marshal(&depInput)
+			assert.NilError(t, err)
+			ud := &unstructured.Unstructured{}
+			err = json.Unmarshal(jsonBytes, ud)
+			assert.NilError(t, err)
+
+			// apply transformer
+			transformer := updateResolverConfigEnvironmentsInDeployment(pipelineCR)
+			err = transformer(ud)
+			assert.NilError(t, err)
+
+			// get transformed deployment
+			depOut := &appsv1.Deployment{}
+			err = apimachineryRuntime.DefaultUnstructuredConverter.FromUnstructured(ud.Object, depOut)
+			assert.NilError(t, err)
+
+			depExpected := test.getExpectedDeployment()
+			if d := cmp.Diff(depOut, depExpected); d != "" {
+				t.Errorf("Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Changes
With this PR, `TEKTON_HUB_API` and `ARTIFACT_HUB_API` environment variables are exposed into `tekton-pipelines-remote-resolvers` controller via TektonConfig CR.

These values will be included in the tektonConfig CR as follows,
```yaml
apiVersion: operator.tekton.dev/v1alpha1
kind: TektonConfig
metadata:
  name: config
spec:
  pipeline:
    enable-hub-resolver: true
    hub-resolver-config:
      tekton-hub-api: "https://my-custom-tekton-hub.example.com"
      artifact-hub-api: "https://my-custom-artifact-hub.example.com"
```

Fixes: [SRVKP-3167](https://issues.redhat.com/browse/SRVKP-3167) - Expose TEKTON_HUB_API variable in the tektonconfig.

### Supporting documents
* https://github.com/tektoncd/pipeline/blob/main/docs/hub-resolver.md#configuring-the-hub-api-endpoint

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Support added to `TEKTON_HUB_API` and `ARTIFACT_HUB_API` environment variables under `tektonConfig.spec.pipeline.hub-resolver-config`
```
