### PR TITLE
Fixes the namespaces while getting chains-config configmap and order of installerset creation in chains

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -219,7 +219,7 @@ func (r *Reconciler) markUpgrade(ctx context.Context, tc *v1alpha1.TektonConfig)
 	tc.SetLabels(labels)
 
 	var chain v1alpha1.ChainProperties
-	cm, err := r.kubeClientSet.CoreV1().ConfigMaps(tc.GetNamespace()).Get(ctx, "chains-config", metav1.GetOptions{})
+	cm, err := r.kubeClientSet.CoreV1().ConfigMaps(tc.Spec.GetTargetNamespace()).Get(ctx, "chains-config", metav1.GetOptions{})
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			chain = v1alpha1.ChainProperties{}


### PR DESCRIPTION
* Fixes the namespaces while getting chains-config configmap
* This patch also fixes the order of creation of installerset in the chain reconciler i.e. first installs the `chains-config` configMap installerset and then `chain` installerset so that deployment does not fail

Related to this PR as namespace was not added properly to fetch the configMap in this PR --> https://github.com/tektoncd/operator/pull/1587

Signed-off-by: Puneet Punamiya ppunamiy@redhat.com

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
