### PR TITLE
chore: Support hostNetwork and dnsPolicy and allow to change webhook port

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -158,6 +158,15 @@ spec:
       labels:
         {{- include "tekton-operator.webhook.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.webhook.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- else }}
+      hostNetwork: false
+      {{- with .Values.webhook.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -182,7 +191,7 @@ spec:
           resources:
             {{- toYaml .Values.webhook.resources | nindent 12 }}
           ports:
-            - containerPort: 8443
+            - containerPort: {{ .Values.webhook.httpsWebhookPort }}
               name: https-webhook
       serviceAccountName: {{ include "tekton-operator.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -183,6 +183,8 @@ spec:
               value: {{ include "tekton-operator.fullname" . }}-webhook
             - name: WEBHOOK_SECRET_NAME
               value: {{ .Values.webhook.certSecret.name | default (include "tekton-operator.fullname" .) }}-webhook-certs
+            - name: WEBHOOK_PORT
+              value: {{ .Values.webhook.httpsWebhookPort | quote }}
             - name: METRICS_DOMAIN
               value: {{ .Values.service.metricsDomain }}
           image: {{ include "tekton-operator.webhook-image" . }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
     - name: https-webhook
       port: 443
-      targetPort: 8443
+      targetPort: {{ .Values.webhook.httpsWebhookPort }}
   selector:
   {{- include "tekton-operator.webhook.selectorLabels" . | nindent 4 }}
 ---

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,6 +45,9 @@ operator:
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:
+  hostNetwork: false
+  dnsPolicy: ""
+  httpsWebhookPort: 8443
   image:
     # Container image for Tekton operator webhook. Default value depends on the flavor (k8s/openshift).
     repository: ""

--- a/cmd/kubernetes/webhook/main.go
+++ b/cmd/kubernetes/webhook/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/tektoncd/operator/pkg/webhook"
 	"knative.dev/pkg/injection"
@@ -39,10 +41,20 @@ func main() {
 		secretName = "tekton-operator-webhook-certs"
 	}
 
+	portStr := os.Getenv("WEBHOOK_PORT")
+	if portStr == "" {
+		portStr = "8443"
+	}
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PORT '%s' is not valid\n", portStr)
+		return
+	}
+
 	//Set up a signal context with our webhook options
 	ctx := kwebhook.WithOptions(signals.NewContext(), kwebhook.Options{
 		ServiceName: serviceName,
-		Port:        8443,
+		Port:        portNum,
 		SecretName:  secretName,
 	})
 	cfg := injection.ParseAndGetRESTConfigOrDie()


### PR DESCRIPTION
# Reason

In EKS, it is not possible to place a daemonset in the ControlPlane.
If you want to use webhook in this configuration, you need to enable hostNetwork.

If you use hostNetwork, you must make sure that it does not overlap with another webhook pod's port.
Therefore, it is necessary to be able to change the port in webhook.httpsWebhookPort.

# Changes

Add `webhook.hostNetwork` and `webhook.dnsPolicy` and `httpsWebhookPort` helm values.

dnsPolicy Conforming to the recommended rules.

https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

> For Pods running with hostNetwork, you should explicitly set its DNS policy to "ClusterFirstWithHostNet".

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add `webhook.hostNetwork` and `webhook.dnsPolicy` and `httpsWebhookPort` helm values.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
