### PR TITLE
exclude deployments replicas from hash compute

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -328,7 +328,7 @@ func (i *installer) ensureDeployment(expected *unstructured.Unstructured) error 
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, existingDeployment); err != nil {
 			return err
 		}
-		existingHashValue, err := hash.Compute(existingDeployment.Spec)
+		existingHashValue, err := computeDeploymentHash(*existingDeployment)
 		if err != nil {
 			return fmt.Errorf("failed to compute hash value of existing deployment, name:%s, error: %v", existing.GetName(), err)
 		}


### PR DESCRIPTION
# Changes

#1665 adds fix to revert local deployment changes. However the replicas value should be ignored on hash compute. This PR addresses that. Since the replicas count will be controlled externally (not by operator). 

There is an outstanding PR #1656 to take the replicas control over to operator. till then we need this fix in the main branch.

**NOTE:** this patch should be cherry picked if we cherry pick #1665 to released versions.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```