### PR TITLE
Reject incorrect SCC configuration

### DIFF
--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -14,7 +14,7 @@ metadata:
   name: tekton-operators-proxy-admin
 rules:
   - apiGroups: [""]
-    resources: ["pods", "configmaps", "services", "events"]
+    resources: ["pods", "configmaps", "services", "events", "namespaces"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "deployments/finalizers"]
@@ -26,6 +26,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["get", "list", "watch"]
 
 ---
 
@@ -180,3 +183,21 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: annotation.operator.tekton.dev
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: namespace.operator.tekton.dev
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: tekton-operator-proxy-webhook
+      namespace: tekton-pipelines
+  failurePolicy: Fail
+  sideEffects: None
+  name: namespace.operator.tekton.dev

--- a/cmd/openshift/proxy-webhook/main.go
+++ b/cmd/openshift/proxy-webhook/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"context"
 
+	"github.com/tektoncd/operator/pkg/reconciler/openshift/namespace"
+
 	"github.com/tektoncd/operator/pkg/reconciler/openshift/annotation"
 	"github.com/tektoncd/operator/pkg/reconciler/proxy"
 	"knative.dev/pkg/configmap"
@@ -54,5 +56,6 @@ func main() {
 		certificates.NewController,
 		proxy.NewProxyDefaultingAdmissionController,
 		newAnnotationDefaultingAdmissionController,
+		namespace.NewNamespaceAdmissionController,
 	)
 }

--- a/pkg/common/scc.go
+++ b/pkg/common/scc.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	sccSort "github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/util/sort"
+	security "github.com/openshift/client-go/security/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/logging"
+)
+
+func GetSecurityClient(ctx context.Context) *security.Clientset {
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		logging.FromContext(ctx).Panic(err)
+	}
+	securityClient, err := security.NewForConfig(restConfig)
+	if err != nil {
+		logging.FromContext(ctx).Panic(err)
+	}
+	return securityClient
+}
+
+func VerifySCCExists(ctx context.Context, sccName string, securityClient *security.Clientset) error {
+	_, err := securityClient.SecurityV1().SecurityContextConstraints().Get(ctx, sccName, metav1.GetOptions{})
+	return err
+}
+
+func GetPrioritizedSCCList(ctx context.Context, securityClient *security.Clientset) ([]*securityv1.SecurityContextConstraints, error) {
+	logger := logging.FromContext(ctx)
+	sccList, err := securityClient.SecurityV1().SecurityContextConstraints().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.Error("Error listing SCCs")
+		return nil, err
+	}
+	var sccPointerList []*securityv1.SecurityContextConstraints
+	for i := range sccList.Items {
+		sccPointerList = append(sccPointerList, &sccList.Items[i])
+	}
+
+	// This will sort the sccPointerList in order of priority
+	// ByPriority implements the sort interface so sort.Sort() can be run on it.
+	sort.Sort(sccSort.ByPriority(sccPointerList))
+
+	sccLog := "SCCs sorted by priority:"
+	for _, sortedSCC := range sccPointerList {
+		sccLog = fmt.Sprintf("%s %s", sccLog, sortedSCC.Name)
+	}
+	logger.Info(sccLog)
+	return sccPointerList, nil
+}
+
+func SCCAEqualORPriorityOverB(prioritizedSCCList []*securityv1.SecurityContextConstraints, sccA string, sccB string) (bool, error) {
+	var sccAIndex, sccBIndex int
+	var sccAFound, sccBFound bool
+	for i, scc := range prioritizedSCCList {
+		if scc.Name == sccA {
+			sccAFound = true
+			sccAIndex = i
+		}
+		if scc.Name == sccB {
+			sccBFound = true
+			sccBIndex = i
+		}
+		if sccAFound && sccBFound {
+			break
+		}
+	}
+
+	if !sccAFound || !sccBFound {
+		return false, fmt.Errorf("SCCs not found while looking up priorities, found SCC %s: %t, found SCC %s: %t", sccA, sccAFound, sccB, sccBFound)
+	}
+
+	return sccAIndex <= sccBIndex, nil
+}

--- a/pkg/common/scc_test.go
+++ b/pkg/common/scc_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tektonconfig
+package common
 
 import (
 	"testing"
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_sccAEqualORPriorityOverB(t *testing.T) {
+func Test_SCCAEqualORPriorityOverB(t *testing.T) {
 	type args struct {
 		prioritizedSCCList []*securityv1.SecurityContextConstraints
 		sccA               string
@@ -161,7 +161,7 @@ func Test_sccAEqualORPriorityOverB(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := sccAEqualORPriorityOverB(test.args.prioritizedSCCList, test.args.sccA, test.args.sccB)
+			got, err := SCCAEqualORPriorityOverB(test.args.prioritizedSCCList, test.args.sccA, test.args.sccB)
 			if (err != nil) != test.wantErr {
 				t.Errorf("sccAEqualORPriorityOverB() error = %v, expected %v", err, test.wantErr)
 				return

--- a/pkg/reconciler/openshift/const.go
+++ b/pkg/reconciler/openshift/const.go
@@ -3,4 +3,6 @@ package openshift
 const (
 	OperandOpenShiftPipelinesAddons = "openshift-pipelines-addons"
 	OperandOpenShiftPipelineAsCode  = "openshift-pipeline-as-code"
+	// NamespaceSCCAnnotation is used to set SCC for a given namespace
+	NamespaceSCCAnnotation = "operator.tekton.dev/scc"
 )

--- a/pkg/reconciler/openshift/namespace/controller.go
+++ b/pkg/reconciler/openshift/namespace/controller.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+
+	"github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
+	"knative.dev/pkg/configmap"
+
+	// Injection stuff
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/validatingwebhookconfiguration"
+	"knative.dev/pkg/controller"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+)
+
+func NewNamespaceAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+
+	return NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"namespace.operator.tekton.dev",
+
+		// The path on which to serve the webhook.
+		"/namespace-validation",
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			return ctx
+		},
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionController(
+	ctx context.Context,
+	name, path string,
+	wc func(context.Context) context.Context,
+	disallowUnknownFields bool,
+) *controller.Impl {
+
+	client := kubeclient.Get(ctx)
+	vwhInformer := vwhinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
+	options := webhook.GetOptions(ctx)
+	tektonConfigInformer := tektonconfig.Get(ctx)
+
+	key := types.NamespacedName{Name: name}
+
+	wh := &reconciler{
+		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
+			// Have this reconciler enqueue our singleton whenever it becomes leader.
+			PromoteFunc: func(bkt pkgreconciler.Bucket, enq func(pkgreconciler.Bucket, types.NamespacedName)) error {
+				enq(bkt, key)
+				return nil
+			},
+		},
+
+		key:  key,
+		path: path,
+
+		withContext:           wc,
+		disallowUnknownFields: disallowUnknownFields,
+		secretName:            options.SecretName,
+
+		client:             client,
+		vwhlister:          vwhInformer.Lister(),
+		secretlister:       secretInformer.Lister(),
+		tektonConfigLister: tektonConfigInformer.Lister(),
+	}
+
+	logger := logging.FromContext(ctx)
+	c := controller.NewContext(ctx, wh, controller.ControllerOptions{WorkQueueName: "NamespaceAdmissionWebhook", Logger: logger})
+
+	// Reconcile when the named ValidatingWebhookConfiguration changes.
+	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithName(name),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	return c
+}

--- a/pkg/reconciler/openshift/namespace/namespace.go
+++ b/pkg/reconciler/openshift/namespace/namespace.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tektoncd/operator/pkg/client/listers/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/common"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/markbates/inflect"
+	"go.uber.org/zap"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+)
+
+// reconciler implements the AdmissionController for resources
+type reconciler struct {
+	webhook.StatelessAdmissionImpl
+	pkgreconciler.LeaderAwareFuncs
+
+	key  types.NamespacedName
+	path string
+
+	withContext func(context.Context) context.Context
+
+	client             kubernetes.Interface
+	vwhlister          admissionlisters.ValidatingWebhookConfigurationLister
+	secretlister       corelisters.SecretLister
+	tektonConfigLister v1alpha1.TektonConfigLister
+
+	disallowUnknownFields bool
+	secretName            string
+}
+
+var _ controller.Reconciler = (*reconciler)(nil)
+var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
+var _ webhook.AdmissionController = (*reconciler)(nil)
+var _ webhook.StatelessAdmissionController = (*reconciler)(nil)
+
+// Reconcile implements controller.Reconciler
+func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+
+	if !ac.IsLeaderFor(ac.key) {
+		logger.Debugf("Skipping key %q, not the leader.", ac.key)
+		return nil
+	}
+
+	// Look up the webhook secret, and fetch the CA cert bundle.
+	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)
+	if err != nil {
+		logger.Errorw("Error fetching secret", zap.Error(err))
+		return err
+	}
+	caCert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return fmt.Errorf("secret %q is missing %q key", ac.secretName, certresources.CACert)
+	}
+
+	// Reconcile the webhook configuration.
+	return ac.reconcileValidatingWebhook(ctx, caCert)
+}
+
+// Path implements AdmissionController
+func (ac *reconciler) Path() string {
+	return ac.path
+}
+
+// Admit implements AdmissionController
+func (ac *reconciler) Admit(ctx context.Context, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	if ac.withContext != nil {
+		ctx = ac.withContext(ctx)
+	}
+
+	logger := logging.FromContext(ctx)
+
+	// Need to handle both, create and update operations for a namespace
+	switch request.Operation {
+	case admissionv1.Create, admissionv1.Update:
+	default:
+		logger.Info("Unhandled webhook operation, letting it through ", request.Operation)
+		return &admissionv1.AdmissionResponse{Allowed: true}
+	}
+
+	isAllowed, status, err := ac.admissionAllowed(ctx, request)
+	if err != nil {
+		return webhook.MakeErrorStatus("admission failed for namespace %v", err)
+	}
+
+	// Something in status means that admission isn't allowed
+	if status != nil {
+		return &admissionv1.AdmissionResponse{
+			// isAllowed should be false here always
+			Allowed: isAllowed,
+			Result:  status,
+		}
+	}
+
+	return &admissionv1.AdmissionResponse{
+		// At this point, isAllowed should always be true
+		Allowed: isAllowed,
+	}
+}
+
+func (ac *reconciler) admissionAllowed(ctx context.Context, req *admissionv1.AdmissionRequest) (bool, *metav1.Status, error) {
+	kind := req.Kind
+	namespaceRawBytes := req.Object.Raw
+
+	// Why, oh why are these different types...
+	gvk := schema.GroupVersionKind{
+		Group:   kind.Group,
+		Version: kind.Version,
+		Kind:    kind.Kind,
+	}
+
+	logger := logging.FromContext(ctx)
+	if gvk.Group != "" || gvk.Version != "v1" || gvk.Kind != "Namespace" {
+		logger.Error("Unhandled kind: ", gvk)
+		return false, nil, fmt.Errorf("unhandled kind: %v", gvk)
+	}
+
+	// nil values denote absence of `old` (create) or `new` (delete) objects.
+	var namespaceObject corev1.Namespace
+
+	if len(namespaceRawBytes) != 0 {
+		newDecoder := json.NewDecoder(bytes.NewBuffer(namespaceRawBytes))
+		if ac.disallowUnknownFields {
+			newDecoder.DisallowUnknownFields()
+		}
+		if err := newDecoder.Decode(&namespaceObject); err != nil {
+			return false, nil, fmt.Errorf("cannot decode incoming new object: %w", err)
+		}
+	}
+
+	nsSCC := namespaceObject.Annotations[openshift.NamespaceSCCAnnotation]
+	// If no annotation in namespace, then nothing to do here
+	if nsSCC == "" {
+		return true, nil, nil
+	}
+
+	logger.Infof("Trying to admit namespace: %s with SCC: %s", namespaceObject.Name, nsSCC)
+
+	tc, err := ac.tektonConfigLister.Get("config")
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Check if the SCC requested in namespace is in line with the maxAllowed SCC in TektonConfig
+	maxAllowedSCC := tc.Spec.Platforms.OpenShift.SCC.MaxAllowed
+
+	// If no maxAllowed is set, no problem
+	if maxAllowedSCC == "" {
+		logger.Infof("Namespace %s validation: no maxAllowed SCC set in TektonConfig", namespaceObject.Name)
+		return true, nil, nil
+	}
+
+	securityClient := common.GetSecurityClient(ctx)
+
+	prioritizedSCCList, err := common.GetPrioritizedSCCList(ctx, securityClient)
+	if err != nil {
+		return false, nil, err
+	}
+
+	isPriority, err := common.SCCAEqualORPriorityOverB(prioritizedSCCList, maxAllowedSCC, nsSCC)
+	if err != nil {
+		return false, nil, err
+	}
+	logger.Infof("Does SCC: %s have >= priority than SCC: %s? %t", maxAllowedSCC, nsSCC, isPriority)
+	if !isPriority {
+		prioErr := fmt.Sprintf("namespace: %s has requested SCC: %s, but it has a higher priority than 'maxAllowed' SCC: %s", namespaceObject.Name, nsSCC, maxAllowedSCC)
+		return false, &metav1.Status{
+			Status:  "Failure",
+			Message: prioErr,
+		}, nil
+	}
+
+	return true, nil, nil
+}
+
+func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []byte) error {
+	logger := logging.FromContext(ctx)
+
+	pluralNS := strings.ToLower(inflect.Pluralize("Namespace"))
+	rules := []admissionregistrationv1.RuleWithOperations{
+		{
+			Operations: []admissionregistrationv1.OperationType{
+				admissionregistrationv1.Create,
+				admissionregistrationv1.Update,
+			},
+			Rule: admissionregistrationv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{pluralNS, pluralNS + "/status"},
+			},
+		},
+	}
+
+	configuredWebhook, err := ac.vwhlister.Get(ac.key.Name)
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %w", err)
+	}
+
+	webhook := configuredWebhook.DeepCopy()
+
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
+		}
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					// "control-plane" is added to support Azure's AKS, otherwise the controllers fight.
+					// See knative/pkg#1590 for details.
+					Key:      "control-plane",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				},
+			},
+		}
+
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
+		}
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %w", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		vwhclient := ac.client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+		if _, err := vwhclient.Update(ctx, webhook, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update webhook: %w", err)
+		}
+	} else {
+		logger.Info("Webhook is valid")
+	}
+	return nil
+}

--- a/pkg/reconciler/openshift/tektonconfig/common.go
+++ b/pkg/reconciler/openshift/tektonconfig/common.go
@@ -21,10 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	security "github.com/openshift/client-go/security/clientset/versioned"
-	"k8s.io/client-go/rest"
-	"knative.dev/pkg/logging"
-
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
@@ -140,18 +136,4 @@ func checkIfInstallerSetExist(ctx context.Context, oc versioned.Interface, relVe
 		return nil, err
 	}
 	return nil, v1alpha1.RECONCILE_AGAIN_ERR
-}
-
-// Note: this should become a generic func going forward when we start adding
-// more OpenShift types
-func getSecurityClient(ctx context.Context) *security.Clientset {
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		logging.FromContext(ctx).Panic(err)
-	}
-	securityClient, err := security.NewForConfig(restConfig)
-	if err != nil {
-		logging.FromContext(ctx).Panic(err)
-	}
-	return securityClient
 }

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	pkgCommon "github.com/tektoncd/operator/pkg/common"
+
 	mf "github.com/manifestival/manifestival"
 	security "github.com/openshift/client-go/security/clientset/versioned"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -47,7 +49,7 @@ func OpenShiftExtension(ctx context.Context) common.Extension {
 		kubeClientSet:     kubeclient.Get(ctx),
 		rbacInformer:      rbacInformer.Get(ctx),
 		nsInformer:        namespaceinformer.Get(ctx),
-		securityClientSet: getSecurityClient(ctx),
+		securityClientSet: pkgCommon.GetSecurityClient(ctx),
 	}
 }
 


### PR DESCRIPTION
# Changes

This commit rejects any conflicting SCC configuration via a separate
namespace admission webhook, and tektonconfig validation.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
