### PR TITLE
Adding events image env for openshift

### DIFF
--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -40,6 +40,13 @@ image-substitutions:
       envKeys:
       # the container name for resolvers controller is "controller" :)
       - IMAGE_PIPELINES_CONTROLLER
+- image: registry.redhat.io/openshift-pipelines/pipelines-events-rhel8@
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator-lifecycle
+        envKeys:
+          - IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
 - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@
   replaceLocations:
     envTargets:


### PR DESCRIPTION
# Changes

Adding environment key to `tekton-events-controller` image in OpenShift under `openshift-pipelines-operator` deployment (container: `openshift-pipelines-operator-lifecycle`).

Deployment name: `tekton-events-controller`
Container name: `tekton-events-controller`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
