### PR TITLE
allow operator to manage resources in pipelinesascode.tekton.dev group

### DIFF
--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -218,6 +218,7 @@ rules:
   - tekton.dev
   - triggers.tekton.dev
   - operator.tekton.dev
+  - pipelinesascode.tekton.dev
   resources:
   - '*'
   verbs:

--- a/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
@@ -19,6 +19,7 @@ package upgrade
 import (
 	"context"
 
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	upgrade "github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/helper"
 	"go.uber.org/zap"
@@ -43,7 +44,6 @@ func upgradeStorageVersion(ctx context.Context, logger *zap.SugaredLogger, k8sCl
 		"interceptors.triggers.tekton.dev",
 		"pipelineruns.tekton.dev",
 		"pipelines.tekton.dev",
-		"repositories.pipelinesascode.tekton.dev",
 		"resolutionrequests.resolution.tekton.dev",
 		"taskruns.tekton.dev",
 		"tasks.tekton.dev",
@@ -51,6 +51,10 @@ func upgradeStorageVersion(ctx context.Context, logger *zap.SugaredLogger, k8sCl
 		"triggers.triggers.tekton.dev",
 		"triggertemplates.triggers.tekton.dev",
 		"verificationpolicies.tekton.dev",
+	}
+
+	if v1alpha1.IsOpenShiftPlatform() {
+		crdGroups = append(crdGroups, "repositories.pipelinesascode.tekton.dev")
 	}
 
 	migrator := storageversion.NewMigrator(


### PR DESCRIPTION
# Changes

PR #1675 introduces storage version migration and it lists and patches resources under `pipelinesascode.tekton.dev`
Operator needs permission to list and patch resources under `pipelinesascode.tekton.dev` group.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```