### PR TITLE
Fix the version configmap for results

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/controller.go
+++ b/pkg/reconciler/kubernetes/tektonresult/controller.go
@@ -34,7 +34,7 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-const versionConfigMap = "results-info"
+const versionConfigMap = "tekton-results-info"
 
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events


### PR DESCRIPTION
The results configmap is named as tekton-results-info instead of results-info

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
