### PR TITLE
Filter service and cm of Postgres for externalDB

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/filter.go
+++ b/pkg/reconciler/kubernetes/tektonresult/filter.go
@@ -18,18 +18,18 @@ package tektonresult
 
 import (
 	mf "github.com/manifestival/manifestival"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 )
 
 const (
-	statefulSetDB = "tekton-results-postgres"
+	statefulSetDB     = "tekton-results-postgres"
+	servicePostgresDB = "tekton-results-postgres-service"
 )
 
-func filterExternalDB(isExternalDB bool) mf.Predicate {
-	return func(u *unstructured.Unstructured) bool {
-		if u.GetKind() != "StatefulSet" || u.GetName() != statefulSetDB || !isExternalDB {
-			return true
-		}
-		return false
+func (r *Reconciler) filterExternalDB(tr *v1alpha1.TektonResult) {
+	if tr.Spec.IsExternalDB {
+		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("StatefulSet"), mf.ByName(statefulSetDB))))
+		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("ConfigMap"), mf.ByName(configPostgresDB))))
+		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("Service"), mf.ByName(servicePostgresDB))))
 	}
 }

--- a/pkg/reconciler/kubernetes/tektonresult/filter_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/filter_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"gotest.tools/v3/assert"
 )
 
@@ -29,9 +30,19 @@ func Test_filterExternalDB(t *testing.T) {
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 	num := len(manifest.Resources())
-	assert.Equal(t, num, 2)
+	assert.Equal(t, num, 4)
 	assert.Equal(t, manifest.Resources()[0].GetName(), statefulSetDB)
-	manifest = manifest.Filter(filterExternalDB(true))
+	r := &Reconciler{
+		manifest: manifest,
+	}
+	r.filterExternalDB(&v1alpha1.TektonResult{
+		Spec: v1alpha1.TektonResultSpec{
+			ResultsAPIProperties: v1alpha1.ResultsAPIProperties{
+				IsExternalDB: true,
+			},
+		},
+	})
+	manifest = r.manifest
 	num = len(manifest.Resources())
 	assert.Equal(t, num, 1)
 	assert.Equal(t, manifest.Resources()[0].GetName(), statefulSetDB+"-external")

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -224,12 +224,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 
 		if lastAppliedHash != expectedSpecHash {
 
+			r.filterExternalDB(tr)
+
 			if err := r.transform(ctx, &r.manifest, tr); err != nil {
 				logger.Error("manifest transformation failed:  ", err)
 				return err
 			}
-
-			r.manifest = r.manifest.Filter(filterExternalDB(tr.Spec.IsExternalDB))
 
 			// Update the spec hash
 			current := installedTIS.GetAnnotations()

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/db-statefulset.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/db-statefulset.yaml
@@ -113,3 +113,33 @@ spec:
         resources:
           requests:
             storage: 1Gi
+---
+apiVersion: v1
+data:
+  POSTGRES_DB: tekton-results
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-results-postgres
+    app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/version: v0.8.0
+  name: tekton-results-postgres
+  namespace: tekton-pipelines
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-results-postgres
+    app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/version: v0.8.0
+  name: tekton-results-postgres-service
+  namespace: tekton-pipelines
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    app.kubernetes.io/name: tekton-results-postgres
+    app.kubernetes.io/version: v0.8.0
+  type: NodePort


### PR DESCRIPTION
Refactor Filtering of Results DB. Also, remove crs which aren't needed when we use external DB.

Fixes #1712
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
