### PR TITLE
Fix TektonResult CR not showing version

### DIFF
--- a/pkg/reconciler/common/initcontroller.go
+++ b/pkg/reconciler/common/initcontroller.go
@@ -112,7 +112,7 @@ func (ctrl Controller) fetchSourceManifests(ctx context.Context, opts PayloadOpt
 	case "chains":
 		var chain v1alpha1.TektonChain
 		return AppendTarget(ctx, ctrl.Manifest, &chain)
-	case "results":
+	case "tekton-results":
 		var results v1alpha1.TektonResult
 		return AppendTarget(ctx, ctrl.Manifest, &results)
 	case "pipelines-as-code":

--- a/pkg/reconciler/kubernetes/tektonresult/installerset.go
+++ b/pkg/reconciler/kubernetes/tektonresult/installerset.go
@@ -28,6 +28,7 @@ import (
 
 func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.TektonResult) (*v1alpha1.TektonInstallerSet, error) {
 
+	r.filterExternalDB(tr)
 	if err := r.transform(ctx, &r.manifest, tr); err != nil {
 		tr.Status.MarkNotReady("transformation failed: " + err.Error())
 		return nil, err

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -276,6 +276,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 func (r *Reconciler) updateTektonResultsStatus(ctx context.Context, tr *v1alpha1.TektonResult, createdIs *v1alpha1.TektonInstallerSet) error {
 	// update the tr with TektonInstallerSet
 	tr.Status.SetTektonInstallerSet(createdIs.Name)
+	tr.Status.SetVersion(r.resultsVersion)
 
 	return nil
 }


### PR DESCRIPTION
Fix TektonResult CR version for `kubectl get TektonResult` and also fixes result's external db filter during creation time.

Fixes #1719 #1717
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
