### PR TITLE
Sort SCCs from most restrictive to least

### DIFF
--- a/pkg/common/scc_test.go
+++ b/pkg/common/scc_test.go
@@ -161,7 +161,7 @@ func Test_SCCAEqualORPriorityOverB(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := SCCAEqualORPriorityOverB(test.args.prioritizedSCCList, test.args.sccA, test.args.sccB)
+			got, err := SCCAMoreRestrictiveThanB(test.args.prioritizedSCCList, test.args.sccA, test.args.sccB)
 			if (err != nil) != test.wantErr {
 				t.Errorf("sccAEqualORPriorityOverB() error = %v, expected %v", err, test.wantErr)
 				return

--- a/pkg/reconciler/openshift/namespace/namespace.go
+++ b/pkg/reconciler/openshift/namespace/namespace.go
@@ -198,18 +198,18 @@ func (ac *reconciler) admissionAllowed(ctx context.Context, req *admissionv1.Adm
 		return true, nil, nil
 	}
 
-	prioritizedSCCList, err := common.GetPrioritizedSCCList(ctx, securityClient)
+	prioritizedSCCList, err := common.GetSCCRestrictiveList(ctx, securityClient)
 	if err != nil {
 		return false, nil, err
 	}
 
-	isPriority, err := common.SCCAEqualORPriorityOverB(prioritizedSCCList, maxAllowedSCC, nsSCC)
+	isPriority, err := common.SCCAMoreRestrictiveThanB(prioritizedSCCList, nsSCC, maxAllowedSCC)
 	if err != nil {
 		return false, nil, err
 	}
-	logger.Infof("Does SCC: %s have >= priority than SCC: %s? %t", maxAllowedSCC, nsSCC, isPriority)
+	logger.Infof("Is maxAllowed SCC: %s less restrictive than namespace SCC: %s? %t", maxAllowedSCC, nsSCC, isPriority)
 	if !isPriority {
-		prioErr := fmt.Sprintf("namespace: %s has requested SCC: %s, but it has a higher priority than 'maxAllowed' SCC: %s", namespaceObject.Name, nsSCC, maxAllowedSCC)
+		prioErr := fmt.Sprintf("namespace: %s has requested SCC: %s, but it is less restrictive than 'maxAllowed' SCC: %s", namespaceObject.Name, nsSCC, maxAllowedSCC)
 		return false, &metav1.Status{
 			Status:  "Failure",
 			Message: prioErr,


### PR DESCRIPTION
This commit changes the order of sorting SCCs from most restrictive to least restrictive.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```