### PR TITLE
wait for ns to be deleted

### DIFF
--- a/test/e2e/common/05_tektonhubdeployment_test.go
+++ b/test/e2e/common/05_tektonhubdeployment_test.go
@@ -110,6 +110,8 @@ func (s *TektonHubTestSuite) SetupTest() {
 	s.logger.Debug("removing the tekton hub cr if any")
 	s.undeploy("")
 	s.undeployExternalDatabase()
+	// wait for target namespace to be deleted
+	time.Sleep(120 * time.Second)
 	err := resources.CreateNamespace(s.clients.KubeClient, s.resourceNames.TargetNamespace)
 	require.NoError(t, err, "create namespace: %s", s.resourceNames.TargetNamespace)
 	s.logger.Debug("test environment ready. starting the actual test")

--- a/test/e2e/common/05_tektonhubdeployment_test.go
+++ b/test/e2e/common/05_tektonhubdeployment_test.go
@@ -111,7 +111,18 @@ func (s *TektonHubTestSuite) SetupTest() {
 	s.undeploy("")
 	s.undeployExternalDatabase()
 	// wait for target namespace to be deleted
-	time.Sleep(120 * time.Second)
+	interval := 3 * time.Second
+	timeout := 2 * time.Minute
+	er := resources.WaitForNamespaceDeletion(s.clients.KubeClient, s.resourceNames.TargetNamespace, interval, timeout)
+	if er != nil {
+		s.logger.Debugw("target namespace already cleanedup",
+			"namespace", s.resourceNames.TargetNamespace,
+		)
+	} else {
+		s.logger.Debugw("target namespace removed",
+			"namespace", s.resourceNames.TargetNamespace,
+		)
+	}
 	err := resources.CreateNamespace(s.clients.KubeClient, s.resourceNames.TargetNamespace)
 	require.NoError(t, err, "create namespace: %s", s.resourceNames.TargetNamespace)
 	s.logger.Debug("test environment ready. starting the actual test")


### PR DESCRIPTION
# Changes
This PR will fix namespace not found issue on e2e testcase. https://github.com/tektoncd/operator/issues/1720 
while running testcase. target namespace is in terminating state, so wait for namespace to deleted properly than create namespace. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
NONE
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
NONE
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
