### PR TITLE
Disable `pipelines-scc` validation for SCC.Default

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -55,8 +55,13 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 
 		// verify default SCC exists on the cluster
-		if err := verifySCCExists(ctx, tc.Spec.Platforms.OpenShift.SCC.Default); err != nil {
-			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("error verifying SCC exists: %s - %v", tc.Spec.Platforms.OpenShift.SCC.Default, err), "spec.platforms.openshift.scc.default"))
+
+		// we don't want to verify pipelines-scc here as it will be created
+		// later when the RBAC reconciler will be run
+		if defaultSCC != PipelinesSCC {
+			if err := verifySCCExists(ctx, tc.Spec.Platforms.OpenShift.SCC.Default); err != nil {
+				errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("error verifying SCC exists: %s - %v", tc.Spec.Platforms.OpenShift.SCC.Default, err), "spec.platforms.openshift.scc.default"))
+			}
 		}
 
 		maxAllowedSCC := tc.Spec.Platforms.OpenShift.SCC.MaxAllowed


### PR DESCRIPTION
This commit disables checking for presence of `pipelines-scc` on the cluster for TektonConfig.Spec....SCC.Default field as `pipelines-scc` is created at a later point in time when the RBAC reconciler is run. Note that this validation will still happen when the SCC priorities are compared when `maxAllowed` or namespace SCC are added.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
