### PR TITLE
Remove Password and sensitive fields from properties

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -89,8 +89,6 @@ metadata:
   name: result
 spec:
   targetNamespace: tekton-pipelines
-  db_user: test
-  db_password: pass
   db_host: localhost
   db_port: 5342
   db_sslmode: false
@@ -102,15 +100,12 @@ spec:
   logs_path: /logs
   tls_hostname_override: localhost
   auth_disable: true
-  s3_bucket_name: test
-  s3_endpoint: aws.com
-  s3_hostname_immutable: sdf
-  s3_region: west
-  s3_access_key_id: 123r
-  s3_secret_access_key: sdfjg
-  s3_multi_part_size: 888mb
   logging_pvc_name: tekton-logs
   secret_name: # optional
+  gcs_creds_secret_name: <value>
+  gcc_creds_secret_key: <value>
+  gcs_bucket_name: <value>
+  is_external_db: false
 ```
 
 These properties are analogous to the one in configmap of tekton results api `tekton-results-api-config` documented at [api.md]:https://github.com/tektoncd/results/blob/4472848a0fb7c1473cfca8b647553170efac78a1/cmd/api/README.md
@@ -190,7 +185,6 @@ If external DB is required, then follow the instructions below:
 - Create a TektonResult CR like below:
 * Add `db_host` with DB url without port.
 * Add `db_port` with your DB port.
-* Add `db_user` username of the DB.
 * Set `is_external_db` to true.
 ```yaml
 apiVersion: operator.tekton.dev/v1alpha1

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -58,8 +58,6 @@ type TektonResultSpec struct {
 // ResultsAPIProperties defines the fields which are configurable for
 // Results API server config
 type ResultsAPIProperties struct {
-	DBUser                string `json:"db_user,omitempty"`
-	DBPassword            string `json:"db_password,omitempty"`
 	DBHost                string `json:"db_host,omitempty"`
 	DBPort                int64  `json:"db_port,omitempty"`
 	DBName                string `json:"db_name,omitempty"`
@@ -75,13 +73,6 @@ type ResultsAPIProperties struct {
 	TLSHostnameOverride   string `json:"tls_hostname_override,omitempty"`
 	AuthDisable           bool   `json:"auth_disable,omitempty"`
 	AuthImpersonate       bool   `json:"auth_impersonate,omitempty"`
-	S3BucketName          string `json:"s3_bucket_name,omitempty"`
-	S3Endpoint            string `json:"s3_endpoint,omitempty"`
-	S3HostnameImmutable   bool   `json:"s3_hostname_immutable,omitempty"`
-	S3Region              string `json:"s3_region,omitempty"`
-	S3AccessKeyID         string `json:"s3_access_key_id,omitempty"`
-	S3SecretAccessKey     string `json:"s3_secret_access_key,omitempty"`
-	S3MultiPartSize       int64  `json:"s3_multi_part_size,omitempty"`
 	LoggingPVCName        string `json:"logging_pvc_name,omitempty"`
 	GcsBucketName         string `json:"gcs_bucket_name,omitempty"`
 	StorageEmulatorHost   string `json:"storage_emulator_host,omitempty"`

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 data:
   config: |-
-    DB_USER=
-    DB_PASSWORD=
     DB_HOST=
     DB_PORT=5432
     SERVER_PORT=8080
@@ -20,13 +18,6 @@ data:
     LOGS_BUFFER_SIZE=32768
     LOGS_PATH=/logs
     STORAGE_EMULATOR_HOST=
-    S3_BUCKET_NAME=
-    S3_ENDPOINT=
-    S3_HOSTNAME_IMMUTABLE=false
-    S3_REGION=
-    S3_ACCESS_KEY_ID=
-    S3_SECRET_ACCESS_KEY=
-    S3_MULTI_PART_SIZE=0
 kind: ConfigMap
 metadata:
   labels:

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -66,8 +66,6 @@ func Test_updateApiConfig(t *testing.T) {
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
 	assert.NilError(t, err)
 	prop := v1alpha1.ResultsAPIProperties{
-		DBUser:                "postgres",
-		DBPassword:            "postgres",
 		DBHost:                "localhost",
 		DBName:                "test",
 		DBPort:                5432,
@@ -83,13 +81,6 @@ func Test_updateApiConfig(t *testing.T) {
 		LogsPath:              "/logs/test",
 		LogsType:              "s3",
 		LogsBufferSize:        12321,
-		S3BucketName:          "test",
-		S3Endpoint:            "test",
-		S3HostnameImmutable:   true,
-		S3Region:              "west",
-		S3AccessKeyID:         "secret",
-		S3SecretAccessKey:     "secret",
-		S3MultiPartSize:       123,
 		StorageEmulatorHost:   "http://localhost:9004",
 	}
 
@@ -99,9 +90,7 @@ func Test_updateApiConfig(t *testing.T) {
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
 	assert.NilError(t, err)
 
-	assert.Equal(t, cm.Data["config"], `DB_USER=postgres
-DB_PASSWORD=postgres
-DB_HOST=localhost
+	assert.Equal(t, cm.Data["config"], `DB_HOST=localhost
 DB_PORT=5432
 SERVER_PORT=12345
 PROMETHEUS_PORT=12347
@@ -117,14 +106,7 @@ LOGS_API=true
 LOGS_TYPE=s3
 LOGS_BUFFER_SIZE=12321
 LOGS_PATH=/logs/test
-STORAGE_EMULATOR_HOST=http://localhost:9004
-S3_BUCKET_NAME=test
-S3_ENDPOINT=test
-S3_HOSTNAME_IMMUTABLE=true
-S3_REGION=west
-S3_ACCESS_KEY_ID=secret
-S3_SECRET_ACCESS_KEY=secret
-S3_MULTI_PART_SIZE=123`)
+STORAGE_EMULATOR_HOST=http://localhost:9004`)
 }
 
 func Test_GoogleCred(t *testing.T) {


### PR DESCRIPTION
These fields come are configured via secrets e.g. #1547
These properties aren't used and the user can mistakenly expose these credentials by trying to set them via CR.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Breaking Change: Delete the existing TektonResultCR and add the following properties via secret:
  db_user: 
  db_password: 
  s3_bucket_name: 
  s3_endpoint: 
  s3_hostname_immutable: 
  s3_region: west
  s3_access_key_id: 
  s3_secret_access_key: 
  s3_multi_part_size: 
```
