### PR TITLE
fix role in openshift and include upgrade status

### DIFF
--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -367,9 +367,12 @@ rules:
   - resolution.tekton.dev
   resources:
   - resolutionrequests
+  - resolutionrequests/status
   verbs:
   - get
   - list
   - watch
   - create
   - delete
+  - update
+  - patch

--- a/pkg/apis/operator/v1alpha1/tektonconfig_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_lifecycle_test.go
@@ -43,6 +43,8 @@ func TestTektonConfigHappyPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tc, PreInstall, t)
 	apistest.CheckConditionOngoing(tc, ComponentsReady, t)
 	apistest.CheckConditionOngoing(tc, PostInstall, t)
+	apistest.CheckConditionOngoing(tc, PreUpgrade, t)
+	apistest.CheckConditionOngoing(tc, PostUpgrade, t)
 
 	// Pre install completes execution
 	tc.MarkPreInstallComplete()
@@ -54,6 +56,20 @@ func TestTektonConfigHappyPath(t *testing.T) {
 
 	tc.MarkPostInstallComplete()
 	apistest.CheckConditionSucceeded(tc, PostInstall, t)
+
+	status := tc.MarkPreUpgradeComplete()
+	assert.Equal(t, true, status)
+	// returns false, as upgrade status already up to date
+	status = tc.MarkPreUpgradeComplete()
+	assert.Equal(t, false, status)
+	apistest.CheckConditionSucceeded(tc, PreUpgrade, t)
+
+	status = tc.MarkPostUpgradeComplete()
+	assert.Equal(t, true, status)
+	// returns false, as upgrade status already up to date
+	status = tc.MarkPostUpgradeComplete()
+	assert.Equal(t, false, status)
+	apistest.CheckConditionSucceeded(tc, PostUpgrade, t)
 
 	if ready := tc.IsReady(); !ready {
 		t.Errorf("tc.IsReady() = %v, want true", ready)
@@ -68,6 +84,8 @@ func TestTektonConfigErrorPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tc, PreInstall, t)
 	apistest.CheckConditionOngoing(tc, ComponentsReady, t)
 	apistest.CheckConditionOngoing(tc, PostInstall, t)
+	apistest.CheckConditionOngoing(tc, PreUpgrade, t)
+	apistest.CheckConditionOngoing(tc, PostUpgrade, t)
 
 	// Pre install completes execution
 	tc.MarkPreInstallComplete()
@@ -84,6 +102,14 @@ func TestTektonConfigErrorPath(t *testing.T) {
 	tc.MarkPostInstallComplete()
 	apistest.CheckConditionSucceeded(tc, PostInstall, t)
 
+	status := tc.MarkPreUpgradeComplete()
+	assert.Equal(t, true, status)
+	apistest.CheckConditionSucceeded(tc, PreUpgrade, t)
+
+	status = tc.MarkPostUpgradeComplete()
+	assert.Equal(t, true, status)
+	apistest.CheckConditionSucceeded(tc, PostUpgrade, t)
+
 	if ready := tc.IsReady(); !ready {
 		t.Errorf("tc.IsReady() = %v, want true", ready)
 	}
@@ -98,35 +124,35 @@ func TestTektonConfigErrorPath(t *testing.T) {
 
 }
 
-func TestAppliedPreUpgradeVersion(t *testing.T) {
+func TestPreUpgradeVersion(t *testing.T) {
 	tc := &TektonConfig{}
 
 	// should return empty
 	assert.Equal(t, tc.Status.GetPreUpgradeVersion(), "")
 
-	// update applied pre upgrade version
+	// update pre upgrade version
 	tc.Status.SetPreUpgradeVersion("foo")
 	assert.Equal(t, tc.Status.GetPreUpgradeVersion(), "foo")
 	assert.Equal(t, tc.Status.Annotations[PreUpgradeVersionKey], "foo")
 
-	// update applied pre upgrade version
+	// update pre upgrade version
 	tc.Status.SetPreUpgradeVersion("bar")
 	assert.Equal(t, tc.Status.GetPreUpgradeVersion(), "bar")
 	assert.Equal(t, tc.Status.Annotations[PreUpgradeVersionKey], "bar")
 }
 
-func TestAppliedPostUpgradeVersion(t *testing.T) {
+func TestPostUpgradeVersion(t *testing.T) {
 	tc := &TektonConfig{}
 
 	// should return empty
 	assert.Equal(t, tc.Status.GetPostUpgradeVersion(), "")
 
-	// update applied post upgrade version
+	// update post upgrade version
 	tc.Status.SetPostUpgradeVersion("foo")
 	assert.Equal(t, tc.Status.GetPostUpgradeVersion(), "foo")
 	assert.Equal(t, tc.Status.Annotations[PostUpgradeVersionKey], "foo")
 
-	// update applied post upgrade version
+	// update post upgrade version
 	tc.Status.SetPostUpgradeVersion("bar")
 	assert.Equal(t, tc.Status.GetPostUpgradeVersion(), "bar")
 	assert.Equal(t, tc.Status.Annotations[PostUpgradeVersionKey], "bar")

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -112,14 +112,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	}
 
 	// run pre upgrade
-	isUpgradePerformed, err := r.upgrade.RunPreUpgrade(ctx)
+	err := r.upgrade.RunPreUpgrade(ctx)
 	if err != nil {
 		return err
-	}
-	// if upgrade executed, tektonConfig CR status will be updated
-	// hence calling the reconcile again
-	if isUpgradePerformed {
-		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
 	tc.SetDefaults(ctx)
@@ -209,14 +204,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	}
 
 	// run post upgrade
-	isUpgradePerformed, err = r.upgrade.RunPostUpgrade(ctx)
+	err = r.upgrade.RunPostUpgrade(ctx)
 	if err != nil {
 		return err
-	}
-	// if upgrade executed, tektonConfig CR status will be updated
-	// hence calling the reconcile again
-	if isUpgradePerformed {
-		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
 	return nil

--- a/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
@@ -19,7 +19,6 @@ package upgrade
 import (
 	"context"
 
-	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
 	upgrade "github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/helper"
 	"go.uber.org/zap"
@@ -35,26 +34,31 @@ import (
 func upgradeStorageVersion(ctx context.Context, logger *zap.SugaredLogger, k8sClient kubernetes.Interface, operatorClient versioned.Interface, restConfig *rest.Config) error {
 	// resources to be upgraded
 	crdGroups := []string{
-		"clusterinterceptors.triggers.tekton.dev",
-		"clustertasks.tekton.dev",
-		"clustertriggerbindings.triggers.tekton.dev",
-		"customruns.tekton.dev",
-		"eventlisteners.triggers.tekton.dev",
+
+		// dashboard
 		"extensions.dashboard.tekton.dev",
-		"interceptors.triggers.tekton.dev",
+
+		// pipelines
+		"clustertasks.tekton.dev",
+		"customruns.tekton.dev",
 		"pipelineruns.tekton.dev",
 		"pipelines.tekton.dev",
-		"resolutionrequests.resolution.tekton.dev",
 		"taskruns.tekton.dev",
 		"tasks.tekton.dev",
+		"verificationpolicies.tekton.dev",
+		"resolutionrequests.resolution.tekton.dev",
+
+		// Pipelines-as-code
+		"repositories.pipelinesascode.tekton.dev",
+
+		// triggers
+		"clusterinterceptors.triggers.tekton.dev",
+		"clustertriggerbindings.triggers.tekton.dev",
+		"eventlisteners.triggers.tekton.dev",
+		"interceptors.triggers.tekton.dev",
 		"triggerbindings.triggers.tekton.dev",
 		"triggers.triggers.tekton.dev",
 		"triggertemplates.triggers.tekton.dev",
-		"verificationpolicies.tekton.dev",
-	}
-
-	if v1alpha1.IsOpenShiftPlatform() {
-		crdGroups = append(crdGroups, "repositories.pipelinesascode.tekton.dev")
 	}
 
 	migrator := storageversion.NewMigrator(


### PR DESCRIPTION
# Changes

Upgrade mechanism added in #1675 and in this PR fixes the following issues,

Fixes:
* allows operator to patch/update `resolutionrequests.resolution.tekton.dev` in openshift
* included upgrade status into TektonConfig CR under status

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
