### PR TITLE
continue the post upgrade on storage migration errors

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/helper/migrator_test.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/helper/migrator_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// copied from: https://github.com/knative/pkg/blob/2783cd8cfad9ba907e6f31cafeef3eb2943424ee/apiextensions/storageversion/migrator_test.go
+// local changes: aligned with local migrator.go
+// ---
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apixFake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/logging"
+)
+
+var (
+	fakeGK = schema.GroupKind{
+		Kind:  "Fake",
+		Group: "group.dev",
+	}
+
+	fakeGR = schema.GroupResource{
+		Resource: "fakes",
+		Group:    "group.dev",
+	}
+
+	fakeCRD = &apix.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fakeGR.String(),
+		},
+		Spec: apix.CustomResourceDefinitionSpec{
+			Group: fakeGK.Group,
+			Versions: []apix.CustomResourceDefinitionVersion{
+				{Name: "v1alpha1", Served: true, Storage: false},
+				{Name: "v1", Served: true, Storage: true},
+			},
+		},
+		Status: apix.CustomResourceDefinitionStatus{
+			StoredVersions: []string{
+				"v1alpha1",
+				"v1",
+			},
+		},
+	}
+)
+
+func TestMigrate(t *testing.T) {
+	// setup
+	resources := []runtime.Object{fake("first"), fake("second")}
+	dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
+	cclient := apixFake.NewSimpleClientset(fakeCRD)
+	ctx := context.TODO()
+	m := NewMigrator(dclient, cclient, logging.FromContext(ctx))
+
+	if err := m.Migrate(context.Background(), fakeGR); err != nil {
+		t.Fatal("Migrate() =", err)
+	}
+
+	assertPatches(t, dclient.Actions(),
+		// patch resource definition dropping non-storage version
+		emptyResourcePatch("first", "v1"),
+		emptyResourcePatch("second", "v1"),
+	)
+
+	assertPatches(t, cclient.Actions(),
+		// patch resource definition dropping non-storage version
+		crdStorageVersionPatch(fakeCRD.Name, "v1"),
+	)
+}
+
+// func TestMigrate_Paging(t *testing.T) {
+// 	t.Skip("client-go lacks testing pagination " +
+// 		"since list options aren't captured in actions")
+// }
+
+func TestMigrate_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		crd  func(*k8stesting.Fake)
+		dyn  func(*k8stesting.Fake)
+		pass bool
+	}{{
+		name: "failed to fetch CRD",
+		crd: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("get", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("failed to get crd")
+				})
+		},
+	}, {
+		name: "listing fails",
+		dyn: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("list", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("failed to list resources")
+				})
+		},
+	}, {
+		name: "patching resource fails",
+		dyn: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("patch", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("failed to patch resources")
+				})
+		},
+		// prints the error and continues the execution
+		pass: true,
+	}, {
+		name: "patching definition fails",
+		crd: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("patch", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("failed to patch definition")
+				})
+		},
+	}, {
+		name: "patching unexisting resource",
+		dyn: func(fake *k8stesting.Fake) {
+			fake.PrependReactor("patch", "*",
+				func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrs.NewNotFound(fakeGR, "resource-removed")
+				})
+		},
+		// Resouce not found error should not block the storage migration.
+		pass: true,
+	},
+	// todo paging fails
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resources := []runtime.Object{fake("first"), fake("second")}
+			dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
+			cclient := apixFake.NewSimpleClientset(fakeCRD)
+
+			if test.crd != nil {
+				test.crd(&cclient.Fake)
+			}
+
+			if test.dyn != nil {
+				test.dyn(&dclient.Fake)
+			}
+
+			m := NewMigrator(dclient, cclient, logging.FromContext(context.TODO()))
+			if err := m.Migrate(context.Background(), fakeGR); test.pass != (err == nil) {
+				t.Error("Migrate should have returned an error")
+			}
+		})
+	}
+}
+
+func assertPatches(t *testing.T, actions []k8stesting.Action, want ...k8stesting.PatchAction) {
+	t.Helper()
+
+	got := getPatchActions(actions)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error("Unexpected patches:", diff)
+	}
+}
+
+func emptyResourcePatch(name, version string) k8stesting.PatchAction {
+	return k8stesting.NewPatchAction(
+		fakeGR.WithVersion(version),
+		"default",
+		name,
+		types.MergePatchType,
+		[]byte("{}"))
+}
+
+func crdStorageVersionPatch(name, version string) k8stesting.PatchAction {
+	return k8stesting.NewRootPatchSubresourceAction(
+		apix.SchemeGroupVersion.WithResource("customresourcedefinitions"),
+		name,
+		types.StrategicMergePatchType,
+		[]byte(`{"status":{"storedVersions":["`+version+`"]}}`),
+		"status",
+	)
+}
+
+func getPatchActions(actions []k8stesting.Action) []k8stesting.PatchAction {
+	var patches []k8stesting.PatchAction
+
+	for _, action := range actions {
+		if pa, ok := action.(k8stesting.PatchAction); ok {
+			patches = append(patches, pa)
+		}
+	}
+
+	return patches
+}
+
+func fake(name string) runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "group.dev/v1",
+			"kind":       "Fake",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "default",
+			},
+		},
+	}
+}

--- a/pkg/reconciler/shared/tektonconfig/upgrade/helper/storage_version_migrator_test.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/helper/storage_version_migrator_test.go
@@ -28,7 +28,6 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicFake "k8s.io/client-go/dynamic/fake"
-	"knative.dev/pkg/apiextensions/storageversion"
 	"knative.dev/pkg/logging"
 )
 
@@ -74,13 +73,12 @@ func TestMigrateStorageVersion(t *testing.T) {
 
 	dclient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
 	cclient := apixFake.NewSimpleClientset(fakeCRD)
-	migrator := storageversion.NewMigrator(dclient, cclient)
+	migrator := NewMigrator(dclient, cclient, logging.FromContext(ctx))
 	logger := logging.FromContext(ctx)
 
 	// TEST
 	// expects only "v1"
-	err := MigrateStorageVersion(ctx, logger, migrator, []string{"fakes.group.dev", "unknown.group.dev"})
-	assert.NoError(t, err)
+	MigrateStorageVersion(ctx, logger, migrator, []string{"fakes.group.dev", "unknown.group.dev"})
 	crd, err := cclient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, fakeCRD.GetName(), metav1.GetOptions{})
 	assert.NoError(t, err)
 	storageVersions := crd.Status.StoredVersions

--- a/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"knative.dev/pkg/apiextensions/storageversion"
 )
 
 // performs storage versions upgrade
@@ -61,10 +60,13 @@ func upgradeStorageVersion(ctx context.Context, logger *zap.SugaredLogger, k8sCl
 		"triggertemplates.triggers.tekton.dev",
 	}
 
-	migrator := storageversion.NewMigrator(
+	migrator := upgrade.NewMigrator(
 		dynamic.NewForConfigOrDie(restConfig),
 		apixclient.NewForConfigOrDie(restConfig),
+		logger,
 	)
 
-	return upgrade.MigrateStorageVersion(ctx, logger, migrator, crdGroups)
+	upgrade.MigrateStorageVersion(ctx, logger, migrator, crdGroups)
+
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2155,7 +2155,6 @@ k8s.io/utils/strings/slices
 k8s.io/utils/trace
 # knative.dev/pkg v0.0.0-20230718152110-aef227e72ead
 ## explicit; go 1.18
-knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/ducktypes


### PR DESCRIPTION
# Changes

#### Issue:
If there is an error happened on storage version upgrade, post upgrade flow stops and repeating the execution from the beginning.

Originally Storage migration is introduced in #1675

#### error on patching a resource:
```
{"level":"error","logger":"tekton-operator-lifecycle.upgrade","caller":"helper/storage_version_migrator.go:49","msg":"failed to migrate: ","commit":"70b39cc","knative.dev/pod":"openshift-pipelines-operator-548c6f67c8-h8vjx","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.shared.tektonconfig.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonConfig","knative.dev/traceid":"46127b82-5f17-4ee7-aa31-e5951cd89b78","knative.dev/key":"config","error":"unable to patch resource /clustertask-with-optional-resources-v1beta1 (gvr: tekton.dev/v1beta1, Resource=clustertasks) - admission webhook \"validation.webhook.pipeline.tekton.dev\" denied the request: validation failed: must not set the field(s): spec.resources","stacktrace":"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/helper.MigrateStorageVersion\n\t/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/helper/storage_version_migrator.go:49\ngithub.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade.upgradeStorageVersion\n\t/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/post_upgrade.go:69\ngithub.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade.(*Upgrade).executeUpgrade\n\t/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go:99\ngithub.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade.(*Upgrade).RunPostUpgrade\n\t/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go:69\ngithub.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig.(*Reconciler).ReconcileKind\n\t/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/tektonconfig.go:207\ngithub.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonconfig.(*reconcilerImpl).Reconcile\n\t/go/src/github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonconfig/reconciler.go:236\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\t/go/src/github.com/tektoncd/operator/vendor/knative.dev/pkg/controller/controller.go:542\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\t/go/src/github.com/tektoncd/operator/vendor/knative.dev/pkg/controller/controller.go:491"}
```
and keep on executing the post upgrade
```
$ oc get tektonconfigs.operator.tekton.dev config
NAME     VERSION   READY   REASON
config   1.12.0    False   Post upgrade is in progress
```

#### Fix:
copied the source https://github.com/knative/pkg/blob/2783cd8cfad9ba907e6f31cafeef3eb2943424ee/apiextensions/storageversion/migrator.go to local and modified as,
* print the resource patching error log, if any and continue the execution
* print the crd error log, if any and continues the execution
* complete the post upgrade

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```
