### PR TITLE
make pruner image configurable and allow for custom labels for operator deployment

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -41,6 +41,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.operator.deployment.customLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -53,6 +56,15 @@ app.kubernetes.io/component: operator
 {{- end }}
 
 {{/*
+Pod Template labels for operator component
+*/}}
+{{- define "tekton-operator.operator.podTemplateLabels" -}}
+{{- with .Values.operator.deployment.podTemplateCustomLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels for webhook component
 */}}
 {{- define "tekton-operator.webhook.selectorLabels" -}}
@@ -60,7 +72,6 @@ app.kubernetes.io/name: {{ include "tekton-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: webhook
 {{- end }}
-
 
 {{/*
 Create the name of the service account to use
@@ -97,6 +108,12 @@ tekton-operator
   {{- $image = "gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator" -}}
 {{- end -}}
 {{- end -}}
+{{- printf "%s:%s" $image $tag -}}
+{{- end -}}
+
+{{- define "tekton-operator.pruner-image" -}}
+{{- $tag := .Values.pruner.image.tag -}}
+{{- $image := .Values.pruner.image.repository -}}
 {{- printf "%s:%s" $image $tag -}}
 {{- end -}}
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       labels:
         {{- include "tekton-operator.operator.selectorLabels" . | nindent 8 }}
+        {{- include "tekton-operator.operator.podTemplateLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -46,7 +47,7 @@ spec:
             - name: IMAGE_PIPELINES_PROXY
               value: {{ include "tekton-operator.webhook-proxy-image" . }}
             - name: IMAGE_JOB_PRUNER_TKN
-              value: gcr.io/tekton-releases/dogfooding/tkn@sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b
+              value: {{ include "tekton-operator.pruner-image" . }}
             - name: METRICS_DOMAIN
               value: {{ .Values.service.metricsDomain }}
             - name: VERSION
@@ -157,6 +158,7 @@ spec:
       {{- end }}
       labels:
         {{- include "tekton-operator.webhook.selectorLabels" . | nindent 8 }}
+        {{- include "tekton-operator.operator.podTemplateLabels" . | nindent 8 }}
     spec:
       {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,6 +42,18 @@ operator:
   # Resource requests and limits for the operator pod
   # see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
+  deployment:
+    # Custom labels for the Deployment resource.
+    customLabels: ""
+    # Custom labels for the Deployment Pod Template.
+    podTemplateCustomLabels: ""
+
+## Configuration for the tekton pruner cron job.
+pruner:
+  image:
+    # Container image for Tekton pruner. Defaults to gcr.
+    repository: "gcr.io/tekton-releases/dogfooding/tkn"
+    tag: "a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b"
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:


### PR DESCRIPTION
# Changes

- add the ability to configure the image used for the tekton pruner cron job (i.e. pulling through a private registry instead of gcr.io).
- add the ability to add custom labels for the operator's `Deployment` and its [Pod Template](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template).

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [N/A] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
- add the ability to configure the image used for the tekton pruner cron job.
- ability to set custom labels for operator's `Deployment` and its [Pod Template](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pod-template).
```