### PR TITLE
fix default version for pruner image

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,7 +53,7 @@ pruner:
   image:
     # Container image for Tekton pruner. Defaults to gcr.
     repository: "gcr.io/tekton-releases/dogfooding/tkn"
-    tag: "v20230913-528623db20"
+    tag: "sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b"
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,7 +53,7 @@ pruner:
   image:
     # Container image for Tekton pruner. Defaults to gcr.
     repository: "gcr.io/tekton-releases/dogfooding/tkn"
-    tag: "a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b"
+    tag: "v20230913-528623db20"
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:


### PR DESCRIPTION
# Changes

The previous refactor was missing `sha256` prefix in the tag (should read `sha256:a572f1748eb5c0e8002dd0a83ee836ad9d755d035cbd5bfbdef5de810d2bea0b`). This PR fixes the default version in `values.yaml`.

Please advise if updating `tkn` to `v20231012-686a1d369c` would make sense here.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [N/A] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
use version tag instead of SHA for `gcr.io/tekton-releases/dogfooding/tkn` image.
```