### PR TITLE
execute GH action release of helm chart only on new tag

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,8 +2,7 @@ name: Release Charts
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches:
-      - main
+    tags: ["v*"]
 
 jobs:
   release:


### PR DESCRIPTION
# Changes

Executes GH action release helm chart only on new tag creation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```