### PR TITLE
Rename CopyConfigMapWithForceUpdate to CopyConfigMap

### DIFF
--- a/pkg/reconciler/common/testdata/test-empty-config.yaml
+++ b/pkg/reconciler/common/testdata/test-empty-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: empty-config
+  namespace: tekton-pipelines-resolvers
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data: {}

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -44,7 +44,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.DeploymentImages(images),
 			common.AddConfiguration(pac.Spec.Config),
 			occommon.ApplyCABundles,
-			common.CopyConfigMapWithForceUpdate(pipelinesAsCodeCM, pac.Spec.Settings, true),
+			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
 		}
 


### PR DESCRIPTION
This patch renames CopyConfigMapWithForceUpdate to CopyConfigMap and removes `forceUpdate` param
and always allow to add extra fields in ConfigMap

Fixes: #1568

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```