### PR TITLE
Add support to update PriorityClassName via options

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -533,6 +533,7 @@ The following fields are supported in `deployment`
   * `template`
     * `spec`
       * `affinity` - replaces the existing Affinity with this, if not empty
+      * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
       * `nodeSelector` - replaces the existing NodeSelector with this, if not empty
       * `tolerations` - replaces the existing tolerations with this, if not empty
       * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
@@ -563,6 +564,7 @@ The following fields are supported in `StatefulSet`
   * `template`
     * `spec`
       * `affinity` - replaces the existing Affinity with this, if not empty
+      * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
       * `nodeSelector` - replaces the existing NodeSelector with this, if not empty
       * `tolerations` - replaces the existing tolerations with this, if not empty
       * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty

--- a/pkg/reconciler/common/testdata/test-additional-options-test-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-deployment.yaml
@@ -64,7 +64,7 @@ spec:
       creationTimestamp: null
       labels:
         app.kubernetes.io/name: controller
-        operator.tekton.dev/deployment-spec-applied-hash: dd069273de050a47c5552fd79a70d4c3
+        operator.tekton.dev/deployment-spec-applied-hash: 1704bb3edd32937a1659b4d42c9f1669
     spec:
       affinity:
         nodeAffinity:
@@ -77,6 +77,7 @@ spec:
                       - ssd
                       - nvme
                       - ramdisk
+      priorityClassName: test
       serviceAccountName: tekton-pipelines-controller
       nodeSelector:
         zone: east

--- a/pkg/reconciler/common/testdata/test-additional-options-test-statefulsets.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-statefulsets.yaml
@@ -30,6 +30,7 @@ spec:
                       - ssd
                       - nvme
                       - ramdisk
+      priorityClassName: test
       containers:
         - args:
             - --mode=production

--- a/pkg/reconciler/common/transformer_additional_options.go
+++ b/pkg/reconciler/common/transformer_additional_options.go
@@ -256,6 +256,11 @@ func (ot *OptionsTransformer) updateDeployments(u *unstructured.Unstructured) er
 		targetDeployment.Spec.Template.Spec.Affinity = deploymentOptions.Spec.Template.Spec.Affinity
 	}
 
+	// update PriorityClassName
+	if deploymentOptions.Spec.Template.Spec.PriorityClassName != "" {
+		targetDeployment.Spec.Template.Spec.PriorityClassName = deploymentOptions.Spec.Template.Spec.PriorityClassName
+	}
+
 	// update node selectors
 	if len(deploymentOptions.Spec.Template.Spec.NodeSelector) > 0 {
 		targetDeployment.Spec.Template.Spec.NodeSelector = deploymentOptions.Spec.Template.Spec.NodeSelector
@@ -439,6 +444,12 @@ func (ot *OptionsTransformer) updateStatefulSets(u *unstructured.Unstructured) e
 	// update affinity
 	if statefulSetOptions.Spec.Template.Spec.Affinity != nil {
 		targetStatefulSet.Spec.Template.Spec.Affinity = statefulSetOptions.Spec.Template.Spec.Affinity
+	}
+
+	// update priorityClassName
+	if statefulSetOptions.Spec.Template.Spec.PriorityClassName != "" {
+		targetStatefulSet.Spec.Template.Spec.PriorityClassName = statefulSetOptions.Spec.Template.Spec.PriorityClassName
+
 	}
 
 	// update node selectors

--- a/pkg/reconciler/common/transformer_additional_options_test.go
+++ b/pkg/reconciler/common/transformer_additional_options_test.go
@@ -155,6 +155,7 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 											},
 										},
 									},
+									PriorityClassName: "test",
 									Volumes: []corev1.Volume{
 										{
 											Name: "my-custom-logs",
@@ -334,6 +335,7 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 											},
 										},
 									},
+									PriorityClassName: "test",
 									Volumes: []corev1.Volume{
 										{
 											Name: "my-custom-logs",


### PR DESCRIPTION
This patch sdds support to update PriorityClassName via options in Deployment and StatefulSet, also updates TektonConfig doc

Fixes: #1835

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Allow to update PriorityClassName via options in Deployment and StatefulSet
```

