### PR TITLE
[main] ignore nested struct in AddConfigMapValues transformer

### DIFF
--- a/pkg/reconciler/common/testdata/test-add-configmap-values.yaml
+++ b/pkg/reconciler/common/testdata/test-add-configmap-values.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-add-config
+  namespace: tekton-pipelines
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-add-config-with-data
+  namespace: tekton-pipelines
+data:
+  foo: bar
+
+---
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: foo-deployment
+  namespace: foo


### PR DESCRIPTION
# Changes
* Fixes: #1847 
* Ignores `nested struct` and `map` in `AddConfigMapValues` transformer

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
