### PR TITLE
[main] fix operator webhook installerset deletion race condition

### DIFF
--- a/cmd/kubernetes/webhook/main.go
+++ b/cmd/kubernetes/webhook/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -62,8 +61,6 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("kubernetes")
 
-	go gracefulTermination(ctx)
-
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -71,9 +68,4 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
-}
-
-func gracefulTermination(ctx context.Context) {
-	<-ctx.Done()
-	webhook.CleanupWebhookResources(ctx)
 }

--- a/cmd/openshift/webhook/main.go
+++ b/cmd/openshift/webhook/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/tektoncd/operator/pkg/webhook"
@@ -50,8 +49,6 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("openshift")
 
-	go gracefulTermination(ctx)
-
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -59,9 +56,4 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
-}
-
-func gracefulTermination(ctx context.Context) {
-	<-ctx.Done()
-	webhook.CleanupWebhookResources(ctx)
 }

--- a/pkg/webhook/webhook_init_test.go
+++ b/pkg/webhook/webhook_init_test.go
@@ -32,7 +32,7 @@ func TestCreateWebhookResources(t *testing.T) {
 		m, err := mf.ManifestFrom(mf.Path(testdataPath))
 		assert.NilError(t, err)
 		_, err = manifestTransform(&m)
-		assert.Error(t, err, ERR_NAMESPACE_ENV_NOT_SET.Error())
+		assert.Error(t, err, ErrNamespaceEnvNotSet.Error())
 	})
 }
 


### PR DESCRIPTION
# Changes

* fixes: [SRVKP-3798](https://issues.redhat.com/browse/SRVKP-3798) - Operator upgrade failing on 4.14

### Issue
Operator webhook installerset `validating-mutating-webhoook` not available on upgrade.

### Observations
* When webhook pod created it removes the `validating-mutating-webhoook` installersets
* creates new `validating-mutating-webhoook` installerset
* also there is a `gracefulTermination` function called on webhook pod termination, it removes the `validating-mutating-webhoook` installersets.
* On OpenShift 4.14 (Kubernetes 1.27), seems we have some changes on the pod termination graceful timing
* on upgrade new webhook pod created and existing webhook pod terminated, on this action, the new pod deletes the webhook installersets and creates webhook installerset (as expected). However the terminating pod takes a bit time to terminate and later(exactly after the new pod completes the webhook installerset creating job) it triggers the `gracefulTermination`, which removes the all the available webhook installersets.


### Fix
* removed the `gracefulTermination` function, which is called on webhook pod termination
* now the removal job only handled by newly created pod

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
