### PR TITLE
Fix config leader election configmap name

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -43,7 +43,7 @@ const (
 	clusterResolverConfig                        = "cluster-resolver-config"
 	hubResolverConfig                            = "hubresolver-config"
 	gitResolverConfig                            = "git-resolver-config"
-	leaderElectionConfig                         = "config-leader-election"
+	leaderElectionConfig                         = "config-leader-election-controller"
 	pipelinesControllerDeployment                = "tekton-pipelines-controller"
 	pipelinesControllerContainer                 = "tekton-pipelines-controller"
 	pipelinesRemoteResolversControllerDeployment = "tekton-pipelines-remote-resolvers"

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
@@ -87,9 +87,9 @@ func TestUpdatePerformanceFlagsInDeployment(t *testing.T) {
 	// update expected output
 	depExpected := depInput.DeepCopy()
 	depExpected.Spec.Template.Labels = map[string]string{
-		"app":                                 "hello",
-		"config-leader-election.data.buckets": "2",
-		"deployment.spec.replicas":            "1",
+		"app": "hello",
+		"config-leader-election-controller.data.buckets": "2",
+		"deployment.spec.replicas":                       "1",
 	}
 	// flags order is important
 	depExpected.Spec.Template.Spec.Containers[1].Args = []string{


### PR DESCRIPTION
This will update the name of the configmap responsible for controller to contain config of leader election

Based on the PR on pipeline upstream
https://github.com/tektoncd/pipeline/pull/7014

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix config leader election configmap name
```