### PR TITLE
[main] fix operator webhook upgrade issue by adding unique identifier and revert gracefulTermination

### DIFF
--- a/cmd/kubernetes/webhook/main.go
+++ b/cmd/kubernetes/webhook/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -61,6 +62,8 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("kubernetes")
 
+	go gracefulTermination(ctx)
+
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -68,4 +71,9 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
+}
+
+func gracefulTermination(ctx context.Context) {
+	<-ctx.Done()
+	webhook.CleanupWebhookResources(ctx)
 }

--- a/cmd/openshift/webhook/main.go
+++ b/cmd/openshift/webhook/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/tektoncd/operator/pkg/webhook"
@@ -49,6 +50,8 @@ func main() {
 	webhook.CreateWebhookResources(ctx)
 	webhook.SetTypes("openshift")
 
+	go gracefulTermination(ctx)
+
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		cfg,
 		certificates.NewController,
@@ -56,4 +59,9 @@ func main() {
 		webhook.NewValidationAdmissionController,
 		webhook.NewConfigValidationController,
 	)
+}
+
+func gracefulTermination(ctx context.Context) {
+	<-ctx.Done()
+	webhook.CleanupWebhookResources(ctx)
 }

--- a/config/kubernetes/base/webhook.yaml
+++ b/config/kubernetes/base/webhook.yaml
@@ -39,6 +39,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: WEBHOOK_SERVICE_NAME

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -43,6 +43,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: WEBHOOK_SERVICE_NAME

--- a/pkg/webhook/webhook_init_test.go
+++ b/pkg/webhook/webhook_init_test.go
@@ -1,11 +1,16 @@
 package webhook
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	k8sfake "github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
 	"gotest.tools/v3/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -51,6 +56,153 @@ func assertServiceNamespace(t *testing.T, u *unstructured.Unstructured, ns strin
 				t.Errorf("expected namespace %q, got %q", ns, got)
 			}
 		}
+	}
+
+}
+
+func TestDeleteExistingInstallerSets(t *testing.T) {
+	tests := []struct {
+		name                      string
+		podName                   string
+		includeUniqueIdentifier   bool
+		installerSets             []v1alpha1.TektonInstallerSet
+		expectedInstallerSetCount int
+		expectedError             string
+	}{
+		{
+			name:                    "remove-deprecated-webhook-installersets",
+			podName:                 "",
+			includeUniqueIdentifier: false,
+			installerSets: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "set1",
+						Labels: map[string]string{
+							DEPRECATED_WEBHOOK_INSTALLERSET_LABEL: "",
+						},
+					},
+				},
+			},
+			expectedInstallerSetCount: 0,
+		},
+		{
+			name:                    "without-pod-name-env-set",
+			podName:                 "",
+			includeUniqueIdentifier: true,
+			installerSets: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "set1",
+						Labels: map[string]string{
+							v1alpha1.CreatedByKey:     labelCreatedByValue,
+							v1alpha1.InstallerSetType: labelInstallerSetTypeValue,
+							WEBHOOK_UNIQUE_LABEL:      "webhook-foo",
+						},
+					},
+				},
+			},
+			expectedInstallerSetCount: 1,
+			expectedError:             fmt.Sprintf("pod name environment variable[%s] details are not set", POD_NAME_ENV_KEY),
+		},
+		{
+			name:                      "delete-on-empty-set-with-pod-name",
+			podName:                   "webhook-foo",
+			includeUniqueIdentifier:   true,
+			installerSets:             []v1alpha1.TektonInstallerSet{},
+			expectedInstallerSetCount: 0,
+		},
+		{
+			name:                      "delete-on-empty-set-without-pod-name",
+			podName:                   "",
+			includeUniqueIdentifier:   false,
+			installerSets:             []v1alpha1.TektonInstallerSet{},
+			expectedInstallerSetCount: 0,
+		},
+		{
+			name:                    "with-pod-name-env-set-and-mismatch",
+			podName:                 "webhook-name-foo",
+			includeUniqueIdentifier: true,
+			installerSets: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "set1",
+						Labels: map[string]string{
+							v1alpha1.CreatedByKey:     labelCreatedByValue,
+							v1alpha1.InstallerSetType: labelInstallerSetTypeValue,
+							WEBHOOK_UNIQUE_LABEL:      "webhook-foo",
+						},
+					},
+				},
+			},
+			expectedInstallerSetCount: 1,
+		},
+		{
+			name:                    "with-pod-name-env-set-and-match",
+			podName:                 "webhook-name-foo",
+			includeUniqueIdentifier: true,
+			installerSets: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "set1",
+						Labels: map[string]string{
+							v1alpha1.CreatedByKey:     labelCreatedByValue,
+							v1alpha1.InstallerSetType: labelInstallerSetTypeValue,
+							WEBHOOK_UNIQUE_LABEL:      "webhook-name-foo",
+						},
+					},
+				},
+			},
+			expectedInstallerSetCount: 0,
+		},
+		{
+			name:                    "mismatch-labels",
+			podName:                 "",
+			includeUniqueIdentifier: false,
+			installerSets: []v1alpha1.TektonInstallerSet{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "set1",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			expectedInstallerSetCount: 1,
+		},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// get fake client
+			k8sClient := k8sfake.NewSimpleClientset()
+
+			if test.podName != "" {
+				t.Setenv(POD_NAME_ENV_KEY, test.podName)
+			}
+
+			// update existing installersets
+			for _, installerSet := range test.installerSets {
+				_, err := k8sClient.OperatorV1alpha1().TektonInstallerSets().Create(ctx, &installerSet, v1.CreateOptions{})
+				assert.NilError(t, err)
+			}
+
+			// run delete installersets
+			err := deleteExistingInstallerSets(ctx, k8sClient, test.includeUniqueIdentifier)
+			if test.expectedError != "" {
+				assert.Error(t, err, test.expectedError)
+			} else {
+				assert.NilError(t, err)
+			}
+
+			// verify the expected count
+			installerSetsList, err := k8sClient.OperatorV1alpha1().TektonInstallerSets().List(ctx, v1.ListOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, test.expectedInstallerSetCount, len(installerSetsList.Items))
+
+		})
 	}
 
 }


### PR DESCRIPTION
# Changes

This is followup fix with #1874
Still the existing pod(from old installed version) removes the installersets on terminating time.

### Changes:
* deprecate the existing webhook installerset reference label
* introduce new primary label
* revert back `gracefulTermination` with unique identifier. deletes the webhook installersets, only created by that pod.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
