### PR TITLE
fix 'G601: Implicit memory aliasing in for loop' linter issue on cabundle.go file

### DIFF
--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -45,7 +45,8 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 
 	// Now that the injected certificates have been added as a volume, let's
 	// mount them via volumeMounts in the containers
-	for i, c := range deployment.Spec.Template.Spec.Containers {
+	for i := range deployment.Spec.Template.Spec.Containers {
+		c := deployment.Spec.Template.Spec.Containers[i] // Create a copy of the container
 		common.AddCABundlesToContainerVolumes(&c)
 		deployment.Spec.Template.Spec.Containers[i] = c
 	}


### PR DESCRIPTION
# Changes

while adapting the CABUNDLE injection to Openshift Serverless, I got warning about:

> G601: Implicit memory aliasing in for loop' linter issue on cabundle.go file

and the fix for the `gosec` linting was this commit:
https://github.com/openshift-knative/serverless-operator/pull/2396/commits/a286ac7a1ad578cb4bec4766ce16b8d1b358a448

Contributing this back to Tekton

