### PR TITLE
[main] manage pipeline console plugin deployment on openshift

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -1,0 +1,139 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# to know about dynamic plugin visit,
+# https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md
+
+# service to access static contents: js, CSS, HTML. etc.,
+# this service creates and manages secret called "pipeline-console-plugin-cert"
+# generated secret will be used in the console plugin container (nginx + static content)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  annotations:
+    # https://docs.openshift.com/container-platform/4.13/security/certificates/service-serving-certificate.html
+    service.beta.openshift.io/serving-cert-secret-name: pipeline-console-plugin-cert
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  ports:
+  - name: 8443-tcp
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+  selector:
+    name: pipeline-console-plugin
+    app: pipeline-console-plugin
+
+# nginx configuration
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+data:
+  nginx.conf: |
+    error_log /dev/stdout warn;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              8443 ssl;
+        listen              [::]:8443 ssl;
+        ssl_certificate     /var/cert/tls.crt;
+        ssl_certificate_key /var/cert/tls.key;
+        root                /usr/share/nginx/html;
+      }
+    }
+
+# nginx + pipeline dynamic console custom static contents
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pipeline-console-plugin
+      app: pipeline-console-plugin
+  template:
+    metadata:
+      labels:
+        name: pipeline-console-plugin
+        app: pipeline-console-plugin
+        app.kubernetes.io/part-of: tekton-config
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: pipeline-console-plugin-cert
+          secret:
+            secretName: pipeline-console-plugin-cert
+            defaultMode: 420
+        - name: nginx-conf
+          configMap:
+            name: pipeline-console-plugin
+            defaultMode: 420
+      containers:
+      - name: pipeline-console-plugin
+        image: ghcr.io/openshift-pipelines/console-plugin:main
+        imagePullPolicy: Always
+        ports:
+          - protocol: TCP
+            containerPort: 8443
+        volumeMounts:
+          - name: pipeline-console-plugin-cert
+            readOnly: true
+            mountPath: /var/cert
+          - name: nginx-conf
+            readOnly: true
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+
+# Console plugin is a cluster wide resource
+# updates pipeline dynamic content provider service details
+---
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: pipeline-console-plugin
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  displayName: Pipeline Console Plugin
+  backend:
+    type: Service
+    service:
+      name: pipeline-console-plugin
+      namespace: openshift-pipelines
+      port: 8443
+      basePath: "/"
+  i18n:
+    loadType: Preload   # options: Preload, Lazy

--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -376,3 +376,16 @@ rules:
   - delete
   - update
   - patch
+# to manage ConsolePlugin custom resource
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -236,6 +236,15 @@ image-substitutions:
         envKeys:
           - IMAGE_ADDONS_PARAM_MAVEN_IMAGE
 
+# pipelines console plugin image
+- image: ghcr.io/openshift-pipelines/console-plugin:main
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator-lifecycle
+        envKeys:
+          - IMAGE_PIPELINE_CONSOLE_PLUGIN
+
 # add third party images which are not replaced by operator
 # but pulled directly by tasks here
 defaultRelatedImages: []

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Developer Tools, Integration & Delivery
     certified: "false"
+    console.openshift.io/plugins: '["pipeline-console-plugin"]'
     description: Red Hat OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.7.2
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'

--- a/pkg/reconciler/common/testdata/test-replace-namespace.yaml
+++ b/pkg/reconciler/common/testdata/test-replace-namespace.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sample-sa
+  namespace: tekton-pipelines
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service
+  namespace: tekton-pipelines
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-config-map
+  namespace: tekton-pipelines
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-config-map
+  namespace: tekton-pipelines
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-pod
+  namespace: tekton-pipelines
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sample-secret
+  namespace: tekton-pipelines
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sample-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-resource-pruner
+    namespace: hello
+  - kind: ServiceAccount
+    name: tekton-resource-pruner2
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-resource-pruner
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler.go
+++ b/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/go-logr/zapr"
+	mf "github.com/manifestival/manifestival"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	// manifests console plugin yaml directory location
+	consolePluginReconcileYamlDirectory = "static/tekton-config/00-console-plugin"
+	// installerSet label value
+	consolePluginReconcileLabelCreatedByValue = "tekton-config-console-plugin-manifests"
+	// pipeline console plugin environment variable key
+	PipelineConsolePluginImageEnvironmentKey = "IMAGE_PIPELINE_CONSOLE_PLUGIN"
+	// pipeline console plugin container name, used to replace the image from the environment
+	PipelineConsolePluginContainerName = "pipeline-console-plugin"
+)
+
+var (
+	// label filter to set/get installerSet specific to this reconciler
+	consolePluginReconcileInstallerSetLabel = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			v1alpha1.InstallerSetType: v1alpha1.ConfigResourceName,
+			v1alpha1.CreatedByKey:     consolePluginReconcileLabelCreatedByValue,
+		},
+	}
+)
+
+type consolePluginReconciler struct {
+	logger                     *zap.SugaredLogger
+	operatorClientSet          versioned.Interface
+	syncOnce                   sync.Once
+	resourcesYamlDirectory     string
+	operatorVersion            string
+	pipelineConsolePluginImage string
+	manifest                   mf.Manifest
+}
+
+// reconcile steps
+// 1. get console plugin manifests from kodata
+// 2. verify the existing installerSet hash value
+// 3. if there is a mismatch or the installerSet not available, (re)create it
+func (cpr *consolePluginReconciler) reconcile(ctx context.Context, tektonConfigCR *v1alpha1.TektonConfig) error {
+
+	cpr.updateOnce(ctx)
+
+	// verify he availability of the installerSet
+	labelSelector, err := common.LabelSelector(consolePluginReconcileInstallerSetLabel)
+	if err != nil {
+		return err
+	}
+
+	installerSetList, err := cpr.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return err
+	}
+
+	doCreateInstallerSet := false
+	var deployedInstallerSet v1alpha1.TektonInstallerSet
+
+	if len(installerSetList.Items) > 1 {
+		for _, installerSet := range installerSetList.Items {
+			err = cpr.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().Delete(ctx, installerSet.GetName(), metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		doCreateInstallerSet = true
+	} else if len(installerSetList.Items) == 1 {
+		deployedInstallerSet = installerSetList.Items[0]
+	} else {
+		doCreateInstallerSet = true
+	}
+
+	// clone the manifest
+	manifest := cpr.manifest.Append()
+	// apply transformations
+	if err := cpr.transform(ctx, &manifest, tektonConfigCR); err != nil {
+		tektonConfigCR.Status.MarkNotReady(fmt.Sprintf("transformation failed: %s", err.Error()))
+		return err
+	}
+
+	// get expected hash value of the manifests
+	expectedHash, err := cpr.getHash(manifest.Resources())
+	if err != nil {
+		return err
+	}
+
+	if !doCreateInstallerSet {
+		// compute hash from the deployed installerSet
+		deployedHash, err := cpr.getHash(deployedInstallerSet.Spec.Manifests)
+		if err != nil {
+			return err
+		}
+
+		releaseVersion := deployedInstallerSet.GetLabels()[v1alpha1.ReleaseVersionKey]
+		// delete the existing installerSet,
+		// if hash mismatch or version mismatch
+		if expectedHash != deployedHash || cpr.operatorVersion != releaseVersion {
+			if err := cpr.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().Delete(ctx, deployedInstallerSet.GetName(), metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+			doCreateInstallerSet = true
+		}
+	}
+
+	if doCreateInstallerSet {
+		return cpr.createInstallerSet(ctx, &manifest, tektonConfigCR)
+	}
+
+	return nil
+}
+
+func (cpr *consolePluginReconciler) updateOnce(ctx context.Context) {
+	// reads all yaml files from the directory, it is an expensive process to access disk on each reconcile call.
+	// hence fetch only once at startup, it helps not to degrade the performance of the reconcile loop
+	// also it not necessary to read the files frequently, as the files are shipped along the container and never change
+	cpr.syncOnce.Do(func() {
+		// fetch manifest from disk
+		manifest, err := mf.NewManifest(cpr.resourcesYamlDirectory, mf.UseLogger(zapr.NewLogger(cpr.logger.Desugar())))
+		if err != nil {
+			cpr.logger.Fatal("error getting manifests",
+				"manifestsLocation", cpr.resourcesYamlDirectory,
+				err,
+			)
+		}
+		cpr.manifest = manifest
+
+		// update pipeline console image details
+		consoleImage, found := os.LookupEnv(PipelineConsolePluginImageEnvironmentKey)
+		if found {
+			cpr.pipelineConsolePluginImage = consoleImage
+			cpr.logger.Debugw("pipeline console plugin image found from environment",
+				"image", consoleImage,
+				"environmentVariable", PipelineConsolePluginImageEnvironmentKey,
+			)
+		} else {
+			cpr.logger.Warnw("pipeline console plugin image not found from environment, continuing with the default image from the manifest",
+				"environmentVariable", PipelineConsolePluginImageEnvironmentKey,
+			)
+		}
+	})
+}
+
+func (cpr *consolePluginReconciler) createInstallerSet(ctx context.Context, manifest *mf.Manifest, tektonConfigCR *v1alpha1.TektonConfig) error {
+	// setup installerSet
+	ownerRef := *metav1.NewControllerRef(tektonConfigCR, tektonConfigCR.GetGroupVersionKind())
+	installerSet := &v1alpha1.TektonInstallerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tekton-config-console-plugin-manifests-",
+			Labels:       consolePluginReconcileInstallerSetLabel.MatchLabels,
+			Annotations: map[string]string{
+				v1alpha1.TargetNamespaceKey: tektonConfigCR.Spec.TargetNamespace,
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: v1alpha1.TektonInstallerSetSpec{
+			Manifests: manifest.Resources(),
+		},
+	}
+	// update operator version
+	installerSet.Labels[v1alpha1.ReleaseVersionKey] = cpr.operatorVersion
+
+	// creates installerSet in the cluster
+	_, err := cpr.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().Create(ctx, installerSet, metav1.CreateOptions{})
+	if err != nil {
+		cpr.logger.Error("error on creating installerset", err)
+	}
+	return err
+}
+
+// apply transformations
+func (cpr *consolePluginReconciler) transform(ctx context.Context, manifest *mf.Manifest, tektonConfigCR *v1alpha1.TektonConfig) error {
+	// load required transformers
+	transformers := []mf.Transformer{
+		// updates "metadata.namespace" to targetNamespace
+		common.ReplaceNamespace(tektonConfigCR.Spec.TargetNamespace),
+		cpr.transformerConsolePlugin(tektonConfigCR.Spec.TargetNamespace),
+	}
+
+	if cpr.pipelineConsolePluginImage != "" {
+		// updates deployments container image
+		transformers = append(transformers, common.DeploymentImages(map[string]string{
+			// on the transformer, in the container name, the '-' replaced with '_'
+			strings.ReplaceAll(PipelineConsolePluginContainerName, "-", "_"): cpr.pipelineConsolePluginImage,
+		}))
+	}
+
+	// perform transformation
+	return common.Transform(ctx, manifest, tektonConfigCR, transformers...)
+}
+
+func (cpr *consolePluginReconciler) getHash(resources []unstructured.Unstructured) (string, error) {
+	return hash.Compute(resources)
+}
+
+func (cpr *consolePluginReconciler) transformerConsolePlugin(targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "ConsolePlugin" {
+			return nil
+		}
+
+		return unstructured.SetNestedField(u.Object, targetNamespace, "spec", "backend", "service", "namespace")
+	}
+}

--- a/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/logging"
+)
+
+// reactor required for the GenerateName field to work when using the fake client
+func generateNameReactor(action k8sTesting.Action) (bool, apimachineryRuntime.Object, error) {
+	resource := action.(k8sTesting.CreateAction).GetObject()
+	meta, ok := resource.(metav1.Object)
+	if !ok {
+		return false, resource, nil
+	}
+
+	if meta.GetName() == "" && meta.GetGenerateName() != "" {
+		meta.SetName(common.SimpleNameGenerator.RestrictLengthWithRandomSuffix(meta.GetGenerateName()))
+	}
+	return false, resource, nil
+}
+
+func TestPostReconcileManifest(t *testing.T) {
+	defaultConsolePluginImage := "ghcr.io/openshift-pipelines/console-plugin:main"
+
+	tests := []struct {
+		name               string
+		consolePluginImage string
+		operatorVersion    string
+		targetNamespace    string
+	}{
+		{
+			name:            "test-without-console-plugin-image",
+			operatorVersion: "1.14.0",
+			targetNamespace: "foo",
+		},
+		{
+			name:               "test-with-console-plugin-image",
+			consolePluginImage: "custom-image:tag1",
+			operatorVersion:    "0.70.0",
+			targetNamespace:    "bar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+			operatorFakeClientSet := fake.NewSimpleClientset()
+
+			// add reactor to update generateName
+			operatorFakeClientSet.PrependReactor("create", "*", generateNameReactor)
+
+			// TEST: verifies required values in generated manifests (InstallerSet)
+			verifyManifestFunc := func(expectedImage, expectedOperatorVersion string) {
+				// verify installersets availability
+				installerSetList, err := operatorFakeClientSet.OperatorV1alpha1().TektonInstallerSets().List(
+					ctx,
+					metav1.ListOptions{LabelSelector: fmt.Sprintf("operator.tekton.dev/created-by=%s", consolePluginReconcileLabelCreatedByValue)},
+				)
+				require.NoError(t, err)
+
+				require.Equal(t, 1, len(installerSetList.Items))
+				installerSet := installerSetList.Items[0]
+
+				// verify operator version label
+				operatorVersion := installerSet.GetLabels()[v1alpha1.ReleaseVersionKey]
+				require.Equal(t, expectedOperatorVersion, operatorVersion)
+
+				// get installerset and verify transform values
+				for _, u := range installerSet.Spec.Manifests {
+					// verify targetNamespace
+					require.Equal(t, test.targetNamespace, u.GetNamespace())
+
+					switch u.GetKind() {
+					case "Deployment":
+						deployment := &appsv1.Deployment{}
+						err := apimachineryRuntime.DefaultUnstructuredConverter.FromUnstructured(u.Object, deployment)
+						require.NoError(t, err)
+						require.Equal(t, "pipeline-console-plugin", deployment.GetName())
+						container := deployment.Spec.Template.Spec.Containers[0]
+						require.Equal(t, expectedImage, container.Image)
+
+					case "ConsolePlugin":
+						actualNamespace, found, err := unstructured.NestedString(u.Object, "spec", "backend", "service", "namespace")
+						require.NoError(t, err)
+						require.True(t, found)
+						require.Equal(t, test.targetNamespace, actualNamespace)
+
+					}
+				}
+			}
+
+			// reconciler reference
+			postReconcile := &consolePluginReconciler{
+				logger:                 logging.FromContext(ctx).Named("post-reconcile-manifest-test"),
+				operatorClientSet:      operatorFakeClientSet,
+				syncOnce:               sync.Once{},
+				resourcesYamlDirectory: "./testdata/postreconcile_manifest",
+				operatorVersion:        test.operatorVersion,
+			}
+
+			// tekton config CR
+			tektonConfigCR := &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					CommonSpec: v1alpha1.CommonSpec{
+						TargetNamespace: test.targetNamespace,
+					},
+				},
+			}
+
+			// console plugin image
+			consolePluginImage := defaultConsolePluginImage
+			// update image env variable
+			if test.consolePluginImage != "" {
+				t.Setenv("IMAGE_PIPELINE_CONSOLE_PLUGIN", test.consolePluginImage)
+				consolePluginImage = test.consolePluginImage
+			}
+			// TEST: image name
+			err := postReconcile.reconcile(ctx, tektonConfigCR) // perform reconcile
+			require.NoError(t, err)
+			verifyManifestFunc(consolePluginImage, test.operatorVersion) // verify manifests
+
+			// TEST: operator version change
+			// update operator version in installerSet and reconcile
+			postReconcile.operatorVersion = "foo"
+			err = postReconcile.reconcile(ctx, tektonConfigCR) // perform reconcile
+			require.NoError(t, err)
+			verifyManifestFunc(consolePluginImage, "foo") // verify
+			postReconcile.operatorVersion = test.operatorVersion
+
+			// TEST: removal of extra installerSet
+			// add another tekton config manifest post reconcile installerset and reconcile
+			newInstallerSet := &v1alpha1.TektonInstallerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "another-tekton-config-manifest-foo-",
+					Labels:       consolePluginReconcileInstallerSetLabel.MatchLabels,
+				},
+			}
+			_, err = operatorFakeClientSet.OperatorV1alpha1().TektonInstallerSets().Create(ctx, newInstallerSet, metav1.CreateOptions{})
+			require.NoError(t, err)
+			err = postReconcile.reconcile(ctx, tektonConfigCR) // perform reconcile
+			require.NoError(t, err)
+			verifyManifestFunc(consolePluginImage, test.operatorVersion) // verify manifests
+
+			// TEST: do not touch others installerSets
+			// add another installerset(not tekton config manifest post reconcile) and reconcile
+			// this installerSet should not be removed
+			anotherInstallerSetName := "pipelines-foo"
+			anotherInstallerSet := &v1alpha1.TektonInstallerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: anotherInstallerSetName,
+				},
+			}
+			_, err = operatorFakeClientSet.OperatorV1alpha1().TektonInstallerSets().Create(ctx, anotherInstallerSet, metav1.CreateOptions{})
+			require.NoError(t, err)
+			err = postReconcile.reconcile(ctx, tektonConfigCR) // perform reconcile
+			require.NoError(t, err)
+			verifyManifestFunc(consolePluginImage, test.operatorVersion) // verify manifests
+			installerSetList, err := operatorFakeClientSet.OperatorV1alpha1().TektonInstallerSets().List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.Equal(t, 2, len(installerSetList.Items))
+			expectedInstallerSetFound := false
+			for _, installerSet := range installerSetList.Items {
+				if installerSet.GetName() == anotherInstallerSetName {
+					expectedInstallerSetFound = true
+					break
+				}
+			}
+			require.True(t, expectedInstallerSetFound)
+		})
+	}
+}

--- a/pkg/reconciler/openshift/tektonconfig/testdata/postreconcile_manifest/test_post_manifest.yaml
+++ b/pkg/reconciler/openshift/tektonconfig/testdata/postreconcile_manifest/test_post_manifest.yaml
@@ -1,0 +1,126 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  ports:
+  - name: 8443-tcp
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+  selector:
+    name: pipeline-console-plugin
+    app: pipeline-console-plugin
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+data:
+  nginx.conf: |
+    error_log /dev/stdout warn;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              8443 ssl;
+        listen              [::]:8443 ssl;
+        ssl_certificate     /var/cert/tls.crt;
+        ssl_certificate_key /var/cert/tls.key;
+        root                /usr/share/nginx/html;
+      }
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pipeline-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pipeline-console-plugin
+      app: pipeline-console-plugin
+  template:
+    metadata:
+      labels:
+        name: pipeline-console-plugin
+        app: pipeline-console-plugin
+        app.kubernetes.io/part-of: tekton-config
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: pipeline-console-plugin-cert
+          secret:
+            secretName: pipeline-console-plugin-cert
+            defaultMode: 420
+        - name: nginx-conf
+          configMap:
+            name: pipeline-console-plugin
+            defaultMode: 420
+      containers:
+      - name: pipeline-console-plugin
+        image: ghcr.io/openshift-pipelines/console-plugin:main
+        imagePullPolicy: Always
+        ports:
+          - protocol: TCP
+            containerPort: 8443
+        volumeMounts:
+          - name: pipeline-console-plugin-cert
+            readOnly: true
+            mountPath: /var/cert
+          - name: nginx-conf
+            readOnly: true
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+
+---
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: pipeline-console-plugin
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  displayName: Pipeline Console Plugin
+  backend:
+    type: Service
+    service:
+      name: pipeline-console-plugin
+      namespace: openshift-pipelines
+      port: 8443
+      basePath: "/"
+  i18n:
+    loadType: Preload   # options: Preload, Lazy


### PR DESCRIPTION
# Changes

* adds support to manage [pipeline-console-plugin](https://github.com/openshift-pipelines/console-plugin) on openshift

NOTE: This feature is applicable only to OpenShift environment

### Implementation description:
* Added all the required resources as static manifest on `cmd/openshift/operator/kodata/static/tekton-config/00-postreconcile/pipeline_console_plugin.yaml`
* implemented a post reconciler on `tekton-config` under openshift
* Added `console.openshift.io` permission to manage `ConsolePlugin`
* annotation `console.openshift.io/plugins: '["pipeline-console-plugin"]'`  added on openshift csv, this will manage entry on `Console` resource, when we deploy the operator via Operator Hub.

After deployed, To enable the pipeline console plugin manually, add an entry on `Console` resource.
```yaml
apiVersion: operator.openshift.io/v1
kind: Console
metadata:
  name: cluster
spec:
  plugins:
  - pipeline-console-plugin
```

To know more about console plugin visit: https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
