### PR TITLE
Added filesystem-custom-path to allowed x509 fulcio providers

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -28,7 +28,7 @@ import (
 var (
 	allowedArtifactsTaskRunFormat     = sets.NewString("", "in-toto", "slsa/v1")
 	allowedArtifactsPipelineRunFormat = sets.NewString("", "in-toto", "slsa/v1")
-	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem")
+	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem", "filesystem-custom-path")
 	allowedTransparencyConfigEnabled  = sets.NewString("", "true", "false", "manual")
 	allowedArtifactsStorage           = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
 	allowedControllerEnvs             = sets.NewString("MONGO_SERVER_URL")


### PR DESCRIPTION
# Changes

Added filesystem-custom-path to allowed x509 fulcio providers for Tekton Chains

Relevant PR: https://github.com/tektoncd/chains/pull/727/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Adds "filesystem-custom-path" to the list of allowed Chains Fulcio x509 providers
```
