### PR TITLE
Adds logic to create configMap of `hub-info` in targetNamespace

### DIFF
--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -187,7 +187,7 @@ release_yaml_hub() {
   mkdir -p ${dirPath} || true
 
   url=""
-  components="db db-migration api ui"
+  components="db db-migration api ui hub-info"
 
   for component in ${components}; do
     echo fetching Hub '|' component: ${component} '|' version: ${2}

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -84,6 +84,7 @@ const (
 	manifestDirDatabaseMigration = "db-migration"
 	manifestDirAPI               = "api"
 	manifestDirUI                = "ui"
+	manifestDirInfo              = "hub-info"
 
 	// resource names
 	databaseSecretName = "tekton-hub-db"
@@ -318,6 +319,15 @@ func (r *Reconciler) reconcileApiInstallerSet(ctx context.Context, th *v1alpha1.
 		if err != nil {
 			return err
 		}
+
+		infoLocation := filepath.Join(hubDir, manifestDirInfo)
+
+		infoManifest, err := r.getManifest(ctx, th, infoLocation)
+		if err != nil {
+			return err
+		}
+
+		*manifest = manifest.Append(*infoManifest)
 
 		err = applyPVC(ctx, manifest, th)
 		if err != nil {


### PR DESCRIPTION
With the new release of Hub, a configMap is added in the release yaml 
which will be created in the targetNamespace when Hub CR is installed, 
so that `tkn version` can also give the Hub version installed on the cluster

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
