### PR TITLE
Ensure Tekton* CR get the `operatorVersion` label.

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/reconcile.go
@@ -40,7 +40,7 @@ const (
 type Reconciler struct {
 	// installer Set client to do CRUD operations for components
 	installerSetClient *client.InstallerSetClient
-	//manifest has the source manifest of Tekton Pipeline for a
+	// manifest has the source manifest of Tekton Pipeline for a
 	// particular version
 	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform

--- a/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon_test.go
@@ -37,34 +37,34 @@ func TestEnsureTektonAddonCRExists(t *testing.T) {
 	tConfig := pipeline.GetTektonConfig()
 
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
-	_, err := EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err := EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
 	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// make upgrade checks pass
 	makeUpgradeCheckPass(t, ctx, c.OperatorV1alpha1().TektonAddons())
 
 	// next invocation should return RECONCILE_AGAIN_ERR as Dashboard is waiting for installation (prereconcile, postreconcile, installersets...)
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// mark the instance ready
 	markAddonsReady(t, ctx, c.OperatorV1alpha1().TektonAddons())
 
 	// next invocation should return nil error as the instance is ready
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, nil)
 
 	// test update propagation from tektonConfig
 	tConfig.Spec.TargetNamespace = "foobar"
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, nil)
 }
 
@@ -78,7 +78,7 @@ func TestEnsureTektonAddonCRNotExists(t *testing.T) {
 
 	// create an instance for testing other cases
 	tConfig := pipeline.GetTektonConfig()
-	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig)
+	_, err = EnsureTektonAddonExists(ctx, c.OperatorV1alpha1().TektonAddons(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// when an instance exists the first invoacation should make the delete API call and

--- a/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode_test.go
@@ -39,27 +39,27 @@ func TestEnsureOpenShiftPipelinesAsCodeExists(t *testing.T) {
 
 	tConfig.SetDefaults(ctx)
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
-	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
 	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// mark the instance ready
 	markOPACReady(t, ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
 
 	// next invocation should return nil error as the instance is ready
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, nil)
 
 	// test update propagation from tektonConfig
 	tConfig.Spec.TargetNamespace = "foobar"
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, nil)
 }
 
@@ -76,7 +76,7 @@ func TestEnsureOpenShiftPipelinesAsCodeCRNotExists(t *testing.T) {
 	// create an instance for testing other cases
 	tConfig := pipeline.GetTektonConfig()
 	tConfig.SetDefaults(ctx)
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	// when an instance exists the first invoacation should make the delete API call and

--- a/pkg/reconciler/shared/tektonconfig/chain/chain_test.go
+++ b/pkg/reconciler/shared/tektonconfig/chain/chain_test.go
@@ -33,7 +33,7 @@ import (
 func TestEnsureTektonChainExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	tt := GetTektonChainCR(getTektonConfig())
+	tt := GetTektonChainCR(getTektonConfig(), "v0.70.0")
 
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonChainExists(ctx, c.OperatorV1alpha1().TektonChains(), tt)
@@ -76,7 +76,7 @@ func TestEnsureTektonChainCRNotExists(t *testing.T) {
 	util.AssertEqual(t, err, nil)
 
 	// create an instance for testing other cases
-	tt := GetTektonChainCR(getTektonConfig())
+	tt := GetTektonChainCR(getTektonConfig(), "v0.70.0")
 	_, err = EnsureTektonChainExists(ctx, c.OperatorV1alpha1().TektonChains(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline_test.go
@@ -33,7 +33,7 @@ import (
 func TestEnsureTektonPipelineExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	tp := GetTektonPipelineCR(GetTektonConfig())
+	tp := GetTektonPipelineCR(GetTektonConfig(), "v0.70.0")
 
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tp)
@@ -76,7 +76,7 @@ func TestEnsureTektonPipelineCRNotExists(t *testing.T) {
 	util.AssertEqual(t, err, nil)
 
 	// create an instance for testing other cases
-	tp := GetTektonPipelineCR(GetTektonConfig())
+	tp := GetTektonPipelineCR(GetTektonConfig(), "v0.70.0")
 	_, err = EnsureTektonPipelineExists(ctx, c.OperatorV1alpha1().TektonPipelines(), tp)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger_test.go
@@ -33,7 +33,7 @@ import (
 func TestEnsureTektonTriggerExists(t *testing.T) {
 	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
 	c := fake.Get(ctx)
-	tt := GetTektonTriggerCR(GetTektonConfig())
+	tt := GetTektonTriggerCR(GetTektonConfig(), "v0.70.0")
 
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
 	_, err := EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
@@ -76,7 +76,7 @@ func TestEnsureTektonTriggerCRNotExists(t *testing.T) {
 	util.AssertEqual(t, err, nil)
 
 	// create an instance for testing other cases
-	tt := GetTektonTriggerCR(GetTektonConfig())
+	tt := GetTektonTriggerCR(GetTektonConfig(), "v0.70.0")
 	_, err = EnsureTektonTriggerExists(ctx, c.OperatorV1alpha1().TektonTriggers(), tt)
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 


### PR DESCRIPTION
Prior to this change, only `TektonConfig` has the
`operator.tekton.dev/release-version` label set to the "current"
release. This was leading to some confusion around figuring out which
operator version "updated" those files last.

With this change, all `Tekton*` CR (`TektonPipeline`, …) as well as
OpenShift specifices (`PipelinesAsCode`, …) will have this label set
if not present.

```release-note
NONE
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
