### PR TITLE
.github/workflows: skip some workflows on forks

### DIFF
--- a/.github/workflows/bump-payload-on-main.yaml
+++ b/.github/workflows/bump-payload-on-main.yaml
@@ -10,6 +10,7 @@ jobs:
   bump-payloads:
     name: "Bump payloads"
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
     steps:
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -9,6 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build-release-matrix:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
     steps:
     - id: set-matrix
       run: |

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION

# Changes

Make sure the *bump payload* worflows as well as the helm release one,
only run when on the main repository, aka `tektoncd/operator` (aka the
owner is `tektoncd` organization)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

