### PR TITLE
Add config leader election configmaps

### DIFF
--- a/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
+++ b/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
@@ -114,6 +114,8 @@ spec:
               value: proxy-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-operator-proxy-webhook-config-leader-election
           ports:
             - name: https-webhook
               containerPort: 8443
@@ -156,3 +158,43 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: proxy.operator.tekton.dev
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-operator-proxy-webhook-config-leader-election
+  labels:
+    operator.tekton.dev/release: devel
+    app.kubernetes.io/instance: default
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -121,6 +121,8 @@ spec:
               value: proxy-webhook-certs
             - name: METRICS_DOMAIN
               value: tekton.dev/operator
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-operator-proxy-webhook-config-leader-election
           ports:
             - name: https-webhook
               containerPort: 8443
@@ -201,3 +203,43 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: namespace.operator.tekton.dev
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-operator-proxy-webhook-config-leader-election
+  labels:
+    operator.tekton.dev/release: devel
+    app.kubernetes.io/instance: default
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"

--- a/config/base/config-leader-election.yaml
+++ b/config/base/config-leader-election.yaml
@@ -1,0 +1,51 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-operator-controller-config-leader-election
+  labels:
+    operator.tekton.dev/release: devel
+    app.kubernetes.io/instance: default
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -33,5 +33,6 @@ resources:
 - config-info.yaml
 - config-info_role.yaml
 - config-info_role_binding.yaml
+- config-leader-election.yaml
 - tekton_result_role.yaml
 - tekton_result_role_binding.yaml

--- a/config/kubernetes/base/operator.yaml
+++ b/config/kubernetes/base/operator.yaml
@@ -58,6 +58,8 @@ spec:
           value: "devel"
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-operator-controller-config-leader-election
         - name: AUTOINSTALL_COMPONENTS
           valueFrom:
             configMapKeyRef:
@@ -93,3 +95,5 @@ spec:
             value: "devel"
           - name: METRICS_DOMAIN
             value: tekton.dev/operator
+          - name: CONFIG_LEADERELECTION_NAME
+            value: tekton-operator-controller-config-leader-election

--- a/config/kubernetes/base/webhook.yaml
+++ b/config/kubernetes/base/webhook.yaml
@@ -45,6 +45,8 @@ spec:
               fieldPath: metadata.name
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-operator-webhook-config-leader-election
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-operator-webhook
         - name: WEBHOOK_SECRET_NAME

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -80,6 +80,8 @@ spec:
               key: DEFAULT_TARGET_NAMESPACE
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-operator-controller-config-leader-election
         - name: IMAGE_HUB_TEKTON_HUB_DB
           value: registry.redhat.io/rhel8/postgresql-13@sha256:f0083c3398501e3b7c82e7f865cd3377ff14cbfb14b1f8f91d7889232afa4796
         - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
@@ -126,3 +128,5 @@ spec:
             value: "devel"
           - name: METRICS_DOMAIN
             value: tekton.dev/operator
+          - name: CONFIG_LEADERELECTION_NAME
+            value: tekton-operator-controller-config-leader-election

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -49,6 +49,8 @@ spec:
               fieldPath: metadata.name
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-operator-webhook-config-leader-election
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-operator-webhook
         - name: WEBHOOK_SECRET_NAME

--- a/config/webhooks/kustomization.yaml
+++ b/config/webhooks/kustomization.yaml
@@ -15,5 +15,6 @@ namespace: tekton-operator
 
 resources:
 - webhook.yaml
+- webhook-config-leader-election.yaml
 - webhook-service.yaml
 - webhook-secret.yaml

--- a/config/webhooks/webhook-config-leader-election.yaml
+++ b/config/webhooks/webhook-config-leader-election.yaml
@@ -1,0 +1,51 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-operator-webhook-config-leader-election
+  labels:
+    operator.tekton.dev/release: devel
+    app.kubernetes.io/instance: default
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"


### PR DESCRIPTION
This will add configmap leader election configmaps for all the deployments created by operator install like operator controller, operator webhook and proxy webhook

This is to make sure that each controller have their config managed separately and also can be configured separately for each component

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add config leader election configmaps for operator controller, operator webhook and proxy webhook
```