### PR TITLE
[main] add hpa under options and support pod template labels and annotations

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -447,12 +447,12 @@ platforms:
 [priorityClass]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
 
 ### Additional fields as `options`
-There is a filed called `options` available in all the components.<br>
+There is a field called `options` available in all the components.<br>
 
 >**NOTE:** There is a possibility to have two different values for a field.<br> 
-An example: with a pre-defined field you can set value and the same filed may be defined under `options` as well. In that case value from `options` will be final.
+An example: with a pre-defined field you can set value and the same field may be defined under `options` as well. In that case value from `options` will be final.
 
-`options` filed is defined as follows,
+A sample `options` field,
 ```yaml
 options:
   disabled: false
@@ -496,7 +496,7 @@ options:
           }
 
   deployments:
-    tekton-pipelines-controller:
+    tekton-pipelines-controller: # name of the deployment
       metadata:
         labels:
           custom-label: "foo"
@@ -512,7 +512,7 @@ options:
                   - name: CONFIG_LOGGING_NAME
                     value: pipeline-config-logging
   statefulSets:
-    web:
+    web: # name of the statefulSets
       metadata:
         labels:
           custom-label: foo
@@ -527,8 +527,23 @@ options:
                 env:
                   - name: NGINX_MODE
                     value: production
+  horizontalPodAutoscalers:
+    tekton-pipelines-webhook: # name of the hpa
+      metadata:
+        annotations:
+        labels:
+      spec:
+        minReplicas: 2
+        maxReplicas: 7
+        metrics:
+        - resource:
+            name: cpu
+            target:
+              averageUtilization: 85
+              type: Utilization
+          type: Resource
 ```
-* `disabled` - disables the additional `options` support, if `disabled` set as `true`. default: `false`
+* `disabled` - disables the additional `options` support, if `disabled` set to `true`. default: `false`
 
 #### ConfigMaps
 Supports to update existing configMap also supports to create new configMap.
@@ -549,6 +564,9 @@ The following fields are supported in `deployment`
 * `spec`
   * `replicas` - updates deployment replicas count
   * `template`
+    * `metadata`
+      * `labels` - supports add and update
+      * `annotations` - supports add and update
     * `spec`
       * `affinity` - replaces the existing Affinity with this, if not empty
       * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
@@ -580,6 +598,9 @@ The following fields are supported in `StatefulSet`
   * `podManagementPolicy` - updates pod management policy
   * `volumeClaimTemplates` - updates volume claim templates
   * `template`
+    * `metadata`
+      * `labels` - supports add and update
+      * `annotations` - supports add and update
     * `spec`
       * `affinity` - replaces the existing Affinity with this, if not empty
       * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
@@ -597,5 +618,21 @@ The following fields are supported in `StatefulSet`
         * `envs` - adds and updates environments
         * `volumeMounts` - adds and updates VolumeMounts
         * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS** 
+
+#### HorizontalPodAutoscalers
+Supports to update the existing HorizontalPodAutoscaler(HPA) also supports to create new HPA.
+
+The following fields are supported in `HorizontalPodAutoscaler` (aka HPA)
+* `metadata`
+  * `labels` - supports add and update
+  * `annotations` - supports add and update
+* `spec`
+  * `scaleTargetRef` - replaces scaleTargetRef with this, if `kind` and `name` are not empty
+  * `minReplicas` - updates minimum replicas count
+  * `maxReplicas` - updates maximum replicas count
+  * `metrics` - replaces the metrics details with this array, if not empty
+  * `behavior` - updates behavior data with this, if not empty
+    * `scaleUp` - replaces scaleUp with this, if not empty
+    * `scaleDown` - replaces scaleDown with this, if not empty
 
 **NOTE**: If a Deployment or StatefulSet has a Horizontal Pod Autoscaling (HPA) and is in active state, Operator will not control the replicas to that resource. However if `status.desiredReplicas` and `spec.minReplicas` not present in HPA, operator takes the control. Also if HPA disabled, operator takes control. Even though the operator takes the control, the replicas value will be adjusted to the hpa's scaling range.

--- a/pkg/apis/operator/v1alpha1/additional_options.go
+++ b/pkg/apis/operator/v1alpha1/additional_options.go
@@ -18,14 +18,16 @@ package v1alpha1
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // additional options will be updated on the manifests
 // these values will be final
 type AdditionalOptions struct {
-	Disabled     bool                          `json:"disabled"`
-	ConfigMaps   map[string]corev1.ConfigMap   `json:"configMaps,omitempty"`
-	Deployments  map[string]appsv1.Deployment  `json:"deployments,omitempty"`
-	StatefulSets map[string]appsv1.StatefulSet `json:"statefulSets,omitempty"`
+	Disabled                 bool                                             `json:"disabled"`
+	ConfigMaps               map[string]corev1.ConfigMap                      `json:"configMaps,omitempty"`
+	Deployments              map[string]appsv1.Deployment                     `json:"deployments,omitempty"`
+	HorizontalPodAutoscalers map[string]autoscalingv2.HorizontalPodAutoscaler `json:"horizontalPodAutoscalers,omitempty"`
+	StatefulSets             map[string]appsv1.StatefulSet                    `json:"statefulSets,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	manifestival "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
+	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -41,6 +42,13 @@ func (in *AdditionalOptions) DeepCopyInto(out *AdditionalOptions) {
 	if in.Deployments != nil {
 		in, out := &in.Deployments, &out.Deployments
 		*out = make(map[string]appsv1.Deployment, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
+		}
+	}
+	if in.HorizontalPodAutoscalers != nil {
+		in, out := &in.HorizontalPodAutoscalers, &out.HorizontalPodAutoscalers
+		*out = make(map[string]v2.HorizontalPodAutoscaler, len(*in))
 		for key, val := range *in {
 			(*out)[key] = *val.DeepCopy()
 		}

--- a/pkg/reconciler/common/testdata/test-additional-options-base-hpa.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-base-hpa.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    test: hello
+    foo: foo
+  labels:
+    test: hello
+    foo: foo
+  name: existing-hpa
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tekton-pipelines-webhook
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 100
+          type: Utilization
+      type: Resource
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  name: test-max-replicas
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 0
+  maxReplicas: 1
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0

--- a/pkg/reconciler/common/testdata/test-additional-options-test-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-deployment.yaml
@@ -62,9 +62,12 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        annotation-foo: annotation-bar
       labels:
         app.kubernetes.io/name: controller
-        operator.tekton.dev/deployment-spec-applied-hash: 1704bb3edd32937a1659b4d42c9f1669
+        label-foo: label-bar
+        operator.tekton.dev/deployment-spec-applied-hash: adf5ca03f3b1b83fa0ccd493ab932fa3
     spec:
       affinity:
         nodeAffinity:

--- a/pkg/reconciler/common/testdata/test-additional-options-test-hpa.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-hpa.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  annotations:
+    test: hello
+    foo: bar
+    annotation1: value1
+  labels:
+    test: hello
+    foo: bar
+    label1: value1
+  name: existing-hpa
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 20
+    scaleUp:
+      stabilizationWindowSeconds: 10
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  name: test-max-replicas
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  annotations:
+    foo: bar
+  labels:
+    foo: bar
+  name: new-hpa
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: foo
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 100
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0

--- a/pkg/reconciler/common/testdata/test-additional-options-test-statefulsets.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-statefulsets.yaml
@@ -16,8 +16,11 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        annotation-foo: annotation-bar
       labels:
         app: nginx
+        label-foo: label-bar
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
# Changes

* update/create HorizontalPodAutoscaler support added via `options`
* fixes: [SRVKP-3731](https://issues.redhat.com/browse/SRVKP-3731) - tekton-pipelines-webhook HorizontalPodAutoscaler should be set to minReplicas:2
* pod template labels and annotations supported by options. Fixes: #1903
* closes: #1812

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
- Added support to update/create HorizontalPodAutoscaler via `options`.
- Added support for adding labels and annotations on Deployments and StatefulSets podTemplate via `options`.
```
