### PR TITLE
Add OpenShift PostReconcile Extension for Results Route RBAC

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: tekton-results-route-view
+  namespace: openshift-pipelines
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  resourceNames:
+  - tekton-results-api-service
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-results-route-view-auth
+roleRef:
+  kind: ClusterRole
+  name: tekton-results-route-view
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/pkg/apis/operator/v1alpha1/tektonresult_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_lifecycle.go
@@ -28,6 +28,7 @@ var (
 		DependenciesInstalled,
 		InstallerSetAvailable,
 		InstallerSetReady,
+		PostReconciler,
 	)
 )
 
@@ -70,6 +71,10 @@ func (trs *TektonResultStatus) MarkInstallerSetAvailable() {
 	resultsCondSet.Manage(trs).MarkTrue(InstallerSetAvailable)
 }
 
+func (trs *TektonResultStatus) MarkInstallerSetReady() {
+	resultsCondSet.Manage(trs).MarkTrue(InstallerSetReady)
+}
+
 func (trs *TektonResultStatus) MarkInstallerSetNotAvailable(msg string) {
 	trs.MarkNotReady("TektonInstallerSet not ready")
 	resultsCondSet.Manage(trs).MarkFalse(
@@ -78,16 +83,16 @@ func (trs *TektonResultStatus) MarkInstallerSetNotAvailable(msg string) {
 		"Installer set not ready: %s", msg)
 }
 
-func (trs *TektonResultStatus) MarkInstallerSetReady() {
-	resultsCondSet.Manage(trs).MarkTrue(InstallerSetReady)
-}
-
 func (trs *TektonResultStatus) MarkInstallerSetNotReady(msg string) {
 	trs.MarkNotReady("TektonInstallerSet not ready")
 	resultsCondSet.Manage(trs).MarkFalse(
 		InstallerSetReady,
 		"Error",
 		"Installer set not ready: %s", msg)
+}
+
+func (trs *TektonResultStatus) MarkPostReconcilerComplete() {
+	resultsCondSet.Manage(trs).MarkTrue(PostReconciler)
 }
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.

--- a/pkg/apis/operator/v1alpha1/tektonresult_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_lifecycle_test.go
@@ -58,6 +58,9 @@ func TestTektonResultHappyPath(t *testing.T) {
 	tt.MarkInstallerSetReady()
 	apistest.CheckConditionSucceeded(tt, InstallerSetReady, t)
 
+	tt.MarkPostReconcilerComplete()
+	apistest.CheckConditionSucceeded(tt, PostReconciler, t)
+
 	if ready := tt.IsReady(); !ready {
 		t.Errorf("tt.IsReady() = %v, want true", ready)
 	}
@@ -90,6 +93,9 @@ func TestTektonResultErrorPath(t *testing.T) {
 	// InstallerSet and then PostReconciler become ready and we're good.
 	tt.MarkInstallerSetReady()
 	apistest.CheckConditionSucceeded(tt, InstallerSetReady, t)
+
+	tt.MarkPostReconcilerComplete()
+	apistest.CheckConditionSucceeded(tt, PostReconciler, t)
 
 	if ready := tt.IsReady(); !ready {
 		t.Errorf("tt.IsReady() = %v, want true", ready)

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -104,9 +104,12 @@ func (in *TektonResultStatus) MarkPreReconcilerFailed(s string) {
 	panic("implement me")
 }
 
-func (in *TektonResultStatus) MarkPostReconcilerFailed(s string) {
-	//TODO implement me
-	panic("implement me")
+func (trs *TektonResultStatus) MarkPostReconcilerFailed(msg string) {
+	trs.MarkNotReady("PostReconciliation failed")
+	resultsCondSet.Manage(trs).MarkFalse(
+		PostReconciler,
+		"Error",
+		msg)
 }
 
 // TektonResultsList contains a list of TektonResult

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -262,7 +262,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 		}
 	}
 
-	// Mark InstallerSetAvailable
+	// Mark InstallerSet Available
 	tr.Status.MarkInstallerSetAvailable()
 
 	ready := installedTIS.Status.GetCondition(apis.ConditionReady)
@@ -279,8 +279,21 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 		return v1alpha1.REQUEUE_EVENT_AFTER
 	}
 
-	// Mark InstallerSet Ready
+	// MarkInstallerSetReady
 	tr.Status.MarkInstallerSetReady()
+
+	if err := r.extension.PostReconcile(ctx, tr); err != nil {
+		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
+		logger.Error(msg)
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		tr.Status.MarkPostReconcilerFailed(msg)
+		return nil
+	}
+
+	// Mark PostReconcile Complete
+	tr.Status.MarkPostReconcilerComplete()
 
 	return nil
 }

--- a/pkg/reconciler/openshift/tektonresult/extension_test.go
+++ b/pkg/reconciler/openshift/tektonresult/extension_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonresult
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetRouteManifest(t *testing.T) {
+	os.Setenv(common.KoEnvKey, "notExist")
+	_, err := getRouteManifest()
+	if err == nil {
+		t.Error("expected error, received no error")
+	}
+
+	os.Setenv(common.KoEnvKey, "testdata")
+	mf, err := getRouteManifest()
+	assertNoEror(t, err)
+
+	cr := &rbac.ClusterRole{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(mf.Resources()[0].Object, cr)
+	assertNoEror(t, err)
+
+}
+
+func assertNoEror(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("assertion failed; expected no error %v", err)
+	}
+}

--- a/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
+++ b/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: tekton-results-route-view
+  namespace: openshift-pipelines
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  resourceNames:
+  - tekton-results-api-service
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-results-route-view-auth
+roleRef:
+  kind: ClusterRole
+  name: tekton-results-route-view
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated


### PR DESCRIPTION
Enables system:authenticated user to view route to Tekton Results API.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
system:authenticated user can view route for Tekton Results API endpoints.

```