### PR TITLE
expose securitycontext to values in helm chart

### DIFF
--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
           name: tekton-operator-lifecycle
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -125,6 +129,14 @@ spec:
           name: tekton-operator-cluster-operations
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tekton-operator.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -198,9 +210,17 @@ spec:
           name: {{ include "tekton-operator.operator-name" . -}}-webhook
           resources:
             {{- toYaml .Values.webhook.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.webhook.httpsWebhookPort }}
               name: https-webhook
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tekton-operator.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
expose securitycontext configuration to values in tekton-operator chart for the operator and operator-webhook deployments

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

expose securitycontext configuration to values in tekton-operator chart for the operator and operator-webhook deployments

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```

