### PR TITLE
Update buildah task to support RHEL entitlement

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -59,6 +59,13 @@ spec:
       The file should be placed at the root of the Workspace with name config.json
       or .dockerconfigjson.
     optional: true
+  - description: >-
+      An optional workspace that allows providing the entitlement keys
+      for Buildah to access subscription. The mounted workspace contains
+      entitlement.pem and entitlement-key.pem.
+    name: rhel-entitlement
+    optional: true
+    mountPath: /tmp/entitlement
 
   results:
   - name: IMAGE_DIGEST
@@ -71,9 +78,15 @@ spec:
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
     script: |
-      buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
-        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
-        --tls-verify=$(params.TLSVERIFY) --no-cache \
+      ENTITLEMENT_VOLUME=""
+
+      if [[ "$(workspaces.rhel-entitlement.bound)" == "true" ]]; then
+        ENTITLEMENT_VOLUME="--volume /tmp/entitlement:/etc/pki/entitlement"
+      fi
+
+      buildah bud --storage-driver=$(params.STORAGE_DRIVER) \
+        $ENTITLEMENT_VOLUME $(params.BUILD_EXTRA_ARGS) \
+        --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) --no-cache \
         -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
 
       [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0


### PR DESCRIPTION
# Changes

with this changes now buildah task can be used for rhel 
entitlement where user can install rhel subscribed tools/packages
 
Signed-off-by: Savita Ashture <sashture@redhat.com>

* Fixes: [SRVKP-4016](https://issues.redhat.com/browse/SRVKP-4016) - Update buildah task to have optional workspace for RHEL entitlment

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
addd RHEL entitlement support to buildah task
```