### PR TITLE
[main] initialize labels of old object to avoid nil error

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension/addon.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/addon.go
@@ -94,6 +94,11 @@ func updateAddon(ctx context.Context, taCR *v1alpha1.TektonAddon, config *v1alph
 	// if the addon spec is changed then update the instance
 	updated := false
 
+	// initialize labels(map) object
+	if taCR.ObjectMeta.Labels == nil {
+		taCR.ObjectMeta.Labels = map[string]string{}
+	}
+
 	if config.Spec.TargetNamespace != taCR.Spec.TargetNamespace {
 		taCR.Spec.TargetNamespace = config.Spec.TargetNamespace
 		updated = true

--- a/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode.go
@@ -95,6 +95,11 @@ func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, 
 	// if the pac spec is changed then update the instance
 	updated := false
 
+	// initialize labels(map) object
+	if opacCR.ObjectMeta.Labels == nil {
+		opacCR.ObjectMeta.Labels = map[string]string{}
+	}
+
 	if config.Spec.TargetNamespace != opacCR.Spec.TargetNamespace {
 		opacCR.Spec.TargetNamespace = config.Spec.TargetNamespace
 		updated = true

--- a/pkg/reconciler/shared/tektonconfig/chain/chain.go
+++ b/pkg/reconciler/shared/tektonconfig/chain/chain.go
@@ -92,6 +92,11 @@ func UpdateChain(ctx context.Context, old *v1alpha1.TektonChain, new *v1alpha1.T
 	// if the chain spec is changed then update the instance
 	updated := false
 
+	// initialize labels(map) object
+	if old.ObjectMeta.Labels == nil {
+		old.ObjectMeta.Labels = map[string]string{}
+	}
+
 	if new.Spec.TargetNamespace != old.Spec.TargetNamespace {
 		old.Spec.TargetNamespace = new.Spec.TargetNamespace
 		updated = true

--- a/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
+++ b/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go
@@ -91,6 +91,11 @@ func UpdatePipeline(ctx context.Context, old *v1alpha1.TektonPipeline, new *v1al
 	// if the pipeline spec is changed then update the instance
 	updated := false
 
+	// initialize labels(map) object
+	if old.ObjectMeta.Labels == nil {
+		old.ObjectMeta.Labels = map[string]string{}
+	}
+
 	if new.Spec.TargetNamespace != old.Spec.TargetNamespace {
 		old.Spec.TargetNamespace = new.Spec.TargetNamespace
 		updated = true

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
@@ -90,6 +90,11 @@ func UpdateTrigger(ctx context.Context, old *v1alpha1.TektonTrigger, new *v1alph
 	// if the trigger spec is changed then update the instance
 	updated := false
 
+	// initialize labels(map) object
+	if old.ObjectMeta.Labels == nil {
+		old.ObjectMeta.Labels = map[string]string{}
+	}
+
 	if new.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey] != old.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey] {
 		old.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey] = new.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey]
 		updated = true


### PR DESCRIPTION
# Changes

* Updating operator version introduced on #1929, not performed `nil` check on the target object that leads `nil` error
* With this PR fixes the `nil` error by initializing labels(map) object
* I hope this PR might fix [SRVKP-4114](https://issues.redhat.com/browse/SRVKP-4114) - Openshift Pipelines operator upgrade from 1.13.1 to 1.14.0 is failing

Error:
```
panic: assignment to entry in nil map

goroutine 2953 [running]:
github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline.UpdatePipeline({0x2622e50, 0xc0026716e0}, 0xc00034c000, 0xc001553b00, {0x262c5b8, 0xc002dfbb70})
	/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go:122 +0x553
github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline.EnsureTektonPipelineExists({0x2622e50, 0xc0026716e0}, {0x262c5b8?, 0xc002dfbb70}, 0x5?)
	/go/src/github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline/pipeline.go:45 +0x19b
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
