### PR TITLE
Lower down the threshold for scaling operator proxy webhook

### DIFF
--- a/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
+++ b/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
@@ -229,4 +229,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 100
+          averageUtilization: 85

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -274,4 +274,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 100
+          averageUtilization: 85


### PR DESCRIPTION
This will lower down the threshold for scaling
operator proxy webhook from 100 to 85 as we wil have some space to handle requests till the time new
replica start handling requests

* Initially the HPA webhook things added on #1946

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Lower down the threshold for scaling operator proxy webhook
```