### PR TITLE
Adds recently added pipelinerun and builder artifacts to chains spec

### DIFF
--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -84,6 +84,7 @@ spec:
   artifacts.pipelinerun.format: in-toto
   artifacts.pipelinerun.storage: tekton,oci (comma separated values)
   artifacts.pipelinerun.signer: x509
+  artifacts.pipelinerun.enable-deep-inspection: #value (boolean - true/false)
   storage.gcs.bucket: #value
   storage.oci.repository: #value
   storage.oci.repository.insecure: #value (boolean - true/false)
@@ -92,6 +93,7 @@ spec:
   storage.grafeas.noteid: #value
   storage.grafeas.notehint: #value
   builder.id: #value
+  builddefinition.buildtype: #value
   signers.x509.fulcio.enabled: #value (boolean - true/false)
   signers.x509.fulcio.address: #value
   signers.x509.fulcio.issuer: #value

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -80,9 +80,10 @@ type ChainProperties struct {
 	ArtifactsTaskRunSigner  string  `json:"artifacts.taskrun.signer,omitempty"`
 
 	// pipelinerun artifacts config
-	ArtifactsPipelineRunFormat  string  `json:"artifacts.pipelinerun.format,omitempty"`
-	ArtifactsPipelineRunStorage *string `json:"artifacts.pipelinerun.storage,omitempty"`
-	ArtifactsPipelineRunSigner  string  `json:"artifacts.pipelinerun.signer,omitempty"`
+	ArtifactsPipelineRunFormat               string  `json:"artifacts.pipelinerun.format,omitempty"`
+	ArtifactsPipelineRunStorage              *string `json:"artifacts.pipelinerun.storage,omitempty"`
+	ArtifactsPipelineRunSigner               string  `json:"artifacts.pipelinerun.signer,omitempty"`
+	ArtifactsPipelineRunEnableDeepInspection *bool   `json:"artifacts.pipelinerun.enable-deep-inspection,omitempty"`
 
 	// oci artifacts config
 	ArtifactsOCIFormat  string  `json:"artifacts.oci.format,omitempty"`
@@ -99,7 +100,8 @@ type ChainProperties struct {
 	StorageGrafeasNoteHint       string `json:"storage.grafeas.notehint,omitempty"`
 
 	// builder config
-	BuilderID string `json:"builder.id,omitempty"`
+	BuilderID                string `json:"builder.id,omitempty"`
+	BuildDefinitionBuildType string `json:"builddefinition.buildtype,omitempty"`
 
 	// x509 signer config
 	X509SignerFulcioEnabled     *bool  `json:"signers.x509.fulcio.enabled,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -26,12 +26,13 @@ import (
 )
 
 var (
-	allowedArtifactsTaskRunFormat     = sets.NewString("", "in-toto", "slsa/v1")
-	allowedArtifactsPipelineRunFormat = sets.NewString("", "in-toto", "slsa/v1")
+	allowedArtifactsTaskRunFormat     = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
+	allowedArtifactsPipelineRunFormat = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
 	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem", "filesystem-custom-path")
 	allowedTransparencyConfigEnabled  = sets.NewString("", "true", "false", "manual")
 	allowedArtifactsStorage           = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
 	allowedControllerEnvs             = sets.NewString("MONGO_SERVER_URL")
+	allowedBuildDefinitionType        = sets.NewString("", "https://tekton.dev/chains/v2/slsa", "https://tekton.dev/chains/v2/slsa-tekton")
 )
 
 func (tc *TektonChain) Validate(ctx context.Context) (errs *apis.FieldError) {
@@ -132,6 +133,10 @@ func (tcs *TektonChainSpec) ValidateChainConfig(path string) (errs *apis.FieldEr
 
 	if !allowedTransparencyConfigEnabled.Has(string(tcs.TransparencyConfigEnabled)) {
 		errs = errs.Also(apis.ErrInvalidValue(tcs.TransparencyConfigEnabled, path+".transparency.enabled"))
+	}
+
+	if !allowedBuildDefinitionType.Has(tcs.BuildDefinitionBuildType) {
+		errs = errs.Also(apis.ErrInvalidValue(tcs.BuildDefinitionBuildType, path+".builddefinition.buildtype"))
 	}
 
 	return errs

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
@@ -290,6 +290,42 @@ func Test_ValidateTektonChain_ConfigTransparencyConfigEnabled(t *testing.T) {
 	}
 }
 
+func Test_ValidateTektonChain_InvalidConfigBuildDefinitionType(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+	tc.Spec.Chain.ChainProperties.BuildDefinitionBuildType = "foo"
+	err := tc.Validate(context.TODO())
+	assert.Equal(t, "invalid value: foo: spec.builddefinition.buildtype", err.Error())
+}
+
+func Test_ValidateTektonChain_ConfigBuildDefinitionType(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+	tc.Spec.Chain.ChainProperties.BuildDefinitionBuildType = "https://tekton.dev/chains/v2/slsa"
+	err := tc.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("ValidateTektonChain.Validate() expected no error for the given config, but got one, ValidateTektonChain: %v", err)
+	}
+}
+
 func Test_ValidateTektonChain_InvalidControllerEnv(t *testing.T) {
 	tc := &TektonChain{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -213,6 +213,11 @@ func (in *ChainProperties) DeepCopyInto(out *ChainProperties) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ArtifactsPipelineRunEnableDeepInspection != nil {
+		in, out := &in.ArtifactsPipelineRunEnableDeepInspection, &out.ArtifactsPipelineRunEnableDeepInspection
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ArtifactsOCIStorage != nil {
 		in, out := &in.ArtifactsOCIStorage, &out.ArtifactsOCIStorage
 		*out = new(string)


### PR DESCRIPTION
Following are the artifacts added

* artifacts.pipelinerun.enable-deep-inspection
* builddefinition.buildtype

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Adds support for `artifacts.pipelinerun.enable-deep-inspection` and `builddefinition.buildtype` to Chains spec
```
