### PR TITLE
Fix the results reconciler's manifest reference 

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -488,7 +488,6 @@ func replaceNamespaceInDBAddress(envs []corev1.EnvVar, targetNamespace string) [
 		if slices.Contains(req, e.Name) {
 			envs[i].Value = strings.ReplaceAll(e.Value, "tekton-pipelines", targetNamespace)
 		}
-
 	}
 	return envs
 }

--- a/pkg/reconciler/kubernetes/tektonresult/controller.go
+++ b/pkg/reconciler/kubernetes/tektonresult/controller.go
@@ -71,7 +71,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			kubeClientSet:     kubeclient.Get(ctx),
 			operatorClientSet: operatorclient.Get(ctx),
 			extension:         generator(ctx),
-			manifest:          manifest,
+			manifest:          &manifest,
 			pipelineInformer:  tektonPipelineInformer.Get(ctx),
 			operatorVersion:   operatorVer,
 			resultsVersion:    resultsVer,

--- a/pkg/reconciler/kubernetes/tektonresult/filter.go
+++ b/pkg/reconciler/kubernetes/tektonresult/filter.go
@@ -26,10 +26,11 @@ const (
 	servicePostgresDB = "tekton-results-postgres-service"
 )
 
-func (r *Reconciler) filterExternalDB(tr *v1alpha1.TektonResult) {
+func filterExternalDB(tr *v1alpha1.TektonResult, manifest mf.Manifest) *mf.Manifest {
 	if tr.Spec.IsExternalDB {
-		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("StatefulSet"), mf.ByName(statefulSetDB))))
-		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("ConfigMap"), mf.ByName(configPostgresDB))))
-		r.manifest = r.manifest.Filter(mf.Not(mf.All(mf.ByKind("Service"), mf.ByName(servicePostgresDB))))
+		manifest = manifest.Filter(mf.Not(mf.All(mf.ByKind("StatefulSet"), mf.ByName(statefulSetDB))))
+		manifest = manifest.Filter(mf.Not(mf.All(mf.ByKind("ConfigMap"), mf.ByName(configPostgresDB))))
+		manifest = manifest.Filter(mf.Not(mf.All(mf.ByKind("Service"), mf.ByName(servicePostgresDB))))
 	}
+	return &manifest
 }

--- a/pkg/reconciler/kubernetes/tektonresult/filter_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/filter_test.go
@@ -32,17 +32,13 @@ func Test_filterExternalDB(t *testing.T) {
 	num := len(manifest.Resources())
 	assert.Equal(t, num, 4)
 	assert.Equal(t, manifest.Resources()[0].GetName(), statefulSetDB)
-	r := &Reconciler{
-		manifest: manifest,
-	}
-	r.filterExternalDB(&v1alpha1.TektonResult{
+	manifest = *filterExternalDB(&v1alpha1.TektonResult{
 		Spec: v1alpha1.TektonResultSpec{
 			ResultsAPIProperties: v1alpha1.ResultsAPIProperties{
 				IsExternalDB: true,
 			},
 		},
-	})
-	manifest = r.manifest
+	}, manifest)
 	num = len(manifest.Resources())
 	assert.Equal(t, num, 1)
 	assert.Equal(t, manifest.Resources()[0].GetName(), statefulSetDB+"-external")

--- a/pkg/reconciler/kubernetes/tektonresult/installerset.go
+++ b/pkg/reconciler/kubernetes/tektonresult/installerset.go
@@ -26,10 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.TektonResult) (*v1alpha1.TektonInstallerSet, error) {
+func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.TektonResult, manifest mf.Manifest) (*v1alpha1.TektonInstallerSet, error) {
 
-	r.filterExternalDB(tr)
-	if err := r.transform(ctx, &r.manifest, tr); err != nil {
+	if err := r.transform(ctx, &manifest, tr); err != nil {
 		tr.Status.MarkNotReady("transformation failed: " + err.Error())
 		return nil, err
 	}
@@ -44,7 +43,7 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.Tekton
 	}
 
 	// create installer set
-	tis := r.makeInstallerSet(tr, r.manifest, specHash)
+	tis := r.makeInstallerSet(tr, manifest, specHash)
 	createdIs, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		Create(ctx, tis, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -68,6 +68,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	resultImgs := common.ToLowerCaseKeys(common.ImagesFromEnv(common.ResultsImagePrefix))
 
 	targetNs := comp.GetSpec().GetTargetNamespace()
+	manifest = filterExternalDB(instance, *manifest)
 	extra := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdResults),
 		common.ApplyProxySettings,
@@ -98,7 +99,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 
 func enablePVCLogging(p v1alpha1.ResultsAPIProperties) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
-		if p.LoggingPVCName == "" || p.LogsPath == "" || u.GetKind() != "Deployment" || u.GetName() != deploymentAPI {
+		if !p.LogsAPI || p.LoggingPVCName == "" || p.LogsPath == "" || u.GetKind() != "Deployment" || u.GetName() != deploymentAPI {
 			return nil
 		}
 


### PR DESCRIPTION
Earlier reconciler's manifest value was being changed every cycle. This fixes is so that, we have same manifest every reconciler. We take value from reconciler at the start of reconcile cycle and transform it.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
