### PR TITLE
[main] fix HPA maxReplicas update and disable HPA creation via options 

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -626,7 +626,8 @@ The following fields are supported in `StatefulSet`
         * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS** 
 
 #### HorizontalPodAutoscalers
-Supports to update the existing HorizontalPodAutoscaler(HPA) also supports to create new HPA.
+Supports to update the existing HorizontalPodAutoscaler(HPA) ~~also supports to create new HPA.~~
+There is open [issue](https://github.com/tektoncd/operator/issues/2002) on `options` transformer. Until resolve the issue create HPA feature will not be available.
 
 The following fields are supported in `HorizontalPodAutoscaler` (aka HPA)
 * `metadata`

--- a/pkg/reconciler/common/testdata/test-additional-options-base-hpa.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-base-hpa.yaml
@@ -30,7 +30,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
-  name: test-max-replicas
+  name: test-metrics
   namespace: tekton-pipelines
 spec:
   scaleTargetRef:
@@ -39,6 +39,56 @@ spec:
     name: bar
   minReplicas: 0
   maxReplicas: 1
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  name: test-max-replicas
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 3
+  maxReplicas: 5
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  name: test-min-replicas
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 1
+  maxReplicas: 5
   metrics:
     - resource:
         name: cpu

--- a/pkg/reconciler/common/testdata/test-additional-options-test-hpa.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-hpa.yaml
@@ -41,6 +41,30 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
+  name: test-metrics
+  namespace: tekton-pipelines
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bar
+  minReplicas: 0
+  maxReplicas: 1
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
   name: test-max-replicas
   namespace: tekton-pipelines
 spec:
@@ -48,8 +72,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: bar
-  minReplicas: 1
-  maxReplicas: 2
+  minReplicas: 3
+  maxReplicas: 9
   metrics:
     - resource:
         name: cpu
@@ -66,26 +90,53 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
-  annotations:
-    foo: bar
-  labels:
-    foo: bar
-  name: new-hpa
+  name: test-min-replicas
   namespace: tekton-pipelines
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: foo
+    name: bar
   minReplicas: 2
   maxReplicas: 5
   metrics:
     - resource:
         name: cpu
         target:
-          averageUtilization: 100
+          averageUtilization: 80
           type: Utilization
       type: Resource
 status:
   currentMetrics: null
   desiredReplicas: 0
+
+# disabled HPA creation until we resolve the bug
+# BUG: https://github.com/tektoncd/operator/issues/2002
+# ---
+# apiVersion: autoscaling/v2
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   creationTimestamp: null
+#   annotations:
+#     foo: bar
+#   labels:
+#     foo: bar
+#   name: new-hpa
+#   namespace: tekton-pipelines
+# spec:
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: foo
+#   minReplicas: 2
+#   maxReplicas: 5
+#   metrics:
+#     - resource:
+#         name: cpu
+#         target:
+#           averageUtilization: 100
+#           type: Utilization
+#       type: Resource
+# status:
+#   currentMetrics: null
+#   desiredReplicas: 0

--- a/pkg/reconciler/common/transformer_additional_options_test.go
+++ b/pkg/reconciler/common/transformer_additional_options_test.go
@@ -503,7 +503,7 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 							},
 						},
 					},
-					"test-max-replicas": {
+					"test-metrics": {
 						Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 							ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 								APIVersion: "apps/v1",
@@ -524,6 +524,18 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 									Type: autoscalingv2.ResourceMetricSourceType,
 								},
 							},
+						},
+					},
+					"test-max-replicas": {
+						Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+							MinReplicas: nil,
+							MaxReplicas: 9,
+						},
+					},
+					"test-min-replicas": {
+						Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+							MinReplicas: ptr.Int32(2),
+							MaxReplicas: 0,
 						},
 					},
 				},


### PR DESCRIPTION
# Changes

* fixes [SRVKP-4160](https://issues.redhat.com/browse/SRVKP-4160) - on "options" leaving maxReplicas on HPA, updates minReplicas+1 on the cluster
* fixes [SRVKP-4161](https://issues.redhat.com/browse/SRVKP-4161) - disable HPA creation via options
   * HPA will be enabled once the issue resolved #2002

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
- HPA creation disabled, see https://github.com/tektoncd/operator/issues/2002 for more details
- HPA maxReplicas will not be updated, if it is not set under options
```
