### PR TITLE
Fix Results version not reflecting in certain flow

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -177,7 +177,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 		if err != nil {
 			return err
 		}
-		return r.updateTektonResultsStatus(ctx, tr, createdIs)
+		r.updateTektonResultsStatus(ctx, tr, createdIs)
+		return v1alpha1.REQUEUE_EVENT_AFTER
 	}
 
 	// If exists, then fetch the TektonInstallerSet
@@ -189,7 +190,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 			if err != nil {
 				return err
 			}
-			return r.updateTektonResultsStatus(ctx, tr, createdIs)
+			r.updateTektonResultsStatus(ctx, tr, createdIs)
+			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		logger.Error("failed to get InstallerSet: %s", err)
 		return err
@@ -265,6 +267,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 	}
+
+	r.updateTektonResultsStatus(ctx, tr, installedTIS)
 
 	// Mark InstallerSet Available
 	tr.Status.MarkInstallerSetAvailable()
@@ -355,12 +359,10 @@ func (r *Reconciler) conflictTIS(ctx context.Context) error {
 	return nil
 }
 
-func (r *Reconciler) updateTektonResultsStatus(ctx context.Context, tr *v1alpha1.TektonResult, createdIs *v1alpha1.TektonInstallerSet) error {
+func (r *Reconciler) updateTektonResultsStatus(ctx context.Context, tr *v1alpha1.TektonResult, createdIs *v1alpha1.TektonInstallerSet) {
 	// update the tr with TektonInstallerSet
 	tr.Status.SetTektonInstallerSet(createdIs.Name)
 	tr.Status.SetVersion(r.resultsVersion)
-
-	return nil
 }
 
 // TektonResults expects secrets to be created before installing


### PR DESCRIPTION
This fixes results version not being set during certain flow.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```
