### PR TITLE
Fix Conflict between Results PreReconciler and Reconciler

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -147,6 +147,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 	}
 	tr.Status.MarkDependenciesInstalled()
 
+	// This function needs to be removed in the next release of operator.
+	if err := r.conflictTIS(ctx); err != nil {
+		return err
+	}
 	if err := r.extension.PreReconcile(ctx, tr); err != nil {
 		msg := fmt.Sprintf("PreReconciliation failed: %s", err.Error())
 		logger.Error(msg)
@@ -295,6 +299,59 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 	// Mark PostReconcile Complete
 	tr.Status.MarkPostReconcilerComplete()
 
+	return nil
+}
+
+// This function exists to resolve conflict between PreReconciler and Reconciler Installerset.
+// This won't be needed in the next release of operator.
+func (r *Reconciler) conflictTIS(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+	// Check if an tektoninstallerset already exists, if not then create
+	labelSelector, err := common.LabelSelector(ls)
+	if err != nil {
+		return err
+	}
+	existingInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, labelSelector)
+	if err != nil {
+		return err
+	}
+
+	if existingInstallerSet == "" {
+		return nil
+	}
+
+	// If exists, then fetch the TektonInstallerSet
+	installedTIS, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+		Get(ctx, existingInstallerSet, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		logger.Error("failed to get InstallerSet: %s", err)
+		return err
+	}
+
+	installerSetReleaseVersion := installedTIS.Labels[v1alpha1.ReleaseVersionKey]
+	if installerSetReleaseVersion != r.operatorVersion {
+		// Delete the existing TektonInstallerSet
+		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+			Delete(ctx, existingInstallerSet, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error("failed to delete InstallerSet: %s", err)
+			return err
+		}
+
+		// Make sure the TektonInstallerSet is deleted
+		_, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
+			Get(ctx, existingInstallerSet, metav1.GetOptions{})
+		if err == nil {
+			return v1alpha1.REQUEUE_EVENT_AFTER
+		}
+		if !apierrors.IsNotFound(err) {
+			logger.Error("failed to get InstallerSet: %s", err)
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes conflict between prereconciler and reconciler during operator upgrade.
Fixes #2010 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
