### PR TITLE
reverting back the change for adding max openshift version 

### DIFF
--- a/operatorhub/openshift/release-artifacts/bundle/metadata/properties.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/metadata/properties.yaml
@@ -1,3 +1,0 @@
-properties:
-  - type: olm.maxOpenShiftVersion
-    value: "4.14"

--- a/operatorhub/tools/bundle.py
+++ b/operatorhub/tools/bundle.py
@@ -36,6 +36,7 @@ def buildConfig():
     config["channels"] = args.channels
     config["default-channel"] = args.default_channel
     config["olm-skip-range"] = args.olm_skip_range
+    config["max-openshift-version"] = args.max_openshift_version
     config["verbose"] = args.verbose
     debug(config, yaml.dump(config))
     return config
@@ -78,6 +79,7 @@ def setParser():
     parser.add_argument('--channels', help='channels',required=True)
     parser.add_argument('--default-channel', help='default channel', required=True)
     parser.add_argument('--olm-skip-range', help='value for olm.skipRange annotation in CSV file in the bundle', required=False)
+    parser.add_argument('--max-openshift-version', help='value for olm.maxOpenShiftVersion property in the CSV', required=False)
     parser.add_argument('--addn-annotations',
                         help='additional annotations to be added to CSV file',
                         metavar='<key1>=<val1>,<key2><val2>,...<keyn>=<valn>')
@@ -229,6 +231,9 @@ def newCSVmods(config):
                     csv['spec']['replaces'] = config["previous-release-version"]
                 if config["olm-skip-range"]:
                     csv['metadata']['annotations']['olm.skipRange'] = config["olm-skip-range"]
+                if config["max-openshift-version"]:
+                    csv['metadata']['annotations']['olm.properties'] = \
+                        '[{"type": "olm.maxOpenShiftVersion", "value": "%s"}]' % config["max-openshift-version"]
                 if "addn-annotations" in config.keys():
                     csv['metadata']['annotations'].update(config["addn-annotations"])
                 if "addn-labels" in config.keys():


### PR DESCRIPTION
# Changes
This PR just reverts  https://github.com/tektoncd/operator/pull/1341 I have not raised against `main` lets test it first and then decide if we want it in main
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
