### PR TITLE
Revert "Added filesystem-custom-path to allowed x509 fulcio providers"

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -28,7 +28,7 @@ import (
 var (
 	allowedArtifactsTaskRunFormat     = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
 	allowedArtifactsPipelineRunFormat = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
-	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem", "filesystem-custom-path")
+	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem")
 	allowedTransparencyConfigEnabled  = sets.NewString("", "true", "false", "manual")
 	allowedArtifactsStorage           = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
 	allowedControllerEnvs             = sets.NewString("MONGO_SERVER_URL")


### PR DESCRIPTION
- This reverts commit 92fc1128868b8b7c29fce938da016f3f3236ad6a. (#1909)

- This patch removes the field `filesystem-custom-path` from Chains validation 
as this field is not supported in the configuration of chains 

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Removed `filesystem-custom-path` from the list of allowed Chains Fulcio x509 providers. This was added via https://github.com/tektoncd/operator/pull/1909 and this field is not explicitly supported in the chains config-map. For ref: [chains-config.md](https://github.com/tektoncd/chains/blob/main/docs/config.md#keyless-signing-with-fulcio)
```