### PR TITLE
Fix buildah clustertask to support long image names

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -108,13 +108,12 @@ spec:
           exit 1
         fi
       fi
-
+      IMAGE=$(params.IMAGE)
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
-        --digestfile /tmp/image-digest $(params.IMAGE) \
-        docker://$(params.IMAGE)
+        --digestfile /tmp/image-digest $IMAGE docker://$IMAGE
       cat /tmp/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -79,7 +79,7 @@ spec:
     workingDir: $(workspaces.source.path)
     script: |
       ENTITLEMENT_VOLUME=""
-
+      IMAGE=$(params.IMAGE)
       if [[ "$(workspaces.rhel-entitlement.bound)" == "true" ]]; then
         ENTITLEMENT_VOLUME="--volume /tmp/entitlement:/etc/pki/entitlement"
       fi
@@ -87,7 +87,7 @@ spec:
       buildah bud --storage-driver=$(params.STORAGE_DRIVER) \
         $ENTITLEMENT_VOLUME $(params.BUILD_EXTRA_ARGS) \
         --format=$(params.FORMAT) --tls-verify=$(params.TLSVERIFY) \
-        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+        -f $(params.DOCKERFILE) -t $IMAGE $(params.CONTEXT)
 
       [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
 
@@ -108,7 +108,7 @@ spec:
           exit 1
         fi
       fi
-      IMAGE=$(params.IMAGE)
+
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile /tmp/image-digest $IMAGE docker://$IMAGE

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local/buildah/buildah-task.yaml
@@ -77,9 +77,11 @@ spec:
   - name: build-and-push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
+    env:
+    - name: IMAGE
+      value: $(params.IMAGE)
     script: |
       ENTITLEMENT_VOLUME=""
-      IMAGE=$(params.IMAGE)
       if [[ "$(workspaces.rhel-entitlement.bound)" == "true" ]]; then
         ENTITLEMENT_VOLUME="--volume /tmp/entitlement:/etc/pki/entitlement"
       fi


### PR DESCRIPTION
# Changes

Fixes a problem in the buildah clustertask where when provided with a long image name (e.g. `image-registry.openshift-image-registry.svc:5000/test/serverless-workflow-mtaanalysis:1.0`), it caused the generated script to wrap the line which is interpreted by the shell as a new command, rather than part of the previous command:

Currently, the script generates this `push` command:
```
buildah --storage-driver=vfs push \
 --tls-verify=true \
--digestfile /tmp/image-digest \
image-registry.openshift-image-registry.svc:5000/test/serverless-workflow-mtaanalysis:1.0
 \
docker://image-registry.openshift-image-registry.svc:5000/test/serverless-workflow-mtaanalysis:1.0
```

Which, when executed, it fails with this error:
```
Writing manifest to image destination
/tekton/scripts/script-0-4dsn8: line 35: docker://image-registry.openshift-image-registry.svc:5000/test/serverless-workflow-mtaanalysis:1.0: No such file or directory
```

The proposal fix here is to capture the value of the image in an environment variable and use it in the `push` command, avoiding the wrapping and ensuring it is not affected by any image length.

```
IMAGE=$(params.IMAGE)
buildah --storage-driver=$(params.STORAGE_DRIVER) push \
  $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
  --digestfile /tmp/image-digest $IMAGE docker://$IMAGE
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR

# Release Notes
```release-note
Fix buildah clustertask to support long image names
```
