### PR TITLE
Documentation aesthetics - removed the excess ``` backticks from fenced code block after rendering

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,6 +26,6 @@ weight: 100
 
     
      To install pipelines, triggers, chains and dashboard (use profile 'all')
-    ``````
+    ```
     $ kubectl apply -f https://raw.githubusercontent.com/tektoncd/operator/main/config/crs/kubernetes/config/all/operator_v1alpha1_config_cr.yaml
     ```


### PR DESCRIPTION
The desired output after remediations:

```
$ kubectl apply -f https://raw.githubusercontent.com/tektoncd/operator/main/config/crs/kubernetes/config/all/operator_v1alpha1_config_cr.yaml
```
Resolves [Issue 596](https://github.com/tektoncd/website/issues/596) after approval by the powers-that-be @AlanGreene