### PR TITLE
[main] support startingDeadlineSeconds configuration in pruner cron jobs

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -282,6 +282,7 @@ Example:
 pruner:
   disabled: false
   schedule: "0 8 * * *"
+  startingDeadlineSeconds: 100 # optional
   resources:
     - taskrun
     - pipelinerun
@@ -292,6 +293,7 @@ pruner:
 ```
 - `disabled` : if the value set as `true`, pruner feature will be disabled (default: `false`)
 - `schedule`: how often to run the pruner job. User can understand the schedule syntax [here][schedule].
+- `startingDeadlineSeconds`: Optional deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones
 - `resources`: supported resources for auto prune are `taskrun` and `pipelinerun`
 - `keep`: maximum number of resources to keep while deleting or removing resources
 - `keep-since`: retain the resources younger than the specified value in minutes

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -66,6 +66,9 @@ type Prune struct {
 	KeepSince *uint `json:"keep-since,omitempty"`
 	// How frequent pruning should happen
 	Schedule string `json:"schedule,omitempty"`
+	// Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
+	// Missed jobs executions will be counted as failed ones.
+	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty"`
 }
 
 func (p Prune) IsEmpty() bool {

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -905,6 +905,11 @@ func (in *Prune) DeepCopyInto(out *Prune) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.StartingDeadlineSeconds != nil {
+		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
# Changes

* Fixes: [SRVKP-4277](https://issues.redhat.com/browse/SRVKP-4277) - Inclusion of configuration parameter "startingDeadlineSeconds" in TektonConfig
* Added support to `startingDeadlineSeconds` in pruner cron jobs

Example in TektonConfig CR:
```yaml
pruner:
  schedule: "0 8 * * *"
  startingDeadlineSeconds: 100 # optional
  resources:
    - taskrun
    - pipelinerun
  keep: 3
```

**_NOTE: under pruner config all the existing fields are in `snake_case`. Cron Job has `spec.startingDeadlineSeconds` as `camelCase`, to have the consistency across, using `startingDeadlineSeconds` as `camelCase`._**

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
`startingDeadlineSeconds` configuration support added to pruner cron jobs via TektonConfig CR
```
