### PR TITLE
Disallow to update the targetNamespace in TektonConfig CR

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -33,6 +33,14 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		return nil
 	}
 
+	// disallow to update the targetNamespace
+	if apis.IsInUpdate(ctx) {
+		existingTC := apis.GetBaseline(ctx).(*TektonConfig)
+		if existingTC.Spec.GetTargetNamespace() != tc.Spec.GetTargetNamespace() {
+			errs = errs.Also(apis.ErrGeneric("Doesn't allow to update targetNamespace, delete existing TektonConfig and create the updated TektonConfig", "spec.targetNamespace"))
+		}
+	}
+
 	if tc.GetName() != ConfigResourceName {
 		errMsg := fmt.Sprintf("metadata.name,  Only one instance of TektonConfig is allowed by name, %s", ConfigResourceName)
 		errs = errs.Also(apis.ErrInvalidValue(tc.GetName(), errMsg))

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -231,3 +231,36 @@ func Test_ValidateTektonConfig_InvalidTriggerProperties(t *testing.T) {
 	err := tc.Validate(context.TODO())
 	assert.Equal(t, "invalid value: test: spec.trigger.enable-api-fields", err.Error())
 }
+
+func Test_ValidateTektonConfig_UpdateTargetNamespace(t *testing.T) {
+	ctx := context.Background()
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "namespace",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Profile: "all",
+			Pruner:  Prune{Disabled: true},
+		},
+	}
+	updatedTC := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "test",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "test",
+			},
+			Profile: "all",
+			Pruner:  Prune{Disabled: true},
+		},
+	}
+	ctx = apis.WithinUpdate(ctx, tc)
+	err := updatedTC.Validate(ctx)
+	assert.Equal(t, `Doesn't allow to update targetNamespace, delete existing TektonConfig and create the updated TektonConfig: spec.targetNamespace`, err.Error())
+}


### PR DESCRIPTION
# Changes

* fixes: [SRVKP-3962](https://issues.redhat.com/browse/SRVKP-3962) - do not allow to change the targetNamespace in operator CR
* This patch disallow to update the targetNamespace in the TektonConfig CR, if users want to update targetNamespace then they will have to delete the existing TektonConfig and create with updated targetNamespace

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Disallow to update the targetNamespace in TektonConfig CR
```