### PR TITLE
[main] perform manifest transformation earlier

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/check.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/check.go
@@ -32,19 +32,19 @@ func (i *InstallerSetClient) checkSet(ctx context.Context, comp v1alpha1.TektonC
 	logger := logging.FromContext(ctx)
 
 	labelSelector := i.getSetLabels(isType)
-	logger.Infof("%v/%v: checking installer sets with labels: %v", i.resourceKind, isType, labelSelector)
+	logger.Debugf("%v/%v: checking installer sets with labels: %v", i.resourceKind, isType, labelSelector)
 
 	is, err := i.clientSet.List(ctx, v1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Infof("%v/%v: found %v installer sets", i.resourceKind, isType, len(is.Items))
+	logger.Debugf("%v/%v: found %v installer sets", i.resourceKind, isType, len(is.Items))
 
 	iSets := is.Items
 
 	if len(iSets) == 0 {
-		logger.Infof("%v/%v: installer sets not found", i.resourceKind, isType)
+		logger.Debugf("%v/%v: installer sets not found", i.resourceKind, isType)
 		return nil, ErrNotFound
 	}
 
@@ -83,7 +83,7 @@ func (i *InstallerSetClient) checkSet(ctx context.Context, comp v1alpha1.TektonC
 		logger.Errorf("%v/%v: meta check failed for installer type: %v", i.resourceKind, isType, err)
 		return iSets, err
 	}
-	logger.Infof("%v/%v: meta check passed", i.resourceKind, isType)
+	logger.Debugf("%v/%v: meta check passed", i.resourceKind, isType)
 
 	return iSets, nil
 }
@@ -109,7 +109,7 @@ func verifyMainInstallerSets(iSets []v1alpha1.TektonInstallerSet) error {
 
 func verifyMeta(resourceKind, isType string, logger *zap.SugaredLogger, set v1alpha1.TektonInstallerSet, comp v1alpha1.TektonComponent, releaseVersion string) error {
 	// Release Version Check
-	logger.Infof("%v/%v: release version check", resourceKind, isType)
+	logger.Debugf("%v/%v: release version check", resourceKind, isType)
 
 	rVel, ok := set.GetLabels()[v1alpha1.ReleaseVersionKey]
 	if !ok {
@@ -120,7 +120,7 @@ func verifyMeta(resourceKind, isType string, logger *zap.SugaredLogger, set v1al
 	}
 
 	// Target namespace check
-	logger.Infof("%v/%v: target namespace check", resourceKind, isType)
+	logger.Debugf("%v/%v: target namespace check", resourceKind, isType)
 
 	targetNamespace, ok := set.GetAnnotations()[v1alpha1.TargetNamespaceKey]
 	if !ok {
@@ -131,7 +131,7 @@ func verifyMeta(resourceKind, isType string, logger *zap.SugaredLogger, set v1al
 	}
 
 	// Spec Hash Check
-	logger.Infof("%v/%v: spec hash check", resourceKind, isType)
+	logger.Debugf("%v/%v: spec hash check", resourceKind, isType)
 
 	expectedHash, err := hash.Compute(comp.GetSpec())
 	if err != nil {

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/cleanup.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/cleanup.go
@@ -23,13 +23,12 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"knative.dev/pkg/logging"
 )
 
-var deletePropagationPolicy = v1.DeletePropagationForeground
+var deletePropagationPolicy = metav1.DeletePropagationForeground
 
 func (i *InstallerSetClient) CleanupMainSet(ctx context.Context) error {
 	logger := logging.FromContext(ctx).With("kind", i.resourceKind, "type", InstallerTypeMain)
@@ -46,7 +45,7 @@ func (i *InstallerSetClient) CleanupMainSet(ctx context.Context) error {
 	// delete all static installerSet first and then deployment one
 	for _, is := range list.Items {
 		if strings.Contains(is.GetName(), InstallerSubTypeStatic) {
-			logger.Infof("deleting main-static installer set: %s", is.GetName())
+			logger.Debugf("deleting main-static installer set: %s", is.GetName())
 			err = i.clientSet.Delete(ctx, is.GetName(), metav1.DeleteOptions{
 				PropagationPolicy: &deletePropagationPolicy,
 			})
@@ -59,7 +58,7 @@ func (i *InstallerSetClient) CleanupMainSet(ctx context.Context) error {
 	// now delete all deployment installerSet
 	for _, is := range list.Items {
 		if strings.Contains(is.GetName(), InstallerSubTypeDeployment) {
-			logger.Infof("deleting main-deployment installer set: %s", is.GetName())
+			logger.Debugf("deleting main-deployment installer set: %s", is.GetName())
 			err = i.clientSet.Delete(ctx, is.GetName(), metav1.DeleteOptions{
 				PropagationPolicy: &deletePropagationPolicy,
 			})
@@ -116,7 +115,7 @@ func (i *InstallerSetClient) cleanup(ctx context.Context, isType string) error {
 	}
 
 	for _, is := range list.Items {
-		logger.Infof("deleting %s installer set: %s", isType, is.GetName())
+		logger.Debugf("deleting %s installer set: %s", isType, is.GetName())
 		err = i.clientSet.Delete(ctx, is.GetName(), metav1.DeleteOptions{
 			PropagationPolicy: &deletePropagationPolicy,
 		})

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/create_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/create_test.go
@@ -23,7 +23,6 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
-	"github.com/tektoncd/operator/pkg/reconciler/common"
 	fake2 "github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client/fake"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,7 +110,7 @@ func TestInstallerSetClient_Create(t *testing.T) {
 				client = NewInstallerSetClient(fakeClient, releaseVersion, "test-version", v1alpha1.KindTektonTrigger, &testMetrics{})
 			}
 
-			iSs, gotErr := client.create(ctx, comp, &manifest, filterAndTransform(common.NoExtension(ctx)), tt.setType, nil)
+			iSs, gotErr := client.create(ctx, comp, &manifest, tt.setType, nil)
 
 			if tt.wantErr != nil {
 				assert.Equal(t, gotErr, tt.wantErr)

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/custom_versioned_clustertask.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/custom_versioned_clustertask.go
@@ -38,6 +38,16 @@ var (
 func (i *InstallerSetClient) VersionedClusterTaskSet(ctx context.Context, comp v1alpha1.TektonComponent, manifest *mf.Manifest, filterAndTransform FilterAndTransform) error {
 	logger := logging.FromContext(ctx)
 
+	// perform transformation
+	manifestUpdated, err := filterAndTransform(ctx, manifest, comp)
+	if err != nil {
+		logger.Errorw("error on transforming a manifest",
+			"component", comp.GroupVersionKind().String(),
+			"componentName", comp.GetName(),
+		)
+		return err
+	}
+
 	setType := InstallerTypeCustom + "-" + strings.ToLower(versionedClusterTaskInstallerSet)
 	versionedClusterTaskLS := v1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -55,7 +65,7 @@ func (i *InstallerSetClient) VersionedClusterTaskSet(ctx context.Context, comp v
 	}
 
 	if len(is.Items) == 0 {
-		vctSet, err := i.makeInstallerSet(ctx, comp, manifest, filterAndTransform, "addon-versioned-clustertasks", setType, nil)
+		vctSet, err := i.makeInstallerSet(ctx, comp, manifestUpdated, "addon-versioned-clustertasks", setType, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Changes

* fixes: #2002 
* with this PR, the transformation applied(very earlier) before splitting the manifest into multiple installersets
* changes some of the logs from `Info` to `Debug`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
