### PR TITLE
[main] ignore unknown fields on webhook call

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -64,8 +64,8 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 			return ctx
 		},
 
-		// Whether to disallow unknown fields.
-		true,
+		// allow unknown fields
+		false,
 	)
 }
 
@@ -86,8 +86,8 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 			return ctx
 		},
 
-		// Whether to disallow unknown fields.
-		true,
+		// allow unknown fields
+		false,
 	)
 }
 


### PR DESCRIPTION
# Changes

* over a time, we removed some of the fields from the CR, If a user upgrades their tekton operator from a very old version to most recent version, there is a huge chance to face unknown field error on a webhook validation. To resolve these kind of issues, we can allow unknown fields. I do not see any issue on allowing unknown fields. Even though, if we allow the unknown fields, the unknown fields are not stored on the CR. Those are all removed on the fly.

##### Sample error:
```
admission webhook "webhook.operator.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "disable-working-directory-overwrite"
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
