### PR TITLE
[main] apply nodeSelector, tolerations, and priorityClassName into pipelines-console-plugin pod

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler.go
+++ b/pkg/reconciler/openshift/tektonconfig/console_plugin_reconciler.go
@@ -206,6 +206,7 @@ func (cpr *consolePluginReconciler) transform(ctx context.Context, manifest *mf.
 		// updates "metadata.namespace" to targetNamespace
 		common.ReplaceNamespace(tektonConfigCR.Spec.TargetNamespace),
 		cpr.transformerConsolePlugin(tektonConfigCR.Spec.TargetNamespace),
+		common.AddConfiguration(tektonConfigCR.Spec.Config),
 	}
 
 	if cpr.pipelinesConsolePluginImage != "" {


### PR DESCRIPTION
# Changes

* applies `nodeSelector`, `tolerations`, and `priorityClassName` from `tektonConfig.config` to `pipelines-console-plugin` pod
* Fixes: [SRVKP-4391](https://issues.redhat.com/browse/SRVKP-4391) - pipelines-console-plugin Pod doesn't move to infra nodes

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```