### PR TITLE
Put back the namespace to reconcile list if a resource cant be created for…

### DIFF
--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -233,8 +233,8 @@ copy_pruner_yaml() {
   srcPath=${SCRIPT_DIR}/config/pruner
   ko_data=${SCRIPT_DIR}/cmd/${TARGET}/operator/kodata
   dstPath=${ko_data}/tekton-pruner
-  rm $dstPath -rf
-  cp $srcPath $dstPath -r
+  rm -rf $dstPath
+  cp -r $srcPath $dstPath
 }
 
 main() {

--- a/pkg/reconciler/openshift/tektonconfig/rbac_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac_test.go
@@ -1,0 +1,85 @@
+package tektonconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetNamespacesToBeReconciled(t *testing.T) {
+	var deletionTime = metav1.Now()
+	for _, c := range []struct {
+		desc           string
+		wantNamespaces []corev1.Namespace
+		objs           []runtime.Object
+		ctx            context.Context
+	}{
+		{
+			desc: "ignore system namespaces",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-test"}},
+			},
+			wantNamespaces: nil,
+			ctx:            context.Background(),
+		},
+		{
+			desc: "ignore namespaces with deletion timestamp",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-test", DeletionTimestamp: &deletionTime}},
+			},
+			wantNamespaces: nil,
+			ctx:            context.Background(),
+		},
+		{
+			desc: "add namespace to reconcile list if it has openshift scc operator.tekton.dev/scc annotation set ",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{"operator.tekton.dev/scc": "restricted"}}},
+			},
+			wantNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test",
+						Annotations: map[string]string{"operator.tekton.dev/scc": "restricted"},
+					},
+				},
+			},
+			ctx: context.Background(),
+		},
+		{
+			desc: "add namespace to reconcile list if it has bad label openshift-pipelines.tekton.dev/namespace-reconcile-version",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""}}},
+			},
+			wantNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "test",
+						Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""},
+					},
+				},
+			},
+			ctx: context.Background(),
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			kubeclient := fakek8s.NewSimpleClientset(c.objs...)
+			r := rbac{
+				kubeClientSet: kubeclient,
+				version:       "devel",
+			}
+			namespaces, err := r.getNamespacesToBeReconciled(c.ctx)
+			if err != nil {
+				t.Fatalf("getNamespacesToBeReconciled: %v", err)
+			}
+			if d := cmp.Diff(c.wantNamespaces, namespaces); d != "" {
+				t.Fatalf("Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
… this namespace


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Put back the namespace to the reconcile list if a resource creation is failing for this namespace, so we continue reconciling even if an error happens when creating a resource one namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Put back the namespace to the reconcile list if a resource creation is failing for this namespace, so we continue reconciling even if an error happens when creating a resource one namespace.
```
