### PR TITLE
fix: prevent upgrade failures caused by deleting resources

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -150,6 +150,12 @@ func (i *installer) ensureResources(resources []unstructured.Unstructured) error
 			return err
 		}
 
+		if res.GetDeletionTimestamp() != nil {
+			i.logger.Debugf("waiting for resource %s: %s/%s to be deleted",
+				r.GetKind(), r.GetNamespace(), r.GetName())
+			return v1alpha1.RECONCILE_AGAIN_ERR
+		}
+
 		i.logger.Infof("found resource %s: %s/%s, checking for update!", r.GetKind(), r.GetNamespace(), r.GetName())
 
 		// if resource exist then check if expected hash is different from the one
@@ -442,6 +448,12 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 		"namespace", existing.GetNamespace(),
 		"kind", existing.GetKind(),
 	)
+
+	if existing.GetDeletionTimestamp() != nil {
+		i.logger.Debugf("waiting for resource %s: %s/%s to be deleted",
+			existing.GetKind(), existing.GetNamespace(), existing.GetName())
+		return v1alpha1.RECONCILE_AGAIN_ERR
+	}
 
 	// get list of reconcile fields
 	reconcileFields := i.resourceReconcileFields(expected)


### PR DESCRIPTION
When installing resources in TektonInstallerSet, if the original resource is in the process of being deleted, it is necessary to wait for the deletion to complete before proceeding with the installation. Otherwise, it may appear that the TektonInstallerSets have been installed successfully, but in the end, there may be missing resources.

In my scenario, when upgrading the pipeline, since the old RoleBinding `tekton-pipelines-webhook` was still being deleted, the new tektoninstallersets thought the resource already existed with no hash change, so no action was taken. As a result, when the Pod tekton-pipelines-webhook started up, it found that it did not have permissions for certain resources `config-logging`, leading to startup failure. Its failure directly caused some configmaps `config-registry-cert` to not be created due to the presence of the validatingwebhookconfigurations named config.webhook.pipeline.tekton.dev. Ultimately, this led to the entire pipeline upgrade failing. Only by reconstructing the instance could recovery be possible.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
fix: prevent upgrade failures caused by deleting resources
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

- Bug fixes

```release-note
fix: prevent upgrade failures caused by deleting resources
```
