### PR TITLE
Update triggers default configmap for runAsUser and runAsGroup to handle restricted securityContext for Triggers

### DIFF
--- a/pkg/reconciler/openshift/tektontrigger/transformers_test.go
+++ b/pkg/reconciler/openshift/tektontrigger/transformers_test.go
@@ -56,13 +56,12 @@ func TestReplaceImages(t *testing.T) {
 		}
 
 		newManifest, err := manifest.Transform(
-			replaceDeploymentArgs("-el-security-context", "false"),
 			replaceDeploymentArgs("-el-events", "enable"),
 		)
 		if err != nil {
 			t.Errorf("assertion failed; expected no error %v", err)
 		}
-		assertDeployContainerArgsValue(t, newManifest.Resources(), "-el-security-context", "false")
+		assertDeployContainerArgsValue(t, newManifest.Resources(), "-el-security-context", "true")
 		assertDeployContainerArgsValue(t, newManifest.Resources(), "-el-events", "enable")
 	})
 }


### PR DESCRIPTION
Context:

As part of addressing https://issues.redhat.com/browse/OCPSTRAT-487, there's a plan to enable restricted security context by default starting from Openshift 4.17. 
Once this becomes the default setting, existing Triggers functionality may break. 
This is because we currently set security context to false, and the pipelines-scc security context constraint (SCC) doesn't have seccompProfiles: runtime/default, which is required when restricted security context is enabled by default because by default triggers set `runAsUser and `runAsGroup` to 65532.

So Updated Triggers only to accept values for `runAsUser and `runAsGroup` through CM and using Operator we are setting to `""` so that Openshift can set those random values.

Tested below scenarios:

1 set security context to restricted for a namespace  (`oc label ns test pod-security.kubernetes.io/enforce=restricted --overwrite=true`)
  * No seccompProfiles: runtime/default to `pipelines-scc`
 and Created EL, POD is up and running
     ```
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsNonRoot: true
      runAsUser: 1000730000
      seccompProfile:
        type: RuntimeDefault

     ```
      
      
2 remove security context to restricted for a namespace  (`oc label ns test pod-security.kubernetes.io/enforce-`)
  * No seccompProfiles: runtime/default to `pipelines-scc`
 and Created EL, POD is up and running
     ```
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsNonRoot: true
      runAsUser: 1000710000
      seccompProfile:
        type: RuntimeDefault
     ```
	

Fixes : https://issues.redhat.com/browse/SRVKP-4372

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
