### PR TITLE
SRVKP-4014: Pull tasks from the tekton ecosystem catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ ifeq ($(TARGET), openshift)
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-pruner
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/pipelines-as-code
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/addons/02-clustertasks/source_external/
+	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/addons/07-ecosystem/task-*
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/pipelines-as-code-templates/go.yaml
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/pipelines-as-code-templates/java.yaml
 	rm -rf ./cmd/$(TARGET)/operator/kodata/tekton-addon/pipelines-as-code-templates/nodejs.yaml

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/07-ecosystem/role.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/07-ecosystem/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-ecosystem-task-list-role
+  namespace: openshift-pipelines
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+    verbs:
+      - get
+      - list

--- a/cmd/openshift/operator/kodata/tekton-addon/addons/07-ecosystem/rolebinding.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/07-ecosystem/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-ecosystem-task-list-binding
+  namespace: openshift-pipelines
+subjects:
+  # Giving all system:authenticated users the access to the
+  # tasks present in openshift-pipelines namespace
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-ecosystem-task-list-role

--- a/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
@@ -27,6 +27,8 @@ spec:
       value: "true"
     - name: communityClusterTasks
       value: "true"
+    - name: resolverTasks
+      value: "true"
   params:
   - name: createRbacResource
     value: "true"

--- a/docs/TektonAddon.md
+++ b/docs/TektonAddon.md
@@ -6,7 +6,8 @@ weight: 6
 -->
 # Tekton Addon
 
-TektonAddon custom resource allows user to install resource like clusterTasks and pipelineTemplate along with Pipelines. 
+TektonAddon custom resource allows user to install resource like clusterTasks and pipelineTemplate along with Pipelines.
+It also allows user to install various Tasks in openshift-pipelines namespace.
 
 **NOTE:** TektonAddon is currently available only for OpenShift Platform. This is roadmap to enable it for Kubernetes platform.
 
@@ -25,6 +26,8 @@ spec:
     value: "true"
   - name: pipelineTemplates
     value: "true"
+  - name: resolverTasks
+    value: "true"
 ```
 You can install this component using [TektonConfig](./TektonConfig.md) by choosing appropriate `profile`.
 
@@ -35,6 +38,7 @@ Available params are
 
 - `clusterTasks` (Default: `true`)
 - `pipelineTemplates` (Default: `true`)
+- `resolverTasks` (Default: `true`)
 
 User can disable the installation of resources by changing the value to `false`.
 

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -319,7 +319,7 @@ By default pruner job will be created from the global pruner config (`spec.prune
 > `keep: 100` <br>
 ### Addon
 
-TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few ClusterTasks, PipelineTemplates.
+TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few ClusterTasks, PipelineTemplates, Tasks.
 
 This section allows to customize installation of those resources through params. You can read more about the supported params [here](./TektonAddon.md).
 
@@ -330,6 +330,8 @@ addon:
     - name: "clusterTask"
       value: "true"
     - name: "pipelineTemplates"
+      value: "true"
+    - name: "resolverTasks"
       value: "true"
 ```
 

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -227,6 +227,8 @@ fetch_openshift_addon_tasks() {
   fetch_addon_task_script="${SCRIPT_DIR}/hack/openshift"
   local dest_dir="cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_external"
   ${fetch_addon_task_script}/fetch-tektoncd-catalog-tasks.sh ${dest_dir}
+  dest_dir='cmd/openshift/operator/kodata/tekton-addon/addons/07-ecosystem'
+  ${fetch_addon_task_script}/fetch-tektoncd-catalog-tasks.sh ${dest_dir} "ecosystem"
 }
 
 copy_pruner_yaml() {

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -36,6 +36,7 @@ const (
 	ClusterTasksParam      = "clusterTasks"
 	PipelineTemplatesParam = "pipelineTemplates"
 	CommunityClusterTasks  = "communityClusterTasks"
+	ResolverTasks          = "resolverTasks"
 
 	// Hub Params
 	EnableDevconsoleIntegrationParam = "enable-devconsole-integration"
@@ -112,6 +113,7 @@ var (
 		ClusterTasksParam:      defaultParamValue,
 		PipelineTemplatesParam: defaultParamValue,
 		CommunityClusterTasks:  defaultParamValue,
+		ResolverTasks:          defaultParamValue,
 	}
 
 	HubParams = map[string]ParamValue{

--- a/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
@@ -39,7 +39,7 @@ func Test_AddonSetDefaults_DefaultParamsWithValues(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 3, len(ta.Spec.Params))
+	assert.Equal(t, 4, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[ClusterTasksParam]
@@ -70,7 +70,7 @@ func Test_AddonSetDefaults_ClusterTaskIsFalse(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 3, len(ta.Spec.Params))
+	assert.Equal(t, 4, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[PipelineTemplatesParam]

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -90,7 +90,7 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	tc.SetDefaults(context.TODO())
-	if len(tc.Spec.Addon.Params) != 3 {
+	if len(tc.Spec.Addon.Params) != 4 {
 		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
 	}
 }

--- a/pkg/reconciler/openshift/tektonaddon/const.go
+++ b/pkg/reconciler/openshift/tektonaddon/const.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tektonaddon
 
 const (
+	ResolverTaskInstallerSet           = "ResolverTask"
 	ClusterTaskInstallerSet            = "ClusterTask"
 	OpenShiftConsoleInstallerSet       = "OpenShiftConsole"
 	CommunityClusterTaskInstallerSet   = "CommunityClusterTask"

--- a/pkg/reconciler/openshift/tektonaddon/controller.go
+++ b/pkg/reconciler/openshift/tektonaddon/controller.go
@@ -78,6 +78,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 		metrics, _ := NewRecorder()
 
+		resolverTaskManifest := &mf.Manifest{}
+		if err := applyAddons(resolverTaskManifest, "07-ecosystem"); err != nil {
+			logger.Fatalf("failed to read namespaced tasks from kodata: %v", err)
+		}
+
 		clusterTaskManifest := &mf.Manifest{}
 		if err := applyAddons(clusterTaskManifest, "02-clustertasks"); err != nil {
 			logger.Fatalf("failed to read clustertask from kodata: %v", err)
@@ -124,6 +129,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			triggerInformer:              tektonTriggerinformer.Get(ctx),
 			manifest:                     manifest,
 			operatorVersion:              version,
+			resolverTaskManifest:         resolverTaskManifest,
 			clusterTaskManifest:          clusterTaskManifest,
 			triggersResourcesManifest:    triggersResourcesManifest,
 			pipelineTemplateManifest:     pipelineTemplateManifest,

--- a/pkg/reconciler/openshift/tektonaddon/resolverTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/resolverTask.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonaddon
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+)
+
+func (r *Reconciler) EnsureResolverTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+	manifest := *r.resolverTaskManifest
+	if enable == "true" {
+		if err := r.installerSetClient.CustomSet(ctx, ta, ResolverTaskInstallerSet, &manifest, filterAndTransformResolverTask(), nil); err != nil {
+			return err
+		}
+	} else {
+		if err := r.installerSetClient.CleanupCustomSet(ctx, ResolverTaskInstallerSet); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func filterAndTransformResolverTask() client.FilterAndTransform {
+	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
+		addon := comp.(*v1alpha1.TektonAddon)
+		tfs := []mf.Transformer{
+			injectLabel(labelProviderType, providerTypeRedHat, overwrite, "Task"),
+		}
+		if err := transformers(ctx, manifest, addon, tfs...); err != nil {
+			return nil, err
+		}
+		return manifest, nil
+	}
+}


### PR DESCRIPTION
# Changes

- Added resolverTasks to tektonconfig to support ecosystem tasks
- Required Behaviour -> when resolverTasks is true in tekton config, it should populate openshift-pipelines namespace with ecosystem tasks & on making the param value as false, it should remove them.
- JIRA: https://issues.redhat.com/browse/SRVKP-4014

# Release Notes

```release-note
Added new Addon field "namespacedTasks" to support populating openshift-pipelines namespace with tasks similar to the current clusterTasks.
```