### PR TITLE
Expose feature flags for disabling inline spec in Pipelines

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -47,6 +47,7 @@ The TektonConfig CR provides the following features
       disable-creds-init: false
       disable-home-env-overwrite: true
       disable-working-directory-overwrite: true
+      disable-inline-spec: "pipeline,pipelinerun,taskrun"
       enable-api-fields: beta
       enable-bundles-resolver: true
       enable-cel-in-whenexpression: false

--- a/docs/TektonPipeline.md
+++ b/docs/TektonPipeline.md
@@ -24,6 +24,7 @@ spec:
   disable-creds-init: false
   disable-home-env-overwrite: true
   disable-working-directory-overwrite: true
+  disable-inline-spec: "taskrun,pipelinerun,pipeline"
   enable-api-fields: beta
   enable-bundles-resolver: true
   enable-cel-in-whenexpression: false
@@ -230,6 +231,9 @@ request supersedes.
 
     `default-managed-by-label-value: "tekton-pipelines"`
 
+- `disable-inline-spec` (Default: ``)
+
+    Inline specifications can be disabled for specific resources only. To achieve that, set the disable-inline-spec flag to a comma-separated list of the desired resources. Valid values are `pipeline`, `pipelinerun` and `taskrun`.
 
 - `default-pod-template`
 

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -113,6 +113,10 @@ func (p *Pipeline) setDefaults() {
 		p.EnableParamEnum = ptr.Bool(config.DefaultEnableParamEnum.Enabled)
 	}
 
+	if p.DisableInlineSpec == "" {
+		p.DisableInlineSpec = config.DefaultDisableInlineSpec
+	}
+
 	if p.MetricsPipelinerunDurationType == "" {
 		p.MetricsPipelinerunDurationType = config.DefaultDurationPipelinerunType
 	}

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
@@ -59,6 +59,7 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 		MaxResultSize:                            ptr.Int32(config.DefaultMaxResultSize),
 		SetSecurityContext:                       ptr.Bool(config.DefaultSetSecurityContext),
 		Coschedule:                               config.DefaultCoschedule,
+		DisableInlineSpec:                        config.DefaultDisableInlineSpec,
 		EnableCELInWhenExpression:                ptr.Bool(config.DefaultEnableCELInWhenExpression.Enabled),
 		EnableStepActions:                        ptr.Bool(config.DefaultEnableStepActions.Enabled),
 		EnableParamEnum:                          ptr.Bool(config.DefaultEnableParamEnum.Enabled),

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -117,6 +117,7 @@ type PipelineProperties struct {
 	EnableCELInWhenExpression *bool  `json:"enable-cel-in-whenexpression,omitempty"`
 	EnableStepActions         *bool  `json:"enable-step-actions,omitempty"`
 	EnableParamEnum           *bool  `json:"enable-param-enum,omitempty"`
+	DisableInlineSpec         string `json:"disable-inline-spec,omitempty"`
 
 	PipelineMetricsProperties `json:",inline"`
 	// +optional

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation_test.go
@@ -210,6 +210,41 @@ func TestValidateTektonPipelineCoschedule(t *testing.T) {
 	}
 }
 
+func TestValidateTektonPipeline_DisableInlineSpec(t *testing.T) {
+	tp := &TektonPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipeline",
+			Namespace: "tekton-pipelines-ns",
+		},
+		Spec: TektonPipelineSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines-ns",
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		disableInlineSpec string
+		err               string
+	}{
+		{name: "disable-inline-spec", disableInlineSpec: "", err: ""},
+		{name: "disable-inline-spec", disableInlineSpec: "pipeline", err: ""},
+		{name: "disable-inline-spec", disableInlineSpec: "pipelinerun", err: ""},
+		{name: "disable-inline-spec", disableInlineSpec: "taskrun", err: ""},
+		{name: "disable-inline-spec", disableInlineSpec: "pipelinerun,taskrun,pipeline", err: ""},
+		{name: "disable-inline-spec", disableInlineSpec: "hello", err: "invalid value: hello: spec.disable-inline-spec"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tp.Spec.Pipeline.DisableInlineSpec = test.disableInlineSpec
+			errs := tp.Validate(context.TODO())
+			assert.Equal(t, test.err, errs.Error())
+		})
+	}
+}
+
 func Test_ValidateTektonPipeline_OnDelete(t *testing.T) {
 
 	td := &TektonPipeline{


### PR DESCRIPTION
This adds a new feature flag `disable-inline-spec`. Added docs for that flag.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Inline specifications can be disabled for specific resources only. To achieve that, set the disable-inline-spec in Pipeline properties to a comma-separated list of the desired resources. Valid values are `pipeline`, `pipelinerun` and `taskrun`.
```
