### PR TITLE
Deprecate TLSHostnameOverride in TektonResult Properties

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -98,7 +98,6 @@ spec:
   logs_type: File
   logs_buffer_size: 90kb
   logs_path: /logs
-  tls_hostname_override: localhost
   auth_disable: true
   logging_pvc_name: tekton-logs
   secret_name: # optional

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
@@ -21,4 +21,8 @@ import (
 )
 
 func (tp *TektonResult) SetDefaults(ctx context.Context) {
+	// Deprecate TLSHostnameOverride
+	if tp.Spec.TLSHostnameOverride != "" {
+		tp.Spec.TLSHostnameOverride = ""
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTektonResult_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		Spec TektonResultSpec
+		want TektonResultSpec
+	}{
+		{
+			name: "Add TLSHostnameOverride Override",
+			Spec: TektonResultSpec{
+				ResultsAPIProperties: ResultsAPIProperties{
+					TLSHostnameOverride: "foo.bar",
+				},
+			},
+			want: TektonResultSpec{
+				ResultsAPIProperties: ResultsAPIProperties{},
+			},
+		},
+		{
+			name: "Empty TLSHostnameOverride Override",
+			Spec: TektonResultSpec{
+				ResultsAPIProperties: ResultsAPIProperties{},
+			},
+			want: TektonResultSpec{
+				ResultsAPIProperties: ResultsAPIProperties{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := &TektonResult{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "result",
+					Namespace: "foo",
+				},
+				Spec: tt.Spec,
+			}
+			tp.SetDefaults(context.Background())
+			if d := cmp.Diff(tt.want, tp.Spec); d != "" {
+				t.Errorf("TektonResult SetDefaults failed: +expected,-got: %s", d)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Deprecating TLSHostnameOverride because it is not supported in results and is not needed.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Deprecate TLSHostnameOverride in TektonResult.Spec Properties
```
