### PR TITLE
Add support for using nightly release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ MODULE   = $(shell env GO111MODULE=on $(GO) list -m)
 DATE         ?= $(shell date +%FT%T%z)
 KO_DATA_PATH  = $(shell pwd)/cmd/$(TARGET)/operator/kodata
 TARGET        = kubernetes
+COMPONENT ?= components.yaml
 FORCE_FETCH_RELEASE = false
 CR            = config/basic
 PLATFORM := $(if $(PLATFORM),--platform $(PLATFORM))
@@ -96,15 +97,15 @@ bin/%: cmd/% FORCE
 
 .PHONY: compoments/bump
 components/bump: $(OPERATORTOOL)
-	@go run ./cmd/tool bump components.yaml
+	@go run ./cmd/tool bump ${COMPONENT}
 
 .PHONY: components/bump-bugfix
 components/bump-bugfix: $(OPERATORTOOL)
-	@go run ./cmd/tool bump --bugfix components.yaml
+	@go run ./cmd/tool bump --bugfix ${COMPONENT}
 
 .PHONY: get-releases
 get-releases: |
-	$Q ./hack/fetch-releases.sh $(TARGET) components.yaml $(FORCE_FETCH_RELEASE) || exit ;
+	$Q ./hack/fetch-releases.sh $(TARGET) ${COMPONENT} $(FORCE_FETCH_RELEASE) || exit ;
 
 .PHONY: apply
 apply: | $(KO) $(KUSTOMIZE) get-releases ; $(info $(M) ko apply on $(TARGET)) @ ## Apply config to the current cluster

--- a/components.nightly.yaml
+++ b/components.nightly.yaml
@@ -17,10 +17,13 @@ chains:
   version: nightly
 results:
   github: tektoncd/results
-  version: v0.5.0
+  version: v0.10.0
+manual-approval-gate:
+  github: openshift-pipelines/manual-approval-gate
+  version: v0.2.0
 hub:
   github: tektoncd/hub
-  version: v1.10.0
+  version: v1.17.0
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code
   version: nightly


### PR DESCRIPTION
This adds support using nightly release manifests for building operator. This is based on `COMPONENT` environment variable.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
We can build operator locally for nightly manifest by using following command:
`COMPONENT=components.nightly.yaml  make  apply`


```
