### PR TITLE
Run rbac createresources for namespaces concurrently to avoid slowness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20230816171015-6bfafa975bfb
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
 	github.com/sigstore/cosign/v2 v2.2.4
-	github.com/spf13/cobra v1.8.0
+	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tektoncd/pipeline v0.60.2

--- a/go.sum
+++ b/go.sum
@@ -888,7 +888,7 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -1685,8 +1685,8 @@ github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
-github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
-github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/common/scc.go
+++ b/pkg/common/scc.go
@@ -41,12 +41,12 @@ func GetSecurityClient(ctx context.Context) *security.Clientset {
 	return securityClient
 }
 
-func VerifySCCExists(ctx context.Context, sccName string, securityClient *security.Clientset) error {
+func VerifySCCExists(ctx context.Context, sccName string, securityClient security.Interface) error {
 	_, err := securityClient.SecurityV1().SecurityContextConstraints().Get(ctx, sccName, metav1.GetOptions{})
 	return err
 }
 
-func GetSCCRestrictiveList(ctx context.Context, securityClient *security.Clientset) ([]*securityv1.SecurityContextConstraints, error) {
+func GetSCCRestrictiveList(ctx context.Context, securityClient security.Interface) ([]*securityv1.SecurityContextConstraints, error) {
 	logger := logging.FromContext(ctx)
 	sccList, err := securityClient.SecurityV1().SecurityContextConstraints().List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -32,7 +32,7 @@ const (
 	PipelineNotFound       = "tekton-pipelines not installed"
 	TriggerNotReady        = "tekton-triggers not ready"
 	TriggerNotFound        = "tekton-triggers not installed"
-	NamespaceIgnorePattern = "^(openshift|kube)-"
+	NamespaceIgnorePattern = "^(openshift|kube|open-cluster-management|package-operator)-"
 )
 
 func PipelineReady(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPipeline, error) {

--- a/pkg/reconciler/openshift/tektonconfig/common.go
+++ b/pkg/reconciler/openshift/tektonconfig/common.go
@@ -97,8 +97,7 @@ func deleteInstallerSet(ctx context.Context, oc versioned.Interface, tc *v1alpha
 // checkIfInstallerSetExist checks if installer set exists for a component and return true/false based on it
 // and if installer set which already exist is of older version then it deletes and return false to create a new
 // installer set
-func checkIfInstallerSetExist(ctx context.Context, oc versioned.Interface, relVersion string,
-	tc *v1alpha1.TektonConfig) (*v1alpha1.TektonInstallerSet, error) {
+func checkIfInstallerSetExist(ctx context.Context, oc versioned.Interface, relVersion string) (*v1alpha1.TektonInstallerSet, error) {
 
 	labelSelector, err := common.LabelSelector(rbacInstallerSetSelector)
 	if err != nil {

--- a/pkg/reconciler/openshift/tektonconfig/rbac_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac_test.go
@@ -1,0 +1,179 @@
+package tektonconfig
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/openshift/api/security/v1"
+	fakesecurity "github.com/openshift/client-go/security/clientset/versioned/fake"
+	"github.com/stretchr/testify/require"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+
+	//fakeoperator "github.com/tektoncd/operator/pkg/client/injection/client/fake"
+	fakeoperator "github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	ts "knative.dev/pkg/reconciler/testing"
+)
+
+func TestGetNamespacesToBeReconciled(t *testing.T) {
+	var deletionTime = metav1.Now()
+	for _, c := range []struct {
+		desc           string
+		wantNamespaces []corev1.Namespace
+		objs           []runtime.Object
+		ctx            context.Context
+	}{
+		{
+			desc: "ignore system namespaces",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-test"}},
+			},
+			wantNamespaces: nil,
+			ctx:            context.Background(),
+		},
+		{
+			desc: "ignore namespaces with deletion timestamp",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-test", DeletionTimestamp: &deletionTime}},
+			},
+			wantNamespaces: nil,
+			ctx:            context.Background(),
+		},
+		{
+			desc: "add namespace to reconcile list if it has openshift scc operator.tekton.dev/scc annotation set ",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Annotations: map[string]string{"operator.tekton.dev/scc": "restricted"}}},
+			},
+			wantNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test",
+						Annotations: map[string]string{"operator.tekton.dev/scc": "restricted"},
+					},
+				},
+			},
+			ctx: context.Background(),
+		},
+		{
+			desc: "add namespace to reconcile list if it has bad label openshift-pipelines.tekton.dev/namespace-reconcile-version",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""}}},
+			},
+			wantNamespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "test",
+						Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""},
+					},
+				},
+			},
+			ctx: context.Background(),
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			kubeclient := fakek8s.NewSimpleClientset(c.objs...)
+			r := rbac{
+				kubeClientSet: kubeclient,
+				version:       "devel",
+			}
+			namespaces, err := r.getNamespacesToBeReconciled(c.ctx)
+			if err != nil {
+				t.Fatalf("getNamespacesToBeReconciled: %v", err)
+			}
+			if d := cmp.Diff(c.wantNamespaces, namespaces); d != "" {
+				t.Fatalf("Diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestCreateResources(t *testing.T) {
+	ctx, _, _ := ts.SetupFakeContextWithCancel(t)
+	os.Setenv(common.KoEnvKey, "testdata")
+	scc := &v1.SecurityContextConstraints{ObjectMeta: metav1.ObjectMeta{Name: "PipelinesSCC"}}
+	tc := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   v1alpha1.ConfigResourceName,
+			Labels: map[string]string{},
+		},
+		Spec: v1alpha1.TektonConfigSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: "foo",
+			},
+			Platforms: v1alpha1.Platforms{
+				OpenShift: v1alpha1.OpenShift{
+					SCC: &v1alpha1.SCC{
+						Default: scc.Name,
+					},
+				},
+			},
+		},
+		Status: v1alpha1.TektonConfigStatus{
+			Status:             duckv1.Status{},
+			TektonInstallerSet: map[string]string{},
+		},
+	}
+	for _, c := range []struct {
+		desc string
+		objs []runtime.Object
+		iSet *v1alpha1.TektonInstallerSet
+		err  error
+	}{
+		{
+			desc: "No existing installer set",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""}}},
+			},
+			err: v1alpha1.RECONCILE_AGAIN_ERR,
+		},
+		{
+			desc: "existing installer set",
+			objs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"openshift-pipelines.tekton.dev/namespace-reconcile-version": ""}}},
+			},
+			iSet: &v1alpha1.TektonInstallerSet{ObjectMeta: metav1.ObjectMeta{Name: "rhosp-rbac-001", Labels: map[string]string{v1alpha1.CreatedByKey: createdByValue, v1alpha1.InstallerSetType: componentNameRBAC}, Annotations: map[string]string{
+				v1alpha1.ReleaseVersionKey: "devel", v1alpha1.TargetNamespaceKey: tc.Spec.TargetNamespace}}, Spec: v1alpha1.TektonInstallerSetSpec{}},
+			err: nil,
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			kubeclient := fakek8s.NewSimpleClientset(c.objs...)
+			fakeoperatorclient := fakeoperator.NewSimpleClientset()
+			fakesecurityclient := fakesecurity.NewSimpleClientset()
+			_, err := fakesecurityclient.SecurityV1().SecurityContextConstraints().Create(ctx, scc, metav1.CreateOptions{})
+			if err != nil {
+				t.Logf("Could not create fake scc %v", err)
+			}
+			if c.iSet != nil {
+				_, err := fakeoperatorclient.OperatorV1alpha1().TektonInstallerSets().Create(ctx, c.iSet, metav1.CreateOptions{})
+				if err != nil {
+					t.Logf("Could not create fake installerSet %v", err)
+				}
+			}
+			informers := informers.NewSharedInformerFactory(kubeclient, 0)
+			nsInformer := informers.Core().V1().Namespaces()
+			rbacinformer := informers.Rbac().V1().ClusterRoleBindings()
+
+			r := rbac{
+				kubeClientSet:     kubeclient,
+				operatorClientSet: fakeoperatorclient,
+				securityClientSet: fakesecurityclient,
+				rbacInformer:      rbacinformer,
+				nsInformer:        nsInformer,
+				version:           "devel",
+				tektonConfig:      tc,
+			}
+			err = r.createResources(ctx)
+			require.ErrorIs(t, err, c.err)
+		})
+	}
+}

--- a/pkg/reconciler/openshift/tektonconfig/testdata/tekton-pipeline/00-prereconcile/openshift-pipelines-scc.yaml
+++ b/pkg/reconciler/openshift/tektonconfig/testdata/tekton-pipeline/00-prereconcile/openshift-pipelines-scc.yaml
@@ -1,0 +1,42 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    kubernetes.io/description: pipelines-scc is a close replica of anyuid scc. pipelines-scc has fsGroup - MustRunAs.
+    release.openshift.io/create-only: "true"
+  name: pipelines-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+- csi

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme // import "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Scheme is the registry for any type that adheres to the meta API spec.
+var scheme = runtime.NewScheme()
+
+// Codecs provides access to encoding and decoding for the scheme.
+var Codecs = serializer.NewCodecFactory(scheme)
+
+// ParameterCodec handles versioning of objects that are converted to query parameters.
+var ParameterCodec = runtime.NewParameterCodec(scheme)
+
+// Unlike other API groups, meta internal knows about all meta external versions, but keeps
+// the logic for conversion private.
+func init() {
+	utilruntime.Must(internalversion.AddToScheme(scheme))
+}

--- a/vendor/k8s.io/client-go/metadata/interface.go
+++ b/vendor/k8s.io/client-go/metadata/interface.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Interface allows a caller to get the metadata (in the form of PartialObjectMetadata objects)
+// from any Kubernetes compatible resource API.
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) Getter
+}
+
+// ResourceInterface contains the set of methods that may be invoked on objects by their metadata.
+// Update is not supported by the server, but Patch can be used for the actions Update would handle.
+type ResourceInterface interface {
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
+}
+
+// Getter handles both namespaced and non-namespaced resource types consistently.
+type Getter interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}

--- a/vendor/k8s.io/client-go/metadata/metadata.go
+++ b/vendor/k8s.io/client-go/metadata/metadata.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	metainternalversionscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+// Client allows callers to retrieve the object metadata for any
+// Kubernetes-compatible API endpoint. The client uses the
+// meta.k8s.io/v1 PartialObjectMetadata resource to more efficiently
+// retrieve just the necessary metadata, but on older servers
+// (Kubernetes 1.14 and before) will retrieve the object and then
+// convert the metadata.
+type Client struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &Client{}
+
+// ConfigFor returns a copy of the provided config with the
+// appropriate metadata client defaults set.
+func ConfigFor(inConfig *rest.Config) *rest.Config {
+	config := rest.CopyConfig(inConfig)
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+	config.NegotiatedSerializer = metainternalversionscheme.Codecs.WithoutConversion()
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	return config
+}
+
+// NewForConfigOrDie creates a new metadata client for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) Interface {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// NewForConfig creates a new metadata client that can retrieve object
+// metadata details about any Kubernetes object (core, aggregated, or custom
+// resource based) in the form of PartialObjectMetadata objects, or returns
+// an error.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := ConfigFor(inConfig)
+
+	httpClient, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(config, httpClient)
+}
+
+// NewForConfigAndClient creates a new metadata client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(inConfig *rest.Config, h *http.Client) (Interface, error) {
+	config := ConfigFor(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/this-value-should-never-be-sent"
+
+	restClient, err := rest.RESTClientForConfigAndClient(config, h)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{client: restClient}, nil
+}
+
+type client struct {
+	client    *Client
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+// Resource returns an interface that can access cluster or namespace
+// scoped instances of resource.
+func (c *Client) Resource(resource schema.GroupVersionResource) Getter {
+	return &client{client: c, resource: resource}
+}
+
+// Namespace returns an interface that can access namespace-scoped instances of the
+// provided resource.
+func (c *client) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+// Delete removes the provided resource from the server.
+func (c *client) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name is required")
+	}
+	// if DeleteOptions are delivered to Negotiator for serialization,
+	// HTTP-Request header will bring "Content-Type: application/vnd.kubernetes.protobuf"
+	// apiextensions-apiserver uses unstructuredNegotiatedSerializer to decode the input,
+	// server-side will reply with 406 errors.
+	// The special treatment here is to be compatible with CRD Handler
+	// see: https://github.com/kubernetes/kubernetes/blob/1a845ccd076bbf1b03420fe694c85a5cd3bd6bed/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L843
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return result.Error()
+}
+
+// DeleteCollection triggers deletion of all resources in the specified scope (namespace or cluster).
+func (c *client) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	// See comment on Delete
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	return result.Error()
+}
+
+// Get returns the resource with name from the specified scope (namespace or cluster).
+func (c *client) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*metav1.PartialObjectMetadata, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		klog.V(5).Infof("Unable to retrieve PartialObjectMetadata: %#v", err)
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadata
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadata: %v", err)
+		}
+		if !isLikelyObjectMetadata(&partial) {
+			return nil, fmt.Errorf("object does not appear to match the ObjectMeta schema: %#v", partial)
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+// List returns all resources within the specified scope (namespace or cluster).
+func (c *client) List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		klog.V(5).Infof("Unable to retrieve PartialObjectMetadataList: %#v", err)
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadataList
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadataList: %v", err)
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadataList)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+// Watch finds all changes to the resources in the specified scope (namespace or cluster).
+func (c *client) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
+	return c.client.client.Get().
+		AbsPath(c.makeURLSegments("")...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Timeout(timeout).
+		Watch(ctx)
+}
+
+// Patch modifies the named resource in the specified scope (namespace or cluster).
+func (c *client) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*metav1.PartialObjectMetadata, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadata
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadata: %v", err)
+		}
+		if !isLikelyObjectMetadata(&partial) {
+			return nil, fmt.Errorf("object does not appear to match the ObjectMeta schema")
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+func (c *client) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}
+
+func isLikelyObjectMetadata(meta *metav1.PartialObjectMetadata) bool {
+	return len(meta.UID) > 0 || !meta.CreationTimestamp.IsZero() || len(meta.Name) > 0 || len(meta.GenerateName) > 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1825,6 +1825,7 @@ k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/apis/meta/internalversion
+k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1/validation
@@ -2142,6 +2143,7 @@ k8s.io/client-go/listers/scheduling/v1beta1
 k8s.io/client-go/listers/storage/v1
 k8s.io/client-go/listers/storage/v1alpha1
 k8s.io/client-go/listers/storage/v1beta1
+k8s.io/client-go/metadata
 k8s.io/client-go/openapi
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/install
@@ -2319,7 +2321,13 @@ knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 # sigs.k8s.io/controller-runtime v0.15.3
 ## explicit; go 1.20
+sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
+sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/client/interceptor
+sigs.k8s.io/controller-runtime/pkg/internal/field/selector
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
+sigs.k8s.io/controller-runtime/pkg/log
 # sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 ## explicit; go 1.18
 sigs.k8s.io/json

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go
@@ -1,0 +1,591 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Options are creation options for a Client.
+type Options struct {
+	// HTTPClient is the HTTP client to use for requests.
+	HTTPClient *http.Client
+
+	// Scheme, if provided, will be used to map go structs to GroupVersionKinds
+	Scheme *runtime.Scheme
+
+	// Mapper, if provided, will be used to map GroupVersionKinds to Resources
+	Mapper meta.RESTMapper
+
+	// Cache, if provided, is used to read objects from the cache.
+	Cache *CacheOptions
+
+	// WarningHandler is used to configure the warning handler responsible for
+	// surfacing and handling warnings messages sent by the API server.
+	WarningHandler WarningHandlerOptions
+
+	// DryRun instructs the client to only perform dry run requests.
+	DryRun *bool
+}
+
+// WarningHandlerOptions are options for configuring a
+// warning handler for the client which is responsible
+// for surfacing API Server warnings.
+type WarningHandlerOptions struct {
+	// SuppressWarnings decides if the warnings from the
+	// API server are suppressed or surfaced in the client.
+	SuppressWarnings bool
+	// AllowDuplicateLogs does not deduplicate the to-be
+	// logged surfaced warnings messages. See
+	// log.WarningHandlerOptions for considerations
+	// regarding deduplication
+	AllowDuplicateLogs bool
+}
+
+// CacheOptions are options for creating a cache-backed client.
+type CacheOptions struct {
+	// Reader is a cache-backed reader that will be used to read objects from the cache.
+	// +required
+	Reader Reader
+	// DisableFor is a list of objects that should not be read from the cache.
+	DisableFor []Object
+	// Unstructured is a flag that indicates whether the cache-backed client should
+	// read unstructured objects or lists from the cache.
+	Unstructured bool
+}
+
+// NewClientFunc allows a user to define how to create a client.
+type NewClientFunc func(config *rest.Config, options Options) (Client, error)
+
+// New returns a new Client using the provided config and Options.
+// The returned client reads *and* writes directly from the server
+// (it doesn't use object caches).  It understands how to work with
+// normal types (both custom resources and aggregated/built-in resources),
+// as well as unstructured types.
+//
+// In the case of normal types, the scheme will be used to look up the
+// corresponding group, version, and kind for the given type.  In the
+// case of unstructured types, the group, version, and kind will be extracted
+// from the corresponding fields on the object.
+func New(config *rest.Config, options Options) (c Client, err error) {
+	c, err = newClient(config, options)
+	if err == nil && options.DryRun != nil && *options.DryRun {
+		c = NewDryRunClient(c)
+	}
+	return c, err
+}
+
+func newClient(config *rest.Config, options Options) (*client, error) {
+	if config == nil {
+		return nil, fmt.Errorf("must provide non-nil rest.Config to client.New")
+	}
+
+	config = rest.CopyConfig(config)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	if !options.WarningHandler.SuppressWarnings {
+		// surface warnings
+		logger := log.Log.WithName("KubeAPIWarningLogger")
+		// Set a WarningHandler, the default WarningHandler
+		// is log.KubeAPIWarningLogger with deduplication enabled.
+		// See log.KubeAPIWarningLoggerOptions for considerations
+		// regarding deduplication.
+		config.WarningHandler = log.NewKubeAPIWarningLogger(
+			logger,
+			log.KubeAPIWarningLoggerOptions{
+				Deduplicate: !options.WarningHandler.AllowDuplicateLogs,
+			},
+		)
+	}
+
+	// Use the rest HTTP client for the provided config if unset
+	if options.HTTPClient == nil {
+		var err error
+		options.HTTPClient, err = rest.HTTPClientFor(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Init a scheme if none provided
+	if options.Scheme == nil {
+		options.Scheme = scheme.Scheme
+	}
+
+	// Init a Mapper if none provided
+	if options.Mapper == nil {
+		var err error
+		options.Mapper, err = apiutil.NewDynamicRESTMapper(config, options.HTTPClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resources := &clientRestResources{
+		httpClient: options.HTTPClient,
+		config:     config,
+		scheme:     options.Scheme,
+		mapper:     options.Mapper,
+		codecs:     serializer.NewCodecFactory(options.Scheme),
+
+		structuredResourceByType:   make(map[schema.GroupVersionKind]*resourceMeta),
+		unstructuredResourceByType: make(map[schema.GroupVersionKind]*resourceMeta),
+	}
+
+	rawMetaClient, err := metadata.NewForConfigAndClient(metadata.ConfigFor(config), options.HTTPClient)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct metadata-only client for use as part of client: %w", err)
+	}
+
+	c := &client{
+		typedClient: typedClient{
+			resources:  resources,
+			paramCodec: runtime.NewParameterCodec(options.Scheme),
+		},
+		unstructuredClient: unstructuredClient{
+			resources:  resources,
+			paramCodec: noConversionParamCodec{},
+		},
+		metadataClient: metadataClient{
+			client:     rawMetaClient,
+			restMapper: options.Mapper,
+		},
+		scheme: options.Scheme,
+		mapper: options.Mapper,
+	}
+	if options.Cache == nil || options.Cache.Reader == nil {
+		return c, nil
+	}
+
+	// We want a cache if we're here.
+	// Set the cache.
+	c.cache = options.Cache.Reader
+
+	// Load uncached GVKs.
+	c.cacheUnstructured = options.Cache.Unstructured
+	c.uncachedGVKs = map[schema.GroupVersionKind]struct{}{}
+	for _, obj := range options.Cache.DisableFor {
+		gvk, err := c.GroupVersionKindFor(obj)
+		if err != nil {
+			return nil, err
+		}
+		c.uncachedGVKs[gvk] = struct{}{}
+	}
+	return c, nil
+}
+
+var _ Client = &client{}
+
+// client is a client.Client that reads and writes directly from/to an API server.
+// It lazily initializes new clients at the time they are used.
+type client struct {
+	typedClient        typedClient
+	unstructuredClient unstructuredClient
+	metadataClient     metadataClient
+	scheme             *runtime.Scheme
+	mapper             meta.RESTMapper
+
+	cache             Reader
+	uncachedGVKs      map[schema.GroupVersionKind]struct{}
+	cacheUnstructured bool
+}
+
+func (c *client) shouldBypassCache(obj runtime.Object) (bool, error) {
+	if c.cache == nil {
+		return true, nil
+	}
+
+	gvk, err := c.GroupVersionKindFor(obj)
+	if err != nil {
+		return false, err
+	}
+	// TODO: this is producing unsafe guesses that don't actually work,
+	// but it matches ~99% of the cases out there.
+	if meta.IsListType(obj) {
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+	}
+	if _, isUncached := c.uncachedGVKs[gvk]; isUncached {
+		return true, nil
+	}
+	if !c.cacheUnstructured {
+		_, isUnstructured := obj.(runtime.Unstructured)
+		return isUnstructured, nil
+	}
+	return false, nil
+}
+
+// resetGroupVersionKind is a helper function to restore and preserve GroupVersionKind on an object.
+func (c *client) resetGroupVersionKind(obj runtime.Object, gvk schema.GroupVersionKind) {
+	if gvk != schema.EmptyObjectKind.GroupVersionKind() {
+		if v, ok := obj.(schema.ObjectKind); ok {
+			v.SetGroupVersionKind(gvk)
+		}
+	}
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *client) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return apiutil.GVKForObject(obj, c.scheme)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *client) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return apiutil.IsObjectNamespaced(obj, c.scheme, c.mapper)
+}
+
+// Scheme returns the scheme this client is using.
+func (c *client) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+// RESTMapper returns the scheme this client is using.
+func (c *client) RESTMapper() meta.RESTMapper {
+	return c.mapper
+}
+
+// Create implements client.Client.
+func (c *client) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.Create(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot create using only metadata")
+	default:
+		return c.typedClient.Create(ctx, obj, opts...)
+	}
+}
+
+// Update implements client.Client.
+func (c *client) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.Update(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update using only metadata -- did you mean to patch?")
+	default:
+		return c.typedClient.Update(ctx, obj, opts...)
+	}
+}
+
+// Delete implements client.Client.
+func (c *client) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.Delete(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.Delete(ctx, obj, opts...)
+	default:
+		return c.typedClient.Delete(ctx, obj, opts...)
+	}
+}
+
+// DeleteAllOf implements client.Client.
+func (c *client) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.DeleteAllOf(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.DeleteAllOf(ctx, obj, opts...)
+	default:
+		return c.typedClient.DeleteAllOf(ctx, obj, opts...)
+	}
+}
+
+// Patch implements client.Client.
+func (c *client) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.Patch(ctx, obj, patch, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.Patch(ctx, obj, patch, opts...)
+	default:
+		return c.typedClient.Patch(ctx, obj, patch, opts...)
+	}
+}
+
+// Get implements client.Client.
+func (c *client) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	if isUncached, err := c.shouldBypassCache(obj); err != nil {
+		return err
+	} else if !isUncached {
+		return c.cache.Get(ctx, key, obj, opts...)
+	}
+
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.Get(ctx, key, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		// Metadata only object should always preserve the GVK coming in from the caller.
+		defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+		return c.metadataClient.Get(ctx, key, obj, opts...)
+	default:
+		return c.typedClient.Get(ctx, key, obj, opts...)
+	}
+}
+
+// List implements client.Client.
+func (c *client) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	if isUncached, err := c.shouldBypassCache(obj); err != nil {
+		return err
+	} else if !isUncached {
+		return c.cache.List(ctx, obj, opts...)
+	}
+
+	switch x := obj.(type) {
+	case runtime.Unstructured:
+		return c.unstructuredClient.List(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadataList:
+		// Metadata only object should always preserve the GVK.
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		defer c.resetGroupVersionKind(obj, gvk)
+
+		// Call the list client.
+		if err := c.metadataClient.List(ctx, obj, opts...); err != nil {
+			return err
+		}
+
+		// Restore the GVK for each item in the list.
+		itemGVK := schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			// TODO: this is producing unsafe guesses that don't actually work,
+			// but it matches ~99% of the cases out there.
+			Kind: strings.TrimSuffix(gvk.Kind, "List"),
+		}
+		for i := range x.Items {
+			item := &x.Items[i]
+			item.SetGroupVersionKind(itemGVK)
+		}
+
+		return nil
+	default:
+		return c.typedClient.List(ctx, obj, opts...)
+	}
+}
+
+// Status implements client.StatusClient.
+func (c *client) Status() SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *client) SubResource(subResource string) SubResourceClient {
+	return &subResourceClient{client: c, subResource: subResource}
+}
+
+// subResourceClient is client.SubResourceWriter that writes to subresources.
+type subResourceClient struct {
+	client      *client
+	subResource string
+}
+
+// ensure subResourceClient implements client.SubResourceClient.
+var _ SubResourceClient = &subResourceClient{}
+
+// SubResourceGetOptions holds all the possible configuration
+// for a subresource Get request.
+type SubResourceGetOptions struct {
+	Raw *metav1.GetOptions
+}
+
+// ApplyToSubResourceGet updates the configuaration to the given get options.
+func (getOpt *SubResourceGetOptions) ApplyToSubResourceGet(o *SubResourceGetOptions) {
+	if getOpt.Raw != nil {
+		o.Raw = getOpt.Raw
+	}
+}
+
+// ApplyOptions applues the given options.
+func (getOpt *SubResourceGetOptions) ApplyOptions(opts []SubResourceGetOption) *SubResourceGetOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceGet(getOpt)
+	}
+
+	return getOpt
+}
+
+// AsGetOptions returns the configured options as *metav1.GetOptions.
+func (getOpt *SubResourceGetOptions) AsGetOptions() *metav1.GetOptions {
+	if getOpt.Raw == nil {
+		return &metav1.GetOptions{}
+	}
+	return getOpt.Raw
+}
+
+// SubResourceUpdateOptions holds all the possible configuration
+// for a subresource update request.
+type SubResourceUpdateOptions struct {
+	UpdateOptions
+	SubResourceBody Object
+}
+
+// ApplyToSubResourceUpdate updates the configuration on the given create options
+func (uo *SubResourceUpdateOptions) ApplyToSubResourceUpdate(o *SubResourceUpdateOptions) {
+	uo.UpdateOptions.ApplyToUpdate(&o.UpdateOptions)
+	if uo.SubResourceBody != nil {
+		o.SubResourceBody = uo.SubResourceBody
+	}
+}
+
+// ApplyOptions applies the given options.
+func (uo *SubResourceUpdateOptions) ApplyOptions(opts []SubResourceUpdateOption) *SubResourceUpdateOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceUpdate(uo)
+	}
+
+	return uo
+}
+
+// SubResourceUpdateAndPatchOption is an option that can be used for either
+// a subresource update or patch request.
+type SubResourceUpdateAndPatchOption interface {
+	SubResourceUpdateOption
+	SubResourcePatchOption
+}
+
+// WithSubResourceBody returns an option that uses the given body
+// for a subresource Update or Patch operation.
+func WithSubResourceBody(body Object) SubResourceUpdateAndPatchOption {
+	return &withSubresourceBody{body: body}
+}
+
+type withSubresourceBody struct {
+	body Object
+}
+
+func (wsr *withSubresourceBody) ApplyToSubResourceUpdate(o *SubResourceUpdateOptions) {
+	o.SubResourceBody = wsr.body
+}
+
+func (wsr *withSubresourceBody) ApplyToSubResourcePatch(o *SubResourcePatchOptions) {
+	o.SubResourceBody = wsr.body
+}
+
+// SubResourceCreateOptions are all the possible configurations for a subresource
+// create request.
+type SubResourceCreateOptions struct {
+	CreateOptions
+}
+
+// ApplyOptions applies the given options.
+func (co *SubResourceCreateOptions) ApplyOptions(opts []SubResourceCreateOption) *SubResourceCreateOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceCreate(co)
+	}
+
+	return co
+}
+
+// ApplyToSubresourceCreate applies the the configuration on the given create options.
+func (co *SubResourceCreateOptions) ApplyToSubresourceCreate(o *SubResourceCreateOptions) {
+	co.CreateOptions.ApplyToCreate(&co.CreateOptions)
+}
+
+// SubResourcePatchOptions holds all possible configurations for a subresource patch
+// request.
+type SubResourcePatchOptions struct {
+	PatchOptions
+	SubResourceBody Object
+}
+
+// ApplyOptions applies the given options.
+func (po *SubResourcePatchOptions) ApplyOptions(opts []SubResourcePatchOption) *SubResourcePatchOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourcePatch(po)
+	}
+
+	return po
+}
+
+// ApplyToSubResourcePatch applies the configuration on the given patch options.
+func (po *SubResourcePatchOptions) ApplyToSubResourcePatch(o *SubResourcePatchOptions) {
+	po.PatchOptions.ApplyToPatch(&o.PatchOptions)
+	if po.SubResourceBody != nil {
+		o.SubResourceBody = po.SubResourceBody
+	}
+}
+
+func (sc *subResourceClient) Get(ctx context.Context, obj Object, subResource Object, opts ...SubResourceGetOption) error {
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return sc.client.unstructuredClient.GetSubResource(ctx, obj, subResource, sc.subResource, opts...)
+	case *metav1.PartialObjectMetadata:
+		return errors.New("can not get subresource using only metadata")
+	default:
+		return sc.client.typedClient.GetSubResource(ctx, obj, subResource, sc.subResource, opts...)
+	}
+}
+
+// Create implements client.SubResourceClient
+func (sc *subResourceClient) Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error {
+	defer sc.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	defer sc.client.resetGroupVersionKind(subResource, subResource.GetObjectKind().GroupVersionKind())
+
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return sc.client.unstructuredClient.CreateSubResource(ctx, obj, subResource, sc.subResource, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
+	default:
+		return sc.client.typedClient.CreateSubResource(ctx, obj, subResource, sc.subResource, opts...)
+	}
+}
+
+// Update implements client.SubResourceClient
+func (sc *subResourceClient) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+	defer sc.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return sc.client.unstructuredClient.UpdateSubResource(ctx, obj, sc.subResource, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
+	default:
+		return sc.client.typedClient.UpdateSubResource(ctx, obj, sc.subResource, opts...)
+	}
+}
+
+// Patch implements client.SubResourceWriter.
+func (sc *subResourceClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+	defer sc.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	switch obj.(type) {
+	case runtime.Unstructured:
+		return sc.client.unstructuredClient.PatchSubResource(ctx, obj, sc.subResource, patch, opts...)
+	case *metav1.PartialObjectMetadata:
+		return sc.client.metadataClient.PatchSubResource(ctx, obj, sc.subResource, patch, opts...)
+	default:
+		return sc.client.typedClient.PatchSubResource(ctx, obj, sc.subResource, patch, opts...)
+	}
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/client_rest_resources.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/client_rest_resources.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// clientRestResources creates and stores rest clients and metadata for Kubernetes types.
+type clientRestResources struct {
+	// httpClient is the http client to use for requests
+	httpClient *http.Client
+
+	// config is the rest.Config to talk to an apiserver
+	config *rest.Config
+
+	// scheme maps go structs to GroupVersionKinds
+	scheme *runtime.Scheme
+
+	// mapper maps GroupVersionKinds to Resources
+	mapper meta.RESTMapper
+
+	// codecs are used to create a REST client for a gvk
+	codecs serializer.CodecFactory
+
+	// structuredResourceByType stores structured type metadata
+	structuredResourceByType map[schema.GroupVersionKind]*resourceMeta
+	// unstructuredResourceByType stores unstructured type metadata
+	unstructuredResourceByType map[schema.GroupVersionKind]*resourceMeta
+	mu                         sync.RWMutex
+}
+
+// newResource maps obj to a Kubernetes Resource and constructs a client for that Resource.
+// If the object is a list, the resource represents the item's type instead.
+func (c *clientRestResources) newResource(gvk schema.GroupVersionKind, isList, isUnstructured bool) (*resourceMeta, error) {
+	if strings.HasSuffix(gvk.Kind, "List") && isList {
+		// if this was a list, treat it as a request for the item's resource
+		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	}
+
+	client, err := apiutil.RESTClientForGVK(gvk, isUnstructured, c.config, c.codecs, c.httpClient)
+	if err != nil {
+		return nil, err
+	}
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceMeta{Interface: client, mapping: mapping, gvk: gvk}, nil
+}
+
+// getResource returns the resource meta information for the given type of object.
+// If the object is a list, the resource represents the item's type instead.
+func (c *clientRestResources) getResource(obj runtime.Object) (*resourceMeta, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	_, isUnstructured := obj.(runtime.Unstructured)
+
+	// It's better to do creation work twice than to not let multiple
+	// people make requests at once
+	c.mu.RLock()
+	resourceByType := c.structuredResourceByType
+	if isUnstructured {
+		resourceByType = c.unstructuredResourceByType
+	}
+	r, known := resourceByType[gvk]
+	c.mu.RUnlock()
+
+	if known {
+		return r, nil
+	}
+
+	// Initialize a new Client
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, err = c.newResource(gvk, meta.IsListType(obj), isUnstructured)
+	if err != nil {
+		return nil, err
+	}
+	resourceByType[gvk] = r
+	return r, err
+}
+
+// getObjMeta returns objMeta containing both type and object metadata and state.
+func (c *clientRestResources) getObjMeta(obj runtime.Object) (*objMeta, error) {
+	r, err := c.getResource(obj)
+	if err != nil {
+		return nil, err
+	}
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &objMeta{resourceMeta: r, Object: m}, err
+}
+
+// resourceMeta stores state for a Kubernetes type.
+type resourceMeta struct {
+	// client is the rest client used to talk to the apiserver
+	rest.Interface
+	// gvk is the GroupVersionKind of the resourceMeta
+	gvk schema.GroupVersionKind
+	// mapping is the rest mapping
+	mapping *meta.RESTMapping
+}
+
+// isNamespaced returns true if the type is namespaced.
+func (r *resourceMeta) isNamespaced() bool {
+	return r.mapping.Scope.Name() != meta.RESTScopeNameRoot
+}
+
+// resource returns the resource name of the type.
+func (r *resourceMeta) resource() string {
+	return r.mapping.Resource.Resource
+}
+
+// objMeta stores type and object information about a Kubernetes type.
+type objMeta struct {
+	// resourceMeta contains type information for the object
+	*resourceMeta
+
+	// Object contains meta data for the object instance
+	metav1.Object
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/codec.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/codec.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"errors"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/conversion/queryparams"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ runtime.ParameterCodec = noConversionParamCodec{}
+
+// noConversionParamCodec is a no-conversion codec for serializing parameters into URL query strings.
+// it's useful in scenarios with the unstructured client and arbitrary resources.
+type noConversionParamCodec struct{}
+
+func (noConversionParamCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
+	return queryparams.Convert(obj)
+}
+
+func (noConversionParamCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
+	return errors.New("DecodeParameters not implemented on noConversionParamCodec")
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/doc.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client contains functionality for interacting with Kubernetes API
+// servers.
+//
+// # Clients
+//
+// Clients are split into two interfaces -- Readers and Writers.   Readers
+// get and list, while writers create, update, and delete.
+//
+// The New function can be used to create a new client that talks directly
+// to the API server.
+//
+// It is a common pattern in Kubernetes to read from a cache and write to the API
+// server.  This pattern is covered by the creating the Client with a Cache.
+//
+// # Options
+//
+// Many client operations in Kubernetes support options.  These options are
+// represented as variadic arguments at the end of a given method call.
+// For instance, to use a label selector on list, you can call
+//
+//	err := someReader.List(context.Background(), &podList, client.MatchingLabels{"somelabel": "someval"})
+//
+// # Indexing
+//
+// Indexes may be added to caches using a FieldIndexer.  This allows you to easily
+// and efficiently look up objects with certain properties.  You can then make
+// use of the index by specifying a field selector on calls to List on the Reader
+// corresponding to the given Cache.
+//
+// For instance, a Secret controller might have an index on the
+// `.spec.volumes.secret.secretName` field in Pod objects, so that it could
+// easily look up all pods that reference a given secret.
+package client

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/dryrun.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/dryrun.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewDryRunClient wraps an existing client and enforces DryRun mode
+// on all mutating api calls.
+func NewDryRunClient(c Client) Client {
+	return &dryRunClient{client: c}
+}
+
+var _ Client = &dryRunClient{}
+
+// dryRunClient is a Client that wraps another Client in order to enforce DryRun mode.
+type dryRunClient struct {
+	client Client
+}
+
+// Scheme returns the scheme this client is using.
+func (c *dryRunClient) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+// RESTMapper returns the rest mapper this client is using.
+func (c *dryRunClient) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *dryRunClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.client.GroupVersionKindFor(obj)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *dryRunClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.client.IsObjectNamespaced(obj)
+}
+
+// Create implements client.Client.
+func (c *dryRunClient) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	return c.client.Create(ctx, obj, append(opts, DryRunAll)...)
+}
+
+// Update implements client.Client.
+func (c *dryRunClient) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	return c.client.Update(ctx, obj, append(opts, DryRunAll)...)
+}
+
+// Delete implements client.Client.
+func (c *dryRunClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	return c.client.Delete(ctx, obj, append(opts, DryRunAll)...)
+}
+
+// DeleteAllOf implements client.Client.
+func (c *dryRunClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	return c.client.DeleteAllOf(ctx, obj, append(opts, DryRunAll)...)
+}
+
+// Patch implements client.Client.
+func (c *dryRunClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
+}
+
+// Get implements client.Client.
+func (c *dryRunClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	return c.client.Get(ctx, key, obj, opts...)
+}
+
+// List implements client.Client.
+func (c *dryRunClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	return c.client.List(ctx, obj, opts...)
+}
+
+// Status implements client.StatusClient.
+func (c *dryRunClient) Status() SubResourceWriter {
+	return c.SubResource("status")
+}
+
+// SubResource implements client.SubResourceClient.
+func (c *dryRunClient) SubResource(subResource string) SubResourceClient {
+	return &dryRunSubResourceClient{client: c.client.SubResource(subResource)}
+}
+
+// ensure dryRunSubResourceWriter implements client.SubResourceWriter.
+var _ SubResourceWriter = &dryRunSubResourceClient{}
+
+// dryRunSubResourceClient is client.SubResourceWriter that writes status subresource with dryRun mode
+// enforced.
+type dryRunSubResourceClient struct {
+	client SubResourceClient
+}
+
+func (sw *dryRunSubResourceClient) Get(ctx context.Context, obj, subResource Object, opts ...SubResourceGetOption) error {
+	return sw.client.Get(ctx, obj, subResource, opts...)
+}
+
+func (sw *dryRunSubResourceClient) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
+	return sw.client.Create(ctx, obj, subResource, append(opts, DryRunAll)...)
+}
+
+// Update implements client.SubResourceWriter.
+func (sw *dryRunSubResourceClient) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+	return sw.client.Update(ctx, obj, append(opts, DryRunAll)...)
+}
+
+// Patch implements client.SubResourceWriter.
+func (sw *dryRunSubResourceClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+	return sw.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,1283 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	// Using v4 to match upstream
+	jsonpatch "github.com/evanphx/json-patch"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/internal/field/selector"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type versionedTracker struct {
+	testing.ObjectTracker
+	scheme                *runtime.Scheme
+	withStatusSubresource sets.Set[schema.GroupVersionKind]
+}
+
+type fakeClient struct {
+	tracker               versionedTracker
+	scheme                *runtime.Scheme
+	restMapper            meta.RESTMapper
+	withStatusSubresource sets.Set[schema.GroupVersionKind]
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+
+	schemeWriteLock sync.Mutex
+}
+
+var _ client.WithWatch = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClient(initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewFakeClientWithScheme creates a new fake client with the given scheme
+// for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+//
+// Deprecated: Please use NewClientBuilder instead.
+func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewClientBuilder returns a new builder to create a fake client.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// ClientBuilder builds a fake client.
+type ClientBuilder struct {
+	scheme                *runtime.Scheme
+	restMapper            meta.RESTMapper
+	initObject            []client.Object
+	initLists             []client.ObjectList
+	initRuntimeObjects    []runtime.Object
+	withStatusSubresource []client.Object
+	objectTracker         testing.ObjectTracker
+	interceptorFuncs      *interceptor.Funcs
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+}
+
+// WithScheme sets this builder's internal scheme.
+// If not set, defaults to client-go's global scheme.Scheme.
+func (f *ClientBuilder) WithScheme(scheme *runtime.Scheme) *ClientBuilder {
+	f.scheme = scheme
+	return f
+}
+
+// WithRESTMapper sets this builder's restMapper.
+// The restMapper is directly set as mapper in the Client. This can be used for example
+// with a meta.DefaultRESTMapper to provide a static rest mapping.
+// If not set, defaults to an empty meta.DefaultRESTMapper.
+func (f *ClientBuilder) WithRESTMapper(restMapper meta.RESTMapper) *ClientBuilder {
+	f.restMapper = restMapper
+	return f
+}
+
+// WithObjects can be optionally used to initialize this fake client with client.Object(s).
+func (f *ClientBuilder) WithObjects(initObjs ...client.Object) *ClientBuilder {
+	f.initObject = append(f.initObject, initObjs...)
+	return f
+}
+
+// WithLists can be optionally used to initialize this fake client with client.ObjectList(s).
+func (f *ClientBuilder) WithLists(initLists ...client.ObjectList) *ClientBuilder {
+	f.initLists = append(f.initLists, initLists...)
+	return f
+}
+
+// WithRuntimeObjects can be optionally used to initialize this fake client with runtime.Object(s).
+func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *ClientBuilder {
+	f.initRuntimeObjects = append(f.initRuntimeObjects, initRuntimeObjs...)
+	return f
+}
+
+// WithObjectTracker can be optionally used to initialize this fake client with testing.ObjectTracker.
+func (f *ClientBuilder) WithObjectTracker(ot testing.ObjectTracker) *ClientBuilder {
+	f.objectTracker = ot
+	return f
+}
+
+// WithIndex can be optionally used to register an index with name `field` and indexer `extractValue`
+// for API objects of the same GroupVersionKind (GVK) as `obj` in the fake client.
+// It can be invoked multiple times, both with objects of the same GVK or different ones.
+// Invoking WithIndex twice with the same `field` and GVK (via `obj`) arguments will panic.
+// WithIndex retrieves the GVK of `obj` using the scheme registered via WithScheme if
+// WithScheme was previously invoked, the default scheme otherwise.
+func (f *ClientBuilder) WithIndex(obj runtime.Object, field string, extractValue client.IndexerFunc) *ClientBuilder {
+	objScheme := f.scheme
+	if objScheme == nil {
+		objScheme = scheme.Scheme
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, objScheme)
+	if err != nil {
+		panic(err)
+	}
+
+	// If this is the first index being registered, we initialize the map storing all the indexes.
+	if f.indexes == nil {
+		f.indexes = make(map[schema.GroupVersionKind]map[string]client.IndexerFunc)
+	}
+
+	// If this is the first index being registered for the GroupVersionKind of `obj`, we initialize
+	// the map storing the indexes for that GroupVersionKind.
+	if f.indexes[gvk] == nil {
+		f.indexes[gvk] = make(map[string]client.IndexerFunc)
+	}
+
+	if _, fieldAlreadyIndexed := f.indexes[gvk][field]; fieldAlreadyIndexed {
+		panic(fmt.Errorf("indexer conflict: field %s for GroupVersionKind %v is already indexed",
+			field, gvk))
+	}
+
+	f.indexes[gvk][field] = extractValue
+
+	return f
+}
+
+// WithStatusSubresource configures the passed object with a status subresource, which means
+// calls to Update and Patch will not alter its status.
+func (f *ClientBuilder) WithStatusSubresource(o ...client.Object) *ClientBuilder {
+	f.withStatusSubresource = append(f.withStatusSubresource, o...)
+	return f
+}
+
+// WithInterceptorFuncs configures the client methods to be intercepted using the provided interceptor.Funcs.
+func (f *ClientBuilder) WithInterceptorFuncs(interceptorFuncs interceptor.Funcs) *ClientBuilder {
+	f.interceptorFuncs = &interceptorFuncs
+	return f
+}
+
+// Build builds and returns a new fake client.
+func (f *ClientBuilder) Build() client.WithWatch {
+	if f.scheme == nil {
+		f.scheme = scheme.Scheme
+	}
+	if f.restMapper == nil {
+		f.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	}
+
+	var tracker versionedTracker
+
+	withStatusSubResource := sets.New(inTreeResourcesWithStatus()...)
+	for _, o := range f.withStatusSubresource {
+		gvk, err := apiutil.GVKForObject(o, f.scheme)
+		if err != nil {
+			panic(fmt.Errorf("failed to get gvk for object %T: %w", withStatusSubResource, err))
+		}
+		withStatusSubResource.Insert(gvk)
+	}
+
+	if f.objectTracker == nil {
+		tracker = versionedTracker{ObjectTracker: testing.NewObjectTracker(f.scheme, scheme.Codecs.UniversalDecoder()), scheme: f.scheme, withStatusSubresource: withStatusSubResource}
+	} else {
+		tracker = versionedTracker{ObjectTracker: f.objectTracker, scheme: f.scheme, withStatusSubresource: withStatusSubResource}
+	}
+
+	for _, obj := range f.initObject {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initLists {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add list %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initRuntimeObjects {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add runtime object %v to fake client: %w", obj, err))
+		}
+	}
+
+	var result client.WithWatch = &fakeClient{
+		tracker:               tracker,
+		scheme:                f.scheme,
+		restMapper:            f.restMapper,
+		indexes:               f.indexes,
+		withStatusSubresource: withStatusSubResource,
+	}
+
+	if f.interceptorFuncs != nil {
+		result = interceptor.NewClient(result, *f.interceptorFuncs)
+	}
+
+	return result
+}
+
+const trackerAddResourceVersion = "999"
+
+func (t versionedTracker) Add(obj runtime.Object) error {
+	var objects []runtime.Object
+	if meta.IsListType(obj) {
+		var err error
+		objects, err = meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+	} else {
+		objects = []runtime.Object{obj}
+	}
+	for _, obj := range objects {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetDeletionTimestamp() != nil && len(accessor.GetFinalizers()) == 0 {
+			return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp but no finalizers", accessor.GetName())
+		}
+		if accessor.GetResourceVersion() == "" {
+			// We use a "magic" value of 999 here because this field
+			// is parsed as uint and and 0 is already used in Update.
+			// As we can't go lower, go very high instead so this can
+			// be recognized
+			accessor.SetResourceVersion(trackerAddResourceVersion)
+		}
+
+		obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+		if err != nil {
+			return err
+		}
+		if err := t.ObjectTracker.Add(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+	if accessor.GetResourceVersion() != "" {
+		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+	accessor.SetResourceVersion("1")
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	if err := t.ObjectTracker.Create(gvr, obj, ns); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+
+	return nil
+}
+
+// convertFromUnstructuredIfNecessary will convert runtime.Unstructured for a GVK that is recognized
+// by the schema into the whatever the schema produces with New() for said GVK.
+// This is required because the tracker unconditionally saves on manipulations, but its List() implementation
+// tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
+// we save as the very same type, otherwise subsequent List requests will fail.
+func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
+	gvk := o.GetObjectKind().GroupVersionKind()
+
+	u, isUnstructured := o.(runtime.Unstructured)
+	if !isUnstructured || !s.Recognizes(gvk) {
+		return o, nil
+	}
+
+	typed, err := s.New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("scheme recognizes %s but failed to produce an object for it: %w", gvk, err)
+	}
+
+	unstructuredSerialized, err := json.Marshal(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize %T: %w", unstructuredSerialized, err)
+	}
+	if err := json.Unmarshal(unstructuredSerialized, typed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", u, typed, err)
+	}
+
+	return typed, nil
+}
+
+func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	isStatus := false
+	// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
+	// that reaction, we use the callstack to figure out if this originated from the status client.
+	if bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).Patch")) {
+		isStatus = true
+	}
+	return t.update(gvr, obj, ns, isStatus, false)
+}
+
+func (t versionedTracker) update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, isStatus bool, deleting bool) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		gvk, err = apiutil.GVKForObject(obj, t.scheme)
+		if err != nil {
+			return err
+		}
+	}
+
+	oldObject, err := t.ObjectTracker.Get(gvr, ns, accessor.GetName())
+	if err != nil {
+		// If the resource is not found and the resource allows create on update, issue a
+		// create instead.
+		if apierrors.IsNotFound(err) && allowsCreateOnUpdate(gvk) {
+			return t.Create(gvr, obj, ns)
+		}
+		return err
+	}
+
+	if t.withStatusSubresource.Has(gvk) {
+		if isStatus { // copy everything but status and metadata.ResourceVersion from original object
+			if err := copyNonStatusFrom(oldObject, obj); err != nil {
+				return fmt.Errorf("failed to copy non-status field for object with status subresouce: %w", err)
+			}
+		} else { // copy status from original object
+			if err := copyStatusFrom(oldObject, obj); err != nil {
+				return fmt.Errorf("failed to copy the status for object with status subresource: %w", err)
+			}
+		}
+	} else if isStatus {
+		return apierrors.NewNotFound(gvr.GroupResource(), accessor.GetName())
+	}
+
+	oldAccessor, err := meta.Accessor(oldObject)
+	if err != nil {
+		return err
+	}
+
+	// If the new object does not have the resource version set and it allows unconditional update,
+	// default it to the resource version of the existing resource
+	if accessor.GetResourceVersion() == "" && allowsUnconditionalUpdate(gvk) {
+		accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+	}
+	if accessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+		return apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), errors.New("object was modified"))
+	}
+	if oldAccessor.GetResourceVersion() == "" {
+		oldAccessor.SetResourceVersion("0")
+	}
+	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("can not convert resourceVersion %q to int: %w", oldAccessor.GetResourceVersion(), err)
+	}
+	intResourceVersion++
+	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
+
+	if !deleting && !deletionTimestampEqual(accessor, oldAccessor) {
+		return fmt.Errorf("error: Unable to edit %s: metadata.deletionTimestamp field is immutable", accessor.GetName())
+	}
+
+	if !accessor.GetDeletionTimestamp().IsZero() && len(accessor.GetFinalizers()) == 0 {
+		return t.ObjectTracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+	}
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	return t.ObjectTracker.Update(gvr, obj, ns)
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return c.tracker.Watch(gvr, listOpts.Namespace)
+}
+
+func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	originalKind := gvk.Kind
+
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	if _, isUnstructuredList := obj.(runtime.Unstructured); isUnstructuredList && !c.scheme.Recognizes(gvk) {
+		// We need to register the ListKind with UnstructuredList:
+		// https://github.com/kubernetes/kubernetes/blob/7b2776b89fb1be28d4e9203bdeec079be903c103/staging/src/k8s.io/client-go/dynamic/fake/simple.go#L44-L51
+		c.schemeWriteLock.Lock()
+		c.scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+		c.schemeWriteLock.Unlock()
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(originalKind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector == nil && listOpts.FieldSelector == nil {
+		return nil
+	}
+
+	// If we're here, either a label or field selector are specified (or both), so before we return
+	// the list we must filter it. If both selectors are set, they are ANDed.
+	objs, err := meta.ExtractList(obj)
+	if err != nil {
+		return err
+	}
+
+	filteredList, err := c.filterList(objs, gvk, listOpts.LabelSelector, listOpts.FieldSelector)
+	if err != nil {
+		return err
+	}
+
+	return meta.SetList(obj, filteredList)
+}
+
+func (c *fakeClient) filterList(list []runtime.Object, gvk schema.GroupVersionKind, ls labels.Selector, fs fields.Selector) ([]runtime.Object, error) {
+	// Filter the objects with the label selector
+	filteredList := list
+	if ls != nil {
+		objsFilteredByLabel, err := objectutil.FilterWithLabels(list, ls)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByLabel
+	}
+
+	// Filter the result of the previous pass with the field selector
+	if fs != nil {
+		objsFilteredByField, err := c.filterWithFields(filteredList, gvk, fs)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByField
+	}
+
+	return filteredList, nil
+}
+
+func (c *fakeClient) filterWithFields(list []runtime.Object, gvk schema.GroupVersionKind, fs fields.Selector) ([]runtime.Object, error) {
+	// We only allow filtering on the basis of a single field to ensure consistency with the
+	// behavior of the cache reader (which we're faking here).
+	fieldKey, fieldVal, requiresExact := selector.RequiresExactMatch(fs)
+	if !requiresExact {
+		return nil, fmt.Errorf("field selector %s is not in one of the two supported forms \"key==val\" or \"key=val\"",
+			fs)
+	}
+
+	// Field selection is mimicked via indexes, so there's no sane answer this function can give
+	// if there are no indexes registered for the GroupVersionKind of the objects in the list.
+	indexes := c.indexes[gvk]
+	if len(indexes) == 0 || indexes[fieldKey] == nil {
+		return nil, fmt.Errorf("List on GroupVersionKind %v specifies selector on field %s, but no "+
+			"index with name %s has been registered for GroupVersionKind %v", gvk, fieldKey, fieldKey, gvk)
+	}
+
+	indexExtractor := indexes[fieldKey]
+	filteredList := make([]runtime.Object, 0, len(list))
+	for _, obj := range list {
+		if c.objMatchesFieldSelector(obj, indexExtractor, fieldVal) {
+			filteredList = append(filteredList, obj)
+		}
+	}
+	return filteredList, nil
+}
+
+func (c *fakeClient) objMatchesFieldSelector(o runtime.Object, extractIndex client.IndexerFunc, val string) bool {
+	obj, isClientObject := o.(client.Object)
+	if !isClientObject {
+		panic(fmt.Errorf("expected object %v to be of type client.Object, but it's not", o))
+	}
+
+	for _, extractedVal := range extractIndex(obj) {
+		if extractedVal == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *fakeClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	return c.restMapper
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *fakeClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return apiutil.GVKForObject(obj, c.scheme)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *fakeClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return apiutil.IsObjectNamespaced(obj, c.scheme, c.restMapper)
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+	// Ignore attempts to set deletion timestamp
+	if !accessor.GetDeletionTimestamp().IsZero() {
+		accessor.SetDeletionTimestamp(nil)
+	}
+
+	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range delOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	// Check the ResourceVersion if that Precondition was specified.
+	if delOptions.Preconditions != nil && delOptions.Preconditions.ResourceVersion != nil {
+		name := accessor.GetName()
+		dbObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), name)
+		if err != nil {
+			return err
+		}
+		oldAccessor, err := meta.Accessor(dbObj)
+		if err != nil {
+			return err
+		}
+		actualRV := oldAccessor.GetResourceVersion()
+		expectRV := *delOptions.Preconditions.ResourceVersion
+		if actualRV != expectRV {
+			msg := fmt.Sprintf(
+				"the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s). "+
+					"The object might have been modified",
+				expectRV, actualRV)
+			return apierrors.NewConflict(gvr.GroupResource(), name, errors.New(msg))
+		}
+	}
+
+	return c.deleteObject(gvr, accessor)
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range dcOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.deleteObject(gvr, accessor)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.update(obj, false, opts...)
+}
+
+func (c *fakeClient) update(obj client.Object, isStatus bool, opts ...client.UpdateOption) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	return c.tracker.update(gvr, obj, accessor.GetNamespace(), isStatus, false)
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.patch(obj, patch, opts...)
+}
+
+func (c *fakeClient) patch(obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range patchOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	oldObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err != nil {
+		return err
+	}
+	oldAccessor, err := meta.Accessor(oldObj)
+	if err != nil {
+		return err
+	}
+
+	// Apply patch without updating object.
+	// To remain in accordance with the behavior of k8s api behavior,
+	// a patch must not allow for changes to the deletionTimestamp of an object.
+	// The reaction() function applies the patch to the object and calls Update(),
+	// whereas dryPatch() replicates this behavior but skips the call to Update().
+	// This ensures that the patch may be rejected if a deletionTimestamp is modified, prior
+	// to updating the object.
+	action := testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data)
+	o, err := dryPatch(action, c.tracker)
+	if err != nil {
+		return err
+	}
+	newObj, err := meta.Accessor(o)
+	if err != nil {
+		return err
+	}
+
+	// Validate that deletionTimestamp has not been changed
+	if !deletionTimestampEqual(newObj, oldAccessor) {
+		return fmt.Errorf("rejected patch, metadata.deletionTimestamp immutable")
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(action)
+	if err != nil {
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+// Applying a patch results in a deletionTimestamp that is truncated to the nearest second.
+// Check that the diff between a new and old deletion timestamp is within a reasonable threshold
+// to be considered unchanged.
+func deletionTimestampEqual(newObj metav1.Object, obj metav1.Object) bool {
+	newTime := newObj.GetDeletionTimestamp()
+	oldTime := obj.GetDeletionTimestamp()
+
+	if newTime == nil || oldTime == nil {
+		return newTime == oldTime
+	}
+	return newTime.Time.Sub(oldTime.Time).Abs() < time.Second
+}
+
+// The behavior of applying the patch is pulled out into dryPatch(),
+// which applies the patch and returns an object, but does not Update() the object.
+// This function returns a patched runtime object that may then be validated before a call to Update() is executed.
+// This results in some code duplication, but was found to be a cleaner alternative than unmarshalling and introspecting the patch data
+// and easier than refactoring the k8s client-go method upstream.
+// Duplicate of upstream: https://github.com/kubernetes/client-go/blob/783d0d33626e59d55d52bfd7696b775851f92107/testing/fixture.go#L146-L194
+func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (runtime.Object, error) {
+	ns := action.GetNamespace()
+	gvr := action.GetResource()
+
+	obj, err := tracker.Get(gvr, ns, action.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	old, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// reset the object in preparation to unmarshal, since unmarshal does not guarantee that fields
+	// in obj that are removed by patch are cleared
+	value := reflect.ValueOf(obj)
+	value.Elem().Set(reflect.New(value.Type().Elem()).Elem())
+
+	switch action.GetPatchType() {
+	case types.JSONPatchType:
+		patch, err := jsonpatch.DecodePatch(action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+		modified, err := patch.Apply(old)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.MergePatchType:
+		modified, err := jsonpatch.MergePatch(old, action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.StrategicMergePatchType, types.ApplyPatchType:
+		mergedByte, err := strategicpatch.StrategicMergePatch(old, action.GetPatch(), obj)
+		if err != nil {
+			return nil, err
+		}
+		if err = json.Unmarshal(mergedByte, obj); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("PatchType is not supported")
+	}
+	return obj, nil
+}
+
+func copyNonStatusFrom(old, new runtime.Object) error {
+	newClientObject, ok := new.(client.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a client.Object", new)
+	}
+	// The only thing other than status we have to retain
+	rv := newClientObject.GetResourceVersion()
+
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	newMapStringAny, err := toMapStringAny(new)
+	if err != nil {
+		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
+	}
+
+	// delete everything other than status in case it has fields that were not present in
+	// the old object
+	for k := range newMapStringAny {
+		if k != "status" {
+			delete(newMapStringAny, k)
+		}
+	}
+	// copy everything other than status from the old object
+	for k := range oldMapStringAny {
+		if k != "status" {
+			newMapStringAny[k] = oldMapStringAny[k]
+		}
+	}
+
+	if err := fromMapStringAny(newMapStringAny, new); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+	newClientObject.SetResourceVersion(rv)
+
+	return nil
+}
+
+// copyStatusFrom copies the status from old into new
+func copyStatusFrom(old, new runtime.Object) error {
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	newMapStringAny, err := toMapStringAny(new)
+	if err != nil {
+		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
+	}
+
+	newMapStringAny["status"] = oldMapStringAny["status"]
+
+	if err := fromMapStringAny(newMapStringAny, new); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+
+	return nil
+}
+
+func toMapStringAny(obj runtime.Object) (map[string]any, error) {
+	if unstructured, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured {
+		return unstructured.Object, nil
+	}
+
+	serialized, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u := map[string]any{}
+	return u, json.Unmarshal(serialized, &u)
+}
+
+func fromMapStringAny(u map[string]any, target runtime.Object) error {
+	if targetUnstructured, isUnstructured := target.(*unstructured.Unstructured); isUnstructured {
+		targetUnstructured.Object = u
+		return nil
+	}
+
+	serialized, err := json.Marshal(u)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+
+	if err := json.Unmarshal(serialized, &target); err != nil {
+		return fmt.Errorf("failed to deserialize: %w", err)
+	}
+
+	return nil
+}
+
+func (c *fakeClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *fakeClient) SubResource(subResource string) client.SubResourceClient {
+	return &fakeSubResourceClient{client: c, subResource: subResource}
+}
+
+func (c *fakeClient) deleteObject(gvr schema.GroupVersionResource, accessor metav1.Object) error {
+	old, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err == nil {
+		oldAccessor, err := meta.Accessor(old)
+		if err == nil {
+			if len(oldAccessor.GetFinalizers()) > 0 {
+				now := metav1.Now()
+				oldAccessor.SetDeletionTimestamp(&now)
+				// Call update directly with mutability parameter set to true to allow
+				// changes to deletionTimestamp
+				return c.tracker.update(gvr, old, accessor.GetNamespace(), false, true)
+			}
+		}
+	}
+
+	//TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeSubResourceClient struct {
+	client      *fakeClient
+	subResource string
+}
+
+func (sw *fakeSubResourceClient) Get(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	panic("fakeSubResourceClient does not support get")
+}
+
+func (sw *fakeSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	switch sw.subResource {
+	case "eviction":
+		_, isEviction := subResource.(*policyv1beta1.Eviction)
+		if !isEviction {
+			_, isEviction = subResource.(*policyv1.Eviction)
+		}
+		if !isEviction {
+			return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %t, expected Eviction", subResource))
+		}
+		if _, isPod := obj.(*corev1.Pod); !isPod {
+			return apierrors.NewNotFound(schema.GroupResource{}, "")
+		}
+
+		return sw.client.Delete(ctx, obj)
+	default:
+		return fmt.Errorf("fakeSubResourceWriter does not support create for %s", sw.subResource)
+	}
+}
+
+func (sw *fakeSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	updateOptions := client.SubResourceUpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	body := obj
+	if updateOptions.SubResourceBody != nil {
+		body = updateOptions.SubResourceBody
+	}
+	return sw.client.update(body, true, &updateOptions.UpdateOptions)
+}
+
+func (sw *fakeSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	patchOptions := client.SubResourcePatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	body := obj
+	if patchOptions.SubResourceBody != nil {
+		body = patchOptions.SubResourceBody
+	}
+
+	return sw.client.patch(body, patch, &patchOptions.PatchOptions)
+}
+
+func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "apps":
+		switch gvk.Kind {
+		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
+			return true
+		}
+	case "autoscaling":
+		switch gvk.Kind {
+		case "HorizontalPodAutoscaler":
+			return true
+		}
+	case "batch":
+		switch gvk.Kind {
+		case "CronJob", "Job":
+			return true
+		}
+	case "certificates":
+		switch gvk.Kind {
+		case "Certificates":
+			return true
+		}
+	case "flowcontrol":
+		switch gvk.Kind {
+		case "FlowSchema", "PriorityLevelConfiguration":
+			return true
+		}
+	case "networking":
+		switch gvk.Kind {
+		case "Ingress", "IngressClass", "NetworkPolicy":
+			return true
+		}
+	case "policy":
+		switch gvk.Kind {
+		case "PodSecurityPolicy":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "scheduling":
+		switch gvk.Kind {
+		case "PriorityClass":
+			return true
+		}
+	case "settings":
+		switch gvk.Kind {
+		case "PodPreset":
+			return true
+		}
+	case "storage":
+		switch gvk.Kind {
+		case "StorageClass":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "ConfigMap", "Endpoint", "Event", "LimitRange", "Namespace", "Node",
+			"PersistentVolume", "PersistentVolumeClaim", "Pod", "PodTemplate",
+			"ReplicationController", "ResourceQuota", "Secret", "Service",
+			"ServiceAccount", "EndpointSlice":
+			return true
+		}
+	}
+
+	return false
+}
+
+func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "coordination":
+		switch gvk.Kind {
+		case "Lease":
+			return true
+		}
+	case "node":
+		switch gvk.Kind {
+		case "RuntimeClass":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "Endpoint", "Event", "LimitRange", "Service":
+			return true
+		}
+	}
+
+	return false
+}
+
+func inTreeResourcesWithStatus() []schema.GroupVersionKind {
+	return []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Namespace"},
+		{Version: "v1", Kind: "Node"},
+		{Version: "v1", Kind: "PersistentVolumeClaim"},
+		{Version: "v1", Kind: "PersistentVolume"},
+		{Version: "v1", Kind: "Pod"},
+		{Version: "v1", Kind: "ReplicationController"},
+		{Version: "v1", Kind: "Service"},
+
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+		{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+
+		{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"},
+
+		{Group: "batch", Version: "v1", Kind: "CronJob"},
+		{Group: "batch", Version: "v1", Kind: "Job"},
+
+		{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"},
+
+		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+
+		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+
+		{Group: "storage.k8s.io", Version: "v1", Kind: "VolumeAttachment"},
+
+		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
+
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "PriorityLevelConfiguration"},
+	}
+}
+
+// zero zeros the value of a pointer.
+func zero(x interface{}) {
+	if x == nil {
+		return
+	}
+	res := reflect.ValueOf(x).Elem()
+	res.Set(reflect.Zero(res.Type()))
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+A fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewFakeClientWithScheme(scheme, initObjs...) // initObjs is a slice of runtime.Object
+
+You can invoke the methods defined in the Client interface.
+
+When in doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
+  - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+  - There is some support for sub resources which can cause issues with tests if you're trying to update
+    e.g. metadata and status in the same reconcile.
+  - No OpenAPI validation is performed when creating or updating objects.
+  - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+    operations that rely on these fields will fail, or give false positives.
+*/
+package fake

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
@@ -1,0 +1,166 @@
+package interceptor
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Funcs contains functions that are called instead of the underlying client's methods.
+type Funcs struct {
+	Get               func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	List              func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error
+	Create            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error
+	Delete            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error
+	DeleteAllOf       func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error
+	Update            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error
+	Patch             func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+	Watch             func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error)
+	SubResource       func(client client.WithWatch, subResource string) client.SubResourceClient
+	SubResourceGet    func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error
+	SubResourceCreate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error
+	SubResourceUpdate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error
+	SubResourcePatch  func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error
+}
+
+// NewClient returns a new interceptor client that calls the functions in funcs instead of the underlying client's methods, if they are not nil.
+func NewClient(interceptedClient client.WithWatch, funcs Funcs) client.WithWatch {
+	return interceptor{
+		client: interceptedClient,
+		funcs:  funcs,
+	}
+}
+
+type interceptor struct {
+	client client.WithWatch
+	funcs  Funcs
+}
+
+var _ client.WithWatch = &interceptor{}
+
+func (c interceptor) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.client.GroupVersionKindFor(obj)
+}
+
+func (c interceptor) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.client.IsObjectNamespaced(obj)
+}
+
+func (c interceptor) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.funcs.Get != nil {
+		return c.funcs.Get(ctx, c.client, key, obj, opts...)
+	}
+	return c.client.Get(ctx, key, obj, opts...)
+}
+
+func (c interceptor) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.funcs.List != nil {
+		return c.funcs.List(ctx, c.client, list, opts...)
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c interceptor) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.funcs.Create != nil {
+		return c.funcs.Create(ctx, c.client, obj, opts...)
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c interceptor) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if c.funcs.Delete != nil {
+		return c.funcs.Delete(ctx, c.client, obj, opts...)
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c interceptor) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.funcs.Update != nil {
+		return c.funcs.Update(ctx, c.client, obj, opts...)
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c interceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.funcs.Patch != nil {
+		return c.funcs.Patch(ctx, c.client, obj, patch, opts...)
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c interceptor) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	if c.funcs.DeleteAllOf != nil {
+		return c.funcs.DeleteAllOf(ctx, c.client, obj, opts...)
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c interceptor) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c interceptor) SubResource(subResource string) client.SubResourceClient {
+	if c.funcs.SubResource != nil {
+		return c.funcs.SubResource(c.client, subResource)
+	}
+	return subResourceInterceptor{
+		subResourceName: subResource,
+		client:          c.client,
+		funcs:           c.funcs,
+	}
+}
+
+func (c interceptor) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+func (c interceptor) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+func (c interceptor) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	if c.funcs.Watch != nil {
+		return c.funcs.Watch(ctx, c.client, obj, opts...)
+	}
+	return c.client.Watch(ctx, obj, opts...)
+}
+
+type subResourceInterceptor struct {
+	subResourceName string
+	client          client.Client
+	funcs           Funcs
+}
+
+var _ client.SubResourceClient = &subResourceInterceptor{}
+
+func (s subResourceInterceptor) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	if s.funcs.SubResourceGet != nil {
+		return s.funcs.SubResourceGet(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Get(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if s.funcs.SubResourceCreate != nil {
+		return s.funcs.SubResourceCreate(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Create(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if s.funcs.SubResourceUpdate != nil {
+		return s.funcs.SubResourceUpdate(ctx, s.client, s.subResourceName, obj, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Update(ctx, obj, opts...)
+}
+
+func (s subResourceInterceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if s.funcs.SubResourcePatch != nil {
+		return s.funcs.SubResourcePatch(ctx, s.client, s.subResourceName, obj, patch, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Patch(ctx, obj, patch, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/interfaces.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/interfaces.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ObjectKey identifies a Kubernetes Object.
+type ObjectKey = types.NamespacedName
+
+// ObjectKeyFromObject returns the ObjectKey given a runtime.Object.
+func ObjectKeyFromObject(obj Object) ObjectKey {
+	return ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+}
+
+// Patch is a patch that can be applied to a Kubernetes object.
+type Patch interface {
+	// Type is the PatchType of the patch.
+	Type() types.PatchType
+	// Data is the raw data representing the patch.
+	Data(obj Object) ([]byte, error)
+}
+
+// TODO(directxman12): is there a sane way to deal with get/delete options?
+
+// Reader knows how to read and list Kubernetes objects.
+type Reader interface {
+	// Get retrieves an obj for the given object key from the Kubernetes Cluster.
+	// obj must be a struct pointer so that obj can be updated with the response
+	// returned by the Server.
+	Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error
+
+	// List retrieves list of objects for a given namespace and list options. On a
+	// successful call, Items field in the list will be populated with the
+	// result returned from the server.
+	List(ctx context.Context, list ObjectList, opts ...ListOption) error
+}
+
+// Writer knows how to create, delete, and update Kubernetes objects.
+type Writer interface {
+	// Create saves the object obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Create(ctx context.Context, obj Object, opts ...CreateOption) error
+
+	// Delete deletes the given obj from Kubernetes cluster.
+	Delete(ctx context.Context, obj Object, opts ...DeleteOption) error
+
+	// Update updates the given obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Update(ctx context.Context, obj Object, opts ...UpdateOption) error
+
+	// Patch patches the given obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error
+
+	// DeleteAllOf deletes all objects of the given type matching the given options.
+	DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error
+}
+
+// StatusClient knows how to create a client which can update status subresource
+// for kubernetes objects.
+type StatusClient interface {
+	Status() SubResourceWriter
+}
+
+// SubResourceClientConstructor knows how to create a client which can update subresource
+// for kubernetes objects.
+type SubResourceClientConstructor interface {
+	// SubResourceClientConstructor returns a subresource client for the named subResource. Known
+	// upstream subResources usages are:
+	// - ServiceAccount token creation:
+	//     sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     token := &authenticationv1.TokenRequest{}
+	//     c.SubResourceClient("token").Create(ctx, sa, token)
+	//
+	// - Pod eviction creation:
+	//     pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     c.SubResourceClient("eviction").Create(ctx, pod, &policyv1.Eviction{})
+	//
+	// - Pod binding creation:
+	//     pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     binding := &corev1.Binding{Target: corev1.ObjectReference{Name: "my-node"}}
+	//     c.SubResourceClient("binding").Create(ctx, pod, binding)
+	//
+	// - CertificateSigningRequest approval:
+	//     csr := &certificatesv1.CertificateSigningRequest{
+	//	     ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+	//       Status: certificatesv1.CertificateSigningRequestStatus{
+	//         Conditions: []certificatesv1.[]CertificateSigningRequestCondition{{
+	//           Type: certificatesv1.CertificateApproved,
+	//           Status: corev1.ConditionTrue,
+	//         }},
+	//       },
+	//     }
+	//     c.SubResourceClient("approval").Update(ctx, csr)
+	//
+	// - Scale retrieval:
+	//     dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     scale := &autoscalingv1.Scale{}
+	//     c.SubResourceClient("scale").Get(ctx, dep, scale)
+	//
+	// - Scale update:
+	//     dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 2}}
+	//     c.SubResourceClient("scale").Update(ctx, dep, client.WithSubResourceBody(scale))
+	SubResource(subResource string) SubResourceClient
+}
+
+// StatusWriter is kept for backward compatibility.
+type StatusWriter = SubResourceWriter
+
+// SubResourceReader knows how to read SubResources
+type SubResourceReader interface {
+	Get(ctx context.Context, obj Object, subResource Object, opts ...SubResourceGetOption) error
+}
+
+// SubResourceWriter knows how to update subresource of a Kubernetes object.
+type SubResourceWriter interface {
+	// Create saves the subResource object in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error
+	// Update updates the fields corresponding to the status subresource for the
+	// given obj. obj must be a struct pointer so that obj can be updated
+	// with the content returned by the Server.
+	Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error
+
+	// Patch patches the given object's subresource. obj must be a struct
+	// pointer so that obj can be updated with the content returned by the
+	// Server.
+	Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error
+}
+
+// SubResourceClient knows how to perform CRU operations on Kubernetes objects.
+type SubResourceClient interface {
+	SubResourceReader
+	SubResourceWriter
+}
+
+// Client knows how to perform CRUD operations on Kubernetes objects.
+type Client interface {
+	Reader
+	Writer
+	StatusClient
+	SubResourceClientConstructor
+
+	// Scheme returns the scheme this client is using.
+	Scheme() *runtime.Scheme
+	// RESTMapper returns the rest this client is using.
+	RESTMapper() meta.RESTMapper
+	// GroupVersionKindFor returns the GroupVersionKind for the given object.
+	GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error)
+	// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+	IsObjectNamespaced(obj runtime.Object) (bool, error)
+}
+
+// WithWatch supports Watch on top of the CRUD operations supported by
+// the normal Client. Its intended use-case are CLI apps that need to wait for
+// events.
+type WithWatch interface {
+	Client
+	Watch(ctx context.Context, obj ObjectList, opts ...ListOption) (watch.Interface, error)
+}
+
+// IndexerFunc knows how to take an object and turn it into a series
+// of non-namespaced keys. Namespaced objects are automatically given
+// namespaced and non-spaced variants, so keys do not need to include namespace.
+type IndexerFunc func(Object) []string
+
+// FieldIndexer knows how to index over a particular "field" such that it
+// can later be used by a field selector.
+type FieldIndexer interface {
+	// IndexFields adds an index with the given field name on the given object type
+	// by using the given function to extract the value for that field.  If you want
+	// compatibility with the Kubernetes API server, only return one key, and only use
+	// fields that the API server supports.  Otherwise, you can return multiple keys,
+	// and "equality" in the field selector means that at least one key matches the value.
+	// The FieldIndexer will automatically take care of indexing over namespace
+	// and supporting efficient all-namespace queries.
+	IndexField(ctx context.Context, obj Object, field string, extractValue IndexerFunc) error
+}
+
+// IgnoreNotFound returns nil on NotFound errors.
+// All other values that are not NotFound errors or nil are returned unmodified.
+func IgnoreNotFound(err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// IgnoreAlreadyExists returns nil on AlreadyExists errors.
+// All other values that are not AlreadyExists errors or nil are returned unmodified.
+func IgnoreAlreadyExists(err error) error {
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return err
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/metadata_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/metadata_client.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
+)
+
+// TODO(directxman12): we could rewrite this on top of the low-level REST
+// client to avoid the extra shallow copy at the end, but I'm not sure it's
+// worth it -- the metadata client deals with falling back to loading the whole
+// object on older API servers, etc, and we'd have to reproduce that.
+
+// metadataClient is a client that reads & writes metadata-only requests to/from the API server.
+type metadataClient struct {
+	client     metadata.Interface
+	restMapper meta.RESTMapper
+}
+
+func (mc *metadataClient) getResourceInterface(gvk schema.GroupVersionKind, ns string) (metadata.ResourceInterface, error) {
+	mapping, err := mc.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return mc.client.Resource(mapping.Resource), nil
+	}
+	return mc.client.Resource(mapping.Resource).Namespace(ns), nil
+}
+
+// Delete implements client.Client.
+func (mc *metadataClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	resInt, err := mc.getResourceInterface(metadata.GroupVersionKind(), metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	return resInt.Delete(ctx, metadata.Name, *deleteOpts.AsDeleteOptions())
+}
+
+// DeleteAllOf implements client.Client.
+func (mc *metadataClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	deleteAllOfOpts := DeleteAllOfOptions{}
+	deleteAllOfOpts.ApplyOptions(opts)
+
+	resInt, err := mc.getResourceInterface(metadata.GroupVersionKind(), deleteAllOfOpts.ListOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	return resInt.DeleteCollection(ctx, *deleteAllOfOpts.AsDeleteOptions(), *deleteAllOfOpts.AsListOptions())
+}
+
+// Patch implements client.Client.
+func (mc *metadataClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	resInt, err := mc.getResourceInterface(gvk, metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &PatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions())
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+// Get implements client.Client.
+func (mc *metadataClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+
+	getOpts := GetOptions{}
+	getOpts.ApplyOptions(opts)
+
+	resInt, err := mc.getResourceInterface(gvk, key.Namespace)
+	if err != nil {
+		return err
+	}
+
+	res, err := resInt.Get(ctx, key.Name, *getOpts.AsGetOptions())
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+// List implements client.Client.
+func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadataList)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	resInt, err := mc.getResourceInterface(gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	res, err := resInt.List(ctx, *listOpts.AsListOptions())
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+func (mc *metadataClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	resInt, err := mc.getResourceInterface(gvk, metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &SubResourcePatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	body := obj
+	if patchOpts.SubResourceBody != nil {
+		body = patchOpts.SubResourceBody
+	}
+
+	data, err := patch.Data(body)
+	if err != nil {
+		return err
+	}
+
+	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions(), subResource)
+	if err != nil {
+		return err
+	}
+
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/namespaced_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/namespaced_client.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewNamespacedClient wraps an existing client enforcing the namespace value.
+// All functions using this client will have the same namespace declared here.
+func NewNamespacedClient(c Client, ns string) Client {
+	return &namespacedClient{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+var _ Client = &namespacedClient{}
+
+// namespacedClient is a Client that wraps another Client in order to enforce the specified namespace value.
+type namespacedClient struct {
+	namespace string
+	client    Client
+}
+
+// Scheme returns the scheme this client is using.
+func (n *namespacedClient) Scheme() *runtime.Scheme {
+	return n.client.Scheme()
+}
+
+// RESTMapper returns the scheme this client is using.
+func (n *namespacedClient) RESTMapper() meta.RESTMapper {
+	return n.client.RESTMapper()
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (n *namespacedClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return n.client.GroupVersionKindFor(obj)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (n *namespacedClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return n.client.IsObjectNamespaced(obj)
+}
+
+// Create implements client.Client.
+func (n *namespacedClient) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != n.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), n.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(n.namespace)
+	}
+	return n.client.Create(ctx, obj, opts...)
+}
+
+// Update implements client.Client.
+func (n *namespacedClient) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != n.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), n.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(n.namespace)
+	}
+	return n.client.Update(ctx, obj, opts...)
+}
+
+// Delete implements client.Client.
+func (n *namespacedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != n.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), n.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(n.namespace)
+	}
+	return n.client.Delete(ctx, obj, opts...)
+}
+
+// DeleteAllOf implements client.Client.
+func (n *namespacedClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	if isNamespaceScoped {
+		opts = append(opts, InNamespace(n.namespace))
+	}
+	return n.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+// Patch implements client.Client.
+func (n *namespacedClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != n.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), n.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(n.namespace)
+	}
+	return n.client.Patch(ctx, obj, patch, opts...)
+}
+
+// Get implements client.Client.
+func (n *namespacedClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+	if isNamespaceScoped {
+		if key.Namespace != "" && key.Namespace != n.namespace {
+			return fmt.Errorf("namespace %s provided for the object %s does not match the namespace %s on the client", key.Namespace, obj.GetName(), n.namespace)
+		}
+		key.Namespace = n.namespace
+	}
+	return n.client.Get(ctx, key, obj, opts...)
+}
+
+// List implements client.Client.
+func (n *namespacedClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	if n.namespace != "" {
+		opts = append(opts, InNamespace(n.namespace))
+	}
+	return n.client.List(ctx, obj, opts...)
+}
+
+// Status implements client.StatusClient.
+func (n *namespacedClient) Status() SubResourceWriter {
+	return n.SubResource("status")
+}
+
+// SubResource implements client.SubResourceClient.
+func (n *namespacedClient) SubResource(subResource string) SubResourceClient {
+	return &namespacedClientSubResourceClient{client: n.client.SubResource(subResource), namespace: n.namespace, namespacedclient: n}
+}
+
+// ensure namespacedClientSubResourceClient implements client.SubResourceClient.
+var _ SubResourceClient = &namespacedClientSubResourceClient{}
+
+type namespacedClientSubResourceClient struct {
+	client           SubResourceClient
+	namespace        string
+	namespacedclient Client
+}
+
+func (nsw *namespacedClientSubResourceClient) Get(ctx context.Context, obj, subResource Object, opts ...SubResourceGetOption) error {
+	isNamespaceScoped, err := nsw.namespacedclient.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != nsw.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(nsw.namespace)
+	}
+
+	return nsw.client.Get(ctx, obj, subResource, opts...)
+}
+
+func (nsw *namespacedClientSubResourceClient) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
+	isNamespaceScoped, err := nsw.namespacedclient.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != nsw.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(nsw.namespace)
+	}
+
+	return nsw.client.Create(ctx, obj, subResource, opts...)
+}
+
+// Update implements client.SubResourceWriter.
+func (nsw *namespacedClientSubResourceClient) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+	isNamespaceScoped, err := nsw.namespacedclient.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != nsw.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(nsw.namespace)
+	}
+	return nsw.client.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.SubResourceWriter.
+func (nsw *namespacedClientSubResourceClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+	isNamespaceScoped, err := nsw.namespacedclient.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != nsw.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(nsw.namespace)
+	}
+	return nsw.client.Patch(ctx, obj, patch, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/object.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Object is a Kubernetes object, allows functions to work indistinctly with
+// any resource that implements both Object interfaces.
+//
+// Semantically, these are objects which are both serializable (runtime.Object)
+// and identifiable (metav1.Object) -- think any object which you could write
+// as YAML or JSON, and then `kubectl create`.
+//
+// Code-wise, this means that any object which embeds both ObjectMeta (which
+// provides metav1.Object) and TypeMeta (which provides half of runtime.Object)
+// and has a `DeepCopyObject` implementation (the other half of runtime.Object)
+// will implement this by default.
+//
+// For example, nearly all the built-in types are Objects, as well as all
+// KubeBuilder-generated CRDs (unless you do something real funky to them).
+//
+// By and large, most things that implement runtime.Object also implement
+// Object -- it's very rare to have *just* a runtime.Object implementation (the
+// cases tend to be funky built-in types like Webhook payloads that don't have
+// a `metadata` field).
+//
+// Notice that XYZList types are distinct: they implement ObjectList instead.
+type Object interface {
+	metav1.Object
+	runtime.Object
+}
+
+// ObjectList is a Kubernetes object list, allows functions to work
+// indistinctly with any resource that implements both runtime.Object and
+// metav1.ListInterface interfaces.
+//
+// Semantically, this is any object which may be serialized (ObjectMeta), and
+// is a kubernetes list wrapper (has items, pagination fields, etc) -- think
+// the wrapper used in a response from a `kubectl list --output yaml` call.
+//
+// Code-wise, this means that any object which embedds both ListMeta (which
+// provides metav1.ListInterface) and TypeMeta (which provides half of
+// runtime.Object) and has a `DeepCopyObject` implementation (the other half of
+// runtime.Object) will implement this by default.
+//
+// For example, nearly all the built-in XYZList types are ObjectLists, as well
+// as the XYZList types for all KubeBuilder-generated CRDs (unless you do
+// something real funky to them).
+//
+// By and large, most things that are XYZList and implement runtime.Object also
+// implement ObjectList -- it's very rare to have *just* a runtime.Object
+// implementation (the cases tend to be funky built-in types like Webhook
+// payloads that don't have a `metadata` field).
+//
+// This is similar to Object, which is almost always implemented by the items
+// in the list themselves.
+type ObjectList interface {
+	metav1.ListInterface
+	runtime.Object
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
@@ -1,0 +1,841 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// {{{ "Functional" Option Interfaces
+
+// CreateOption is some configuration that modifies options for a create request.
+type CreateOption interface {
+	// ApplyToCreate applies this configuration to the given create options.
+	ApplyToCreate(*CreateOptions)
+}
+
+// DeleteOption is some configuration that modifies options for a delete request.
+type DeleteOption interface {
+	// ApplyToDelete applies this configuration to the given delete options.
+	ApplyToDelete(*DeleteOptions)
+}
+
+// GetOption is some configuration that modifies options for a get request.
+type GetOption interface {
+	// ApplyToGet applies this configuration to the given get options.
+	ApplyToGet(*GetOptions)
+}
+
+// ListOption is some configuration that modifies options for a list request.
+type ListOption interface {
+	// ApplyToList applies this configuration to the given list options.
+	ApplyToList(*ListOptions)
+}
+
+// UpdateOption is some configuration that modifies options for a update request.
+type UpdateOption interface {
+	// ApplyToUpdate applies this configuration to the given update options.
+	ApplyToUpdate(*UpdateOptions)
+}
+
+// PatchOption is some configuration that modifies options for a patch request.
+type PatchOption interface {
+	// ApplyToPatch applies this configuration to the given patch options.
+	ApplyToPatch(*PatchOptions)
+}
+
+// DeleteAllOfOption is some configuration that modifies options for a delete request.
+type DeleteAllOfOption interface {
+	// ApplyToDeleteAllOf applies this configuration to the given deletecollection options.
+	ApplyToDeleteAllOf(*DeleteAllOfOptions)
+}
+
+// SubResourceGetOption modifies options for a SubResource Get request.
+type SubResourceGetOption interface {
+	ApplyToSubResourceGet(*SubResourceGetOptions)
+}
+
+// SubResourceUpdateOption is some configuration that modifies options for a update request.
+type SubResourceUpdateOption interface {
+	// ApplyToSubResourceUpdate applies this configuration to the given update options.
+	ApplyToSubResourceUpdate(*SubResourceUpdateOptions)
+}
+
+// SubResourceCreateOption is some configuration that modifies options for a create request.
+type SubResourceCreateOption interface {
+	// ApplyToSubResourceCreate applies this configuration to the given create options.
+	ApplyToSubResourceCreate(*SubResourceCreateOptions)
+}
+
+// SubResourcePatchOption configures a subresource patch request.
+type SubResourcePatchOption interface {
+	// ApplyToSubResourcePatch applies the configuration on the given patch options.
+	ApplyToSubResourcePatch(*SubResourcePatchOptions)
+}
+
+// }}}
+
+// {{{ Multi-Type Options
+
+// DryRunAll sets the "dry run" option to "all", executing all
+// validation, etc without persisting the change to storage.
+var DryRunAll = dryRunAll{}
+
+type dryRunAll struct{}
+
+// ApplyToCreate applies this configuration to the given create options.
+func (dryRunAll) ApplyToCreate(opts *CreateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+// ApplyToUpdate applies this configuration to the given update options.
+func (dryRunAll) ApplyToUpdate(opts *UpdateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+// ApplyToPatch applies this configuration to the given patch options.
+func (dryRunAll) ApplyToPatch(opts *PatchOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+// ApplyToPatch applies this configuration to the given delete options.
+func (dryRunAll) ApplyToDelete(opts *DeleteOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourceCreate(opts *SubResourceCreateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+// FieldOwner set the field manager name for the given server-side apply patch.
+type FieldOwner string
+
+// ApplyToPatch applies this configuration to the given patch options.
+func (f FieldOwner) ApplyToPatch(opts *PatchOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToCreate applies this configuration to the given create options.
+func (f FieldOwner) ApplyToCreate(opts *CreateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToUpdate applies this configuration to the given update options.
+func (f FieldOwner) ApplyToUpdate(opts *UpdateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToSubResourcePatch applies this configuration to the given patch options.
+func (f FieldOwner) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToSubResourceCreate applies this configuration to the given create options.
+func (f FieldOwner) ApplyToSubResourceCreate(opts *SubResourceCreateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToSubResourceUpdate applies this configuration to the given update options.
+func (f FieldOwner) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// }}}
+
+// {{{ Create Options
+
+// CreateOptions contains options for create requests. It's generally a subset
+// of metav1.CreateOptions.
+type CreateOptions struct {
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	DryRun []string
+
+	// FieldManager is the name of the user or component submitting
+	// this request.  It must be set with server-side apply.
+	FieldManager string
+
+	// Raw represents raw CreateOptions, as passed to the API server.
+	Raw *metav1.CreateOptions
+}
+
+// AsCreateOptions returns these options as a metav1.CreateOptions.
+// This may mutate the Raw field.
+func (o *CreateOptions) AsCreateOptions() *metav1.CreateOptions {
+	if o == nil {
+		return &metav1.CreateOptions{}
+	}
+	if o.Raw == nil {
+		o.Raw = &metav1.CreateOptions{}
+	}
+
+	o.Raw.DryRun = o.DryRun
+	o.Raw.FieldManager = o.FieldManager
+	return o.Raw
+}
+
+// ApplyOptions applies the given create options on these options,
+// and then returns itself (for convenient chaining).
+func (o *CreateOptions) ApplyOptions(opts []CreateOption) *CreateOptions {
+	for _, opt := range opts {
+		opt.ApplyToCreate(o)
+	}
+	return o
+}
+
+// ApplyToCreate implements CreateOption.
+func (o *CreateOptions) ApplyToCreate(co *CreateOptions) {
+	if o.DryRun != nil {
+		co.DryRun = o.DryRun
+	}
+	if o.FieldManager != "" {
+		co.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		co.Raw = o.Raw
+	}
+}
+
+var _ CreateOption = &CreateOptions{}
+
+// }}}
+
+// {{{ Delete Options
+
+// DeleteOptions contains options for delete requests. It's generally a subset
+// of metav1.DeleteOptions.
+type DeleteOptions struct {
+	// GracePeriodSeconds is the duration in seconds before the object should be
+	// deleted. Value must be non-negative integer. The value zero indicates
+	// delete immediately. If this value is nil, the default grace period for the
+	// specified type will be used.
+	GracePeriodSeconds *int64
+
+	// Preconditions must be fulfilled before a deletion is carried out. If not
+	// possible, a 409 Conflict status will be returned.
+	Preconditions *metav1.Preconditions
+
+	// PropagationPolicy determined whether and how garbage collection will be
+	// performed. Either this field or OrphanDependents may be set, but not both.
+	// The default policy is decided by the existing finalizer set in the
+	// metadata.finalizers and the resource-specific default policy.
+	// Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+	// allow the garbage collector to delete the dependents in the background;
+	// 'Foreground' - a cascading policy that deletes all dependents in the
+	// foreground.
+	PropagationPolicy *metav1.DeletionPropagation
+
+	// Raw represents raw DeleteOptions, as passed to the API server.
+	Raw *metav1.DeleteOptions
+
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	DryRun []string
+}
+
+// AsDeleteOptions returns these options as a metav1.DeleteOptions.
+// This may mutate the Raw field.
+func (o *DeleteOptions) AsDeleteOptions() *metav1.DeleteOptions {
+	if o == nil {
+		return &metav1.DeleteOptions{}
+	}
+	if o.Raw == nil {
+		o.Raw = &metav1.DeleteOptions{}
+	}
+
+	o.Raw.GracePeriodSeconds = o.GracePeriodSeconds
+	o.Raw.Preconditions = o.Preconditions
+	o.Raw.PropagationPolicy = o.PropagationPolicy
+	o.Raw.DryRun = o.DryRun
+	return o.Raw
+}
+
+// ApplyOptions applies the given delete options on these options,
+// and then returns itself (for convenient chaining).
+func (o *DeleteOptions) ApplyOptions(opts []DeleteOption) *DeleteOptions {
+	for _, opt := range opts {
+		opt.ApplyToDelete(o)
+	}
+	return o
+}
+
+var _ DeleteOption = &DeleteOptions{}
+
+// ApplyToDelete implements DeleteOption.
+func (o *DeleteOptions) ApplyToDelete(do *DeleteOptions) {
+	if o.GracePeriodSeconds != nil {
+		do.GracePeriodSeconds = o.GracePeriodSeconds
+	}
+	if o.Preconditions != nil {
+		do.Preconditions = o.Preconditions
+	}
+	if o.PropagationPolicy != nil {
+		do.PropagationPolicy = o.PropagationPolicy
+	}
+	if o.Raw != nil {
+		do.Raw = o.Raw
+	}
+	if o.DryRun != nil {
+		do.DryRun = o.DryRun
+	}
+}
+
+// GracePeriodSeconds sets the grace period for the deletion
+// to the given number of seconds.
+type GracePeriodSeconds int64
+
+// ApplyToDelete applies this configuration to the given delete options.
+func (s GracePeriodSeconds) ApplyToDelete(opts *DeleteOptions) {
+	secs := int64(s)
+	opts.GracePeriodSeconds = &secs
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (s GracePeriodSeconds) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	s.ApplyToDelete(&opts.DeleteOptions)
+}
+
+// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
+type Preconditions metav1.Preconditions
+
+// ApplyToDelete applies this configuration to the given delete options.
+func (p Preconditions) ApplyToDelete(opts *DeleteOptions) {
+	preconds := metav1.Preconditions(p)
+	opts.Preconditions = &preconds
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (p Preconditions) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	p.ApplyToDelete(&opts.DeleteOptions)
+}
+
+// PropagationPolicy determined whether and how garbage collection will be
+// performed. Either this field or OrphanDependents may be set, but not both.
+// The default policy is decided by the existing finalizer set in the
+// metadata.finalizers and the resource-specific default policy.
+// Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+// allow the garbage collector to delete the dependents in the background;
+// 'Foreground' - a cascading policy that deletes all dependents in the
+// foreground.
+type PropagationPolicy metav1.DeletionPropagation
+
+// ApplyToDelete applies the given delete options on these options.
+// It will propagate to the dependents of the object to let the garbage collector handle it.
+func (p PropagationPolicy) ApplyToDelete(opts *DeleteOptions) {
+	policy := metav1.DeletionPropagation(p)
+	opts.PropagationPolicy = &policy
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (p PropagationPolicy) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	p.ApplyToDelete(&opts.DeleteOptions)
+}
+
+// }}}
+
+// {{{ Get Options
+
+// GetOptions contains options for get operation.
+// Now it only has a Raw field, with support for specific resourceVersion.
+type GetOptions struct {
+	// Raw represents raw GetOptions, as passed to the API server.  Note
+	// that these may not be respected by all implementations of interface.
+	Raw *metav1.GetOptions
+}
+
+var _ GetOption = &GetOptions{}
+
+// ApplyToGet implements GetOption for GetOptions.
+func (o *GetOptions) ApplyToGet(lo *GetOptions) {
+	if o.Raw != nil {
+		lo.Raw = o.Raw
+	}
+}
+
+// AsGetOptions returns these options as a flattened metav1.GetOptions.
+// This may mutate the Raw field.
+func (o *GetOptions) AsGetOptions() *metav1.GetOptions {
+	if o == nil || o.Raw == nil {
+		return &metav1.GetOptions{}
+	}
+	return o.Raw
+}
+
+// ApplyOptions applies the given get options on these options,
+// and then returns itself (for convenient chaining).
+func (o *GetOptions) ApplyOptions(opts []GetOption) *GetOptions {
+	for _, opt := range opts {
+		opt.ApplyToGet(o)
+	}
+	return o
+}
+
+// }}}
+
+// {{{ List Options
+
+// ListOptions contains options for limiting or filtering results.
+// It's generally a subset of metav1.ListOptions, with support for
+// pre-parsed selectors (since generally, selectors will be executed
+// against the cache).
+type ListOptions struct {
+	// LabelSelector filters results by label. Use labels.Parse() to
+	// set from raw string form.
+	LabelSelector labels.Selector
+	// FieldSelector filters results by a particular field.  In order
+	// to use this with cache-based implementations, restrict usage to
+	// a single field-value pair that's been added to the indexers.
+	FieldSelector fields.Selector
+
+	// Namespace represents the namespace to list for, or empty for
+	// non-namespaced objects, or to list across all namespaces.
+	Namespace string
+
+	// Limit specifies the maximum number of results to return from the server. The server may
+	// not support this field on all resource types, but if it does and more results remain it
+	// will set the continue field on the returned list object. This field is not supported if watch
+	// is true in the Raw ListOptions.
+	Limit int64
+	// Continue is a token returned by the server that lets a client retrieve chunks of results
+	// from the server by specifying limit. The server may reject requests for continuation tokens
+	// it does not recognize and will return a 410 error if the token can no longer be used because
+	// it has expired. This field is not supported if watch is true in the Raw ListOptions.
+	Continue string
+
+	// UnsafeDisableDeepCopy indicates not to deep copy objects during list objects.
+	// Be very careful with this, when enabled you must DeepCopy any object before mutating it,
+	// otherwise you will mutate the object in the cache.
+	// +optional
+	UnsafeDisableDeepCopy *bool
+
+	// Raw represents raw ListOptions, as passed to the API server.  Note
+	// that these may not be respected by all implementations of interface,
+	// and the LabelSelector, FieldSelector, Limit and Continue fields are ignored.
+	Raw *metav1.ListOptions
+}
+
+var _ ListOption = &ListOptions{}
+
+// ApplyToList implements ListOption for ListOptions.
+func (o *ListOptions) ApplyToList(lo *ListOptions) {
+	if o.LabelSelector != nil {
+		lo.LabelSelector = o.LabelSelector
+	}
+	if o.FieldSelector != nil {
+		lo.FieldSelector = o.FieldSelector
+	}
+	if o.Namespace != "" {
+		lo.Namespace = o.Namespace
+	}
+	if o.Raw != nil {
+		lo.Raw = o.Raw
+	}
+	if o.Limit > 0 {
+		lo.Limit = o.Limit
+	}
+	if o.Continue != "" {
+		lo.Continue = o.Continue
+	}
+	if o.UnsafeDisableDeepCopy != nil {
+		lo.UnsafeDisableDeepCopy = o.UnsafeDisableDeepCopy
+	}
+}
+
+// AsListOptions returns these options as a flattened metav1.ListOptions.
+// This may mutate the Raw field.
+func (o *ListOptions) AsListOptions() *metav1.ListOptions {
+	if o == nil {
+		return &metav1.ListOptions{}
+	}
+	if o.Raw == nil {
+		o.Raw = &metav1.ListOptions{}
+	}
+	if o.LabelSelector != nil {
+		o.Raw.LabelSelector = o.LabelSelector.String()
+	}
+	if o.FieldSelector != nil {
+		o.Raw.FieldSelector = o.FieldSelector.String()
+	}
+	if !o.Raw.Watch {
+		o.Raw.Limit = o.Limit
+		o.Raw.Continue = o.Continue
+	}
+	return o.Raw
+}
+
+// ApplyOptions applies the given list options on these options,
+// and then returns itself (for convenient chaining).
+func (o *ListOptions) ApplyOptions(opts []ListOption) *ListOptions {
+	for _, opt := range opts {
+		opt.ApplyToList(o)
+	}
+	return o
+}
+
+// MatchingLabels filters the list/delete operation on the given set of labels.
+type MatchingLabels map[string]string
+
+// ApplyToList applies this configuration to the given list options.
+func (m MatchingLabels) ApplyToList(opts *ListOptions) {
+	// TODO(directxman12): can we avoid reserializing this over and over?
+	if opts.LabelSelector == nil {
+		opts.LabelSelector = labels.NewSelector()
+	}
+	// If there's already a selector, we need to AND the two together.
+	noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))
+	reqs, _ := noValidSel.Requirements()
+	for _, req := range reqs {
+		opts.LabelSelector = opts.LabelSelector.Add(req)
+	}
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (m MatchingLabels) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	m.ApplyToList(&opts.ListOptions)
+}
+
+// HasLabels filters the list/delete operation checking if the set of labels exists
+// without checking their values.
+type HasLabels []string
+
+// ApplyToList applies this configuration to the given list options.
+func (m HasLabels) ApplyToList(opts *ListOptions) {
+	if opts.LabelSelector == nil {
+		opts.LabelSelector = labels.NewSelector()
+	}
+	// TODO: ignore invalid labels will result in an empty selector.
+	// This is inconsistent to the that of MatchingLabels.
+	for _, label := range m {
+		r, err := labels.NewRequirement(label, selection.Exists, nil)
+		if err == nil {
+			opts.LabelSelector = opts.LabelSelector.Add(*r)
+		}
+	}
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (m HasLabels) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	m.ApplyToList(&opts.ListOptions)
+}
+
+// MatchingLabelsSelector filters the list/delete operation on the given label
+// selector (or index in the case of cached lists). A struct is used because
+// labels.Selector is an interface, which cannot be aliased.
+type MatchingLabelsSelector struct {
+	labels.Selector
+}
+
+// ApplyToList applies this configuration to the given list options.
+func (m MatchingLabelsSelector) ApplyToList(opts *ListOptions) {
+	opts.LabelSelector = m
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (m MatchingLabelsSelector) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	m.ApplyToList(&opts.ListOptions)
+}
+
+// MatchingFields filters the list/delete operation on the given field Set
+// (or index in the case of cached lists).
+type MatchingFields fields.Set
+
+// ApplyToList applies this configuration to the given list options.
+func (m MatchingFields) ApplyToList(opts *ListOptions) {
+	// TODO(directxman12): can we avoid re-serializing this?
+	sel := fields.Set(m).AsSelector()
+	opts.FieldSelector = sel
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (m MatchingFields) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	m.ApplyToList(&opts.ListOptions)
+}
+
+// MatchingFieldsSelector filters the list/delete operation on the given field
+// selector (or index in the case of cached lists). A struct is used because
+// fields.Selector is an interface, which cannot be aliased.
+type MatchingFieldsSelector struct {
+	fields.Selector
+}
+
+// ApplyToList applies this configuration to the given list options.
+func (m MatchingFieldsSelector) ApplyToList(opts *ListOptions) {
+	opts.FieldSelector = m
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (m MatchingFieldsSelector) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	m.ApplyToList(&opts.ListOptions)
+}
+
+// InNamespace restricts the list/delete operation to the given namespace.
+type InNamespace string
+
+// ApplyToList applies this configuration to the given list options.
+func (n InNamespace) ApplyToList(opts *ListOptions) {
+	opts.Namespace = string(n)
+}
+
+// ApplyToDeleteAllOf applies this configuration to the given an List options.
+func (n InNamespace) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	n.ApplyToList(&opts.ListOptions)
+}
+
+// AsSelector returns a selector that matches objects in the given namespace.
+func (n InNamespace) AsSelector() fields.Selector {
+	return fields.SelectorFromSet(fields.Set{"metadata.namespace": string(n)})
+}
+
+// Limit specifies the maximum number of results to return from the server.
+// Limit does not implement DeleteAllOfOption interface because the server
+// does not support setting it for deletecollection operations.
+type Limit int64
+
+// ApplyToList applies this configuration to the given an list options.
+func (l Limit) ApplyToList(opts *ListOptions) {
+	opts.Limit = int64(l)
+}
+
+// UnsafeDisableDeepCopyOption indicates not to deep copy objects during list objects.
+// Be very careful with this, when enabled you must DeepCopy any object before mutating it,
+// otherwise you will mutate the object in the cache.
+type UnsafeDisableDeepCopyOption bool
+
+// ApplyToList applies this configuration to the given an List options.
+func (d UnsafeDisableDeepCopyOption) ApplyToList(opts *ListOptions) {
+	definitelyTrue := true
+	definitelyFalse := false
+	if d {
+		opts.UnsafeDisableDeepCopy = &definitelyTrue
+	} else {
+		opts.UnsafeDisableDeepCopy = &definitelyFalse
+	}
+}
+
+// UnsafeDisableDeepCopy indicates not to deep copy objects during list objects.
+const UnsafeDisableDeepCopy = UnsafeDisableDeepCopyOption(true)
+
+// Continue sets a continuation token to retrieve chunks of results when using limit.
+// Continue does not implement DeleteAllOfOption interface because the server
+// does not support setting it for deletecollection operations.
+type Continue string
+
+// ApplyToList applies this configuration to the given an List options.
+func (c Continue) ApplyToList(opts *ListOptions) {
+	opts.Continue = string(c)
+}
+
+// }}}
+
+// {{{ Update Options
+
+// UpdateOptions contains options for create requests. It's generally a subset
+// of metav1.UpdateOptions.
+type UpdateOptions struct {
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	DryRun []string
+
+	// FieldManager is the name of the user or component submitting
+	// this request.  It must be set with server-side apply.
+	FieldManager string
+
+	// Raw represents raw UpdateOptions, as passed to the API server.
+	Raw *metav1.UpdateOptions
+}
+
+// AsUpdateOptions returns these options as a metav1.UpdateOptions.
+// This may mutate the Raw field.
+func (o *UpdateOptions) AsUpdateOptions() *metav1.UpdateOptions {
+	if o == nil {
+		return &metav1.UpdateOptions{}
+	}
+	if o.Raw == nil {
+		o.Raw = &metav1.UpdateOptions{}
+	}
+
+	o.Raw.DryRun = o.DryRun
+	o.Raw.FieldManager = o.FieldManager
+	return o.Raw
+}
+
+// ApplyOptions applies the given update options on these options,
+// and then returns itself (for convenient chaining).
+func (o *UpdateOptions) ApplyOptions(opts []UpdateOption) *UpdateOptions {
+	for _, opt := range opts {
+		opt.ApplyToUpdate(o)
+	}
+	return o
+}
+
+var _ UpdateOption = &UpdateOptions{}
+
+// ApplyToUpdate implements UpdateOption.
+func (o *UpdateOptions) ApplyToUpdate(uo *UpdateOptions) {
+	if o.DryRun != nil {
+		uo.DryRun = o.DryRun
+	}
+	if o.FieldManager != "" {
+		uo.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		uo.Raw = o.Raw
+	}
+}
+
+// }}}
+
+// {{{ Patch Options
+
+// PatchOptions contains options for patch requests.
+type PatchOptions struct {
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	DryRun []string
+
+	// Force is going to "force" Apply requests. It means user will
+	// re-acquire conflicting fields owned by other people. Force
+	// flag must be unset for non-apply patch requests.
+	// +optional
+	Force *bool
+
+	// FieldManager is the name of the user or component submitting
+	// this request.  It must be set with server-side apply.
+	FieldManager string
+
+	// Raw represents raw PatchOptions, as passed to the API server.
+	Raw *metav1.PatchOptions
+}
+
+// ApplyOptions applies the given patch options on these options,
+// and then returns itself (for convenient chaining).
+func (o *PatchOptions) ApplyOptions(opts []PatchOption) *PatchOptions {
+	for _, opt := range opts {
+		opt.ApplyToPatch(o)
+	}
+	return o
+}
+
+// AsPatchOptions returns these options as a metav1.PatchOptions.
+// This may mutate the Raw field.
+func (o *PatchOptions) AsPatchOptions() *metav1.PatchOptions {
+	if o == nil {
+		return &metav1.PatchOptions{}
+	}
+	if o.Raw == nil {
+		o.Raw = &metav1.PatchOptions{}
+	}
+
+	o.Raw.DryRun = o.DryRun
+	o.Raw.Force = o.Force
+	o.Raw.FieldManager = o.FieldManager
+	return o.Raw
+}
+
+var _ PatchOption = &PatchOptions{}
+
+// ApplyToPatch implements PatchOptions.
+func (o *PatchOptions) ApplyToPatch(po *PatchOptions) {
+	if o.DryRun != nil {
+		po.DryRun = o.DryRun
+	}
+	if o.Force != nil {
+		po.Force = o.Force
+	}
+	if o.FieldManager != "" {
+		po.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		po.Raw = o.Raw
+	}
+}
+
+// ForceOwnership indicates that in case of conflicts with server-side apply,
+// the client should acquire ownership of the conflicting field.  Most
+// controllers should use this.
+var ForceOwnership = forceOwnership{}
+
+type forceOwnership struct{}
+
+func (forceOwnership) ApplyToPatch(opts *PatchOptions) {
+	definitelyTrue := true
+	opts.Force = &definitelyTrue
+}
+
+func (forceOwnership) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
+	definitelyTrue := true
+	opts.Force = &definitelyTrue
+}
+
+// }}}
+
+// {{{ DeleteAllOf Options
+
+// these are all just delete options and list options
+
+// DeleteAllOfOptions contains options for deletecollection (deleteallof) requests.
+// It's just list and delete options smooshed together.
+type DeleteAllOfOptions struct {
+	ListOptions
+	DeleteOptions
+}
+
+// ApplyOptions applies the given deleteallof options on these options,
+// and then returns itself (for convenient chaining).
+func (o *DeleteAllOfOptions) ApplyOptions(opts []DeleteAllOfOption) *DeleteAllOfOptions {
+	for _, opt := range opts {
+		opt.ApplyToDeleteAllOf(o)
+	}
+	return o
+}
+
+var _ DeleteAllOfOption = &DeleteAllOfOptions{}
+
+// ApplyToDeleteAllOf implements DeleteAllOfOption.
+func (o *DeleteAllOfOptions) ApplyToDeleteAllOf(do *DeleteAllOfOptions) {
+	o.ApplyToList(&do.ListOptions)
+	o.ApplyToDelete(&do.DeleteOptions)
+}
+
+// }}}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/patch.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/patch.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+var (
+	// Apply uses server-side apply to patch the given object.
+	Apply Patch = applyPatch{}
+
+	// Merge uses the raw object as a merge patch, without modifications.
+	// Use MergeFrom if you wish to compute a diff instead.
+	Merge Patch = mergePatch{}
+)
+
+type patch struct {
+	patchType types.PatchType
+	data      []byte
+}
+
+// Type implements Patch.
+func (s *patch) Type() types.PatchType {
+	return s.patchType
+}
+
+// Data implements Patch.
+func (s *patch) Data(obj Object) ([]byte, error) {
+	return s.data, nil
+}
+
+// RawPatch constructs a new Patch with the given PatchType and data.
+func RawPatch(patchType types.PatchType, data []byte) Patch {
+	return &patch{patchType, data}
+}
+
+// MergeFromWithOptimisticLock can be used if clients want to make sure a patch
+// is being applied to the latest resource version of an object.
+//
+// The behavior is similar to what an Update would do, without the need to send the
+// whole object. Usually this method is useful if you might have multiple clients
+// acting on the same object and the same API version, but with different versions of the Go structs.
+//
+// For example, an "older" copy of a Widget that has fields A and B, and a "newer" copy with A, B, and C.
+// Sending an update using the older struct definition results in C being dropped, whereas using a patch does not.
+type MergeFromWithOptimisticLock struct{}
+
+// ApplyToMergeFrom applies this configuration to the given patch options.
+func (m MergeFromWithOptimisticLock) ApplyToMergeFrom(in *MergeFromOptions) {
+	in.OptimisticLock = true
+}
+
+// MergeFromOption is some configuration that modifies options for a merge-from patch data.
+type MergeFromOption interface {
+	// ApplyToMergeFrom applies this configuration to the given patch options.
+	ApplyToMergeFrom(*MergeFromOptions)
+}
+
+// MergeFromOptions contains options to generate a merge-from patch data.
+type MergeFromOptions struct {
+	// OptimisticLock, when true, includes `metadata.resourceVersion` into the final
+	// patch data. If the `resourceVersion` field doesn't match what's stored,
+	// the operation results in a conflict and clients will need to try again.
+	OptimisticLock bool
+}
+
+type mergeFromPatch struct {
+	patchType   types.PatchType
+	createPatch func(originalJSON, modifiedJSON []byte, dataStruct interface{}) ([]byte, error)
+	from        Object
+	opts        MergeFromOptions
+}
+
+// Type implements Patch.
+func (s *mergeFromPatch) Type() types.PatchType {
+	return s.patchType
+}
+
+// Data implements Patch.
+func (s *mergeFromPatch) Data(obj Object) ([]byte, error) {
+	original := s.from
+	modified := obj
+
+	if s.opts.OptimisticLock {
+		version := original.GetResourceVersion()
+		if len(version) == 0 {
+			return nil, fmt.Errorf("cannot use OptimisticLock, object %q does not have any resource version we can use", original)
+		}
+
+		original = original.DeepCopyObject().(Object)
+		original.SetResourceVersion("")
+
+		modified = modified.DeepCopyObject().(Object)
+		modified.SetResourceVersion(version)
+	}
+
+	originalJSON, err := json.Marshal(original)
+	if err != nil {
+		return nil, err
+	}
+
+	modifiedJSON, err := json.Marshal(modified)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := s.createPatch(originalJSON, modifiedJSON, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func createMergePatch(originalJSON, modifiedJSON []byte, _ interface{}) ([]byte, error) {
+	return jsonpatch.CreateMergePatch(originalJSON, modifiedJSON)
+}
+
+func createStrategicMergePatch(originalJSON, modifiedJSON []byte, dataStruct interface{}) ([]byte, error) {
+	return strategicpatch.CreateTwoWayMergePatch(originalJSON, modifiedJSON, dataStruct)
+}
+
+// MergeFrom creates a Patch that patches using the merge-patch strategy with the given object as base.
+// The difference between MergeFrom and StrategicMergeFrom lays in the handling of modified list fields.
+// When using MergeFrom, existing lists will be completely replaced by new lists.
+// When using StrategicMergeFrom, the list field's `patchStrategy` is respected if specified in the API type,
+// e.g. the existing list is not replaced completely but rather merged with the new one using the list's `patchMergeKey`.
+// See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ for more details on
+// the difference between merge-patch and strategic-merge-patch.
+func MergeFrom(obj Object) Patch {
+	return &mergeFromPatch{patchType: types.MergePatchType, createPatch: createMergePatch, from: obj}
+}
+
+// MergeFromWithOptions creates a Patch that patches using the merge-patch strategy with the given object as base.
+// See MergeFrom for more details.
+func MergeFromWithOptions(obj Object, opts ...MergeFromOption) Patch {
+	options := &MergeFromOptions{}
+	for _, opt := range opts {
+		opt.ApplyToMergeFrom(options)
+	}
+	return &mergeFromPatch{patchType: types.MergePatchType, createPatch: createMergePatch, from: obj, opts: *options}
+}
+
+// StrategicMergeFrom creates a Patch that patches using the strategic-merge-patch strategy with the given object as base.
+// The difference between MergeFrom and StrategicMergeFrom lays in the handling of modified list fields.
+// When using MergeFrom, existing lists will be completely replaced by new lists.
+// When using StrategicMergeFrom, the list field's `patchStrategy` is respected if specified in the API type,
+// e.g. the existing list is not replaced completely but rather merged with the new one using the list's `patchMergeKey`.
+// See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ for more details on
+// the difference between merge-patch and strategic-merge-patch.
+// Please note, that CRDs don't support strategic-merge-patch, see
+// https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#advanced-features-and-flexibility
+func StrategicMergeFrom(obj Object, opts ...MergeFromOption) Patch {
+	options := &MergeFromOptions{}
+	for _, opt := range opts {
+		opt.ApplyToMergeFrom(options)
+	}
+	return &mergeFromPatch{patchType: types.StrategicMergePatchType, createPatch: createStrategicMergePatch, from: obj, opts: *options}
+}
+
+// mergePatch uses a raw merge strategy to patch the object.
+type mergePatch struct{}
+
+// Type implements Patch.
+func (p mergePatch) Type() types.PatchType {
+	return types.MergePatchType
+}
+
+// Data implements Patch.
+func (p mergePatch) Data(obj Object) ([]byte, error) {
+	// NB(directxman12): we might technically want to be using an actual encoder
+	// here (in case some more performant encoder is introduced) but this is
+	// correct and sufficient for our uses (it's what the JSON serializer in
+	// client-go does, more-or-less).
+	return json.Marshal(obj)
+}
+
+// applyPatch uses server-side apply to patch the object.
+type applyPatch struct{}
+
+// Type implements Patch.
+func (p applyPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+// Data implements Patch.
+func (p applyPatch) Data(obj Object) ([]byte, error) {
+	// NB(directxman12): we might technically want to be using an actual encoder
+	// here (in case some more performant encoder is introduced) but this is
+	// correct and sufficient for our uses (it's what the JSON serializer in
+	// client-go does, more-or-less).
+	return json.Marshal(obj)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ Reader = &typedClient{}
+var _ Writer = &typedClient{}
+
+type typedClient struct {
+	resources  *clientRestResources
+	paramCodec runtime.ParameterCodec
+}
+
+// Create implements client.Client.
+func (c *typedClient) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	createOpts := &CreateOptions{}
+	createOpts.ApplyOptions(opts)
+
+	return o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Body(obj).
+		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
+		Do(ctx).
+		Into(obj)
+}
+
+// Update implements client.Client.
+func (c *typedClient) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	updateOpts := &UpdateOptions{}
+	updateOpts.ApplyOptions(opts)
+
+	return o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(obj).
+		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
+		Do(ctx).
+		Into(obj)
+}
+
+// Delete implements client.Client.
+func (c *typedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	return o.Delete().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(deleteOpts.AsDeleteOptions()).
+		Do(ctx).
+		Error()
+}
+
+// DeleteAllOf implements client.Client.
+func (c *typedClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	deleteAllOfOpts := DeleteAllOfOptions{}
+	deleteAllOfOpts.ApplyOptions(opts)
+
+	return o.Delete().
+		NamespaceIfScoped(deleteAllOfOpts.ListOptions.Namespace, o.isNamespaced()).
+		Resource(o.resource()).
+		VersionedParams(deleteAllOfOpts.AsListOptions(), c.paramCodec).
+		Body(deleteAllOfOpts.AsDeleteOptions()).
+		Do(ctx).
+		Error()
+}
+
+// Patch implements client.Client.
+func (c *typedClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &PatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		VersionedParams(patchOpts.AsPatchOptions(), c.paramCodec).
+		Body(data).
+		Do(ctx).
+		Into(obj)
+}
+
+// Get implements client.Client.
+func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	r, err := c.resources.getResource(obj)
+	if err != nil {
+		return err
+	}
+	getOpts := GetOptions{}
+	getOpts.ApplyOptions(opts)
+	return r.Get().
+		NamespaceIfScoped(key.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(getOpts.AsGetOptions(), c.paramCodec).
+		Name(key.Name).Do(ctx).Into(obj)
+}
+
+// List implements client.Client.
+func (c *typedClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	r, err := c.resources.getResource(obj)
+	if err != nil {
+		return err
+	}
+
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	return r.Get().
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(listOpts.AsListOptions(), c.paramCodec).
+		Do(ctx).
+		Into(obj)
+}
+
+func (c *typedClient) GetSubResource(ctx context.Context, obj, subResourceObj Object, subResource string, opts ...SubResourceGetOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	getOpts := &SubResourceGetOptions{}
+	getOpts.ApplyOptions(opts)
+
+	return o.Get().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		VersionedParams(getOpts.AsGetOptions(), c.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
+func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subResourceObj Object, subResource string, opts ...SubResourceCreateOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	createOpts := &SubResourceCreateOptions{}
+	createOpts.ApplyOptions(opts)
+
+	return o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(subResourceObj).
+		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
+// UpdateSubResource used by SubResourceWriter to write status.
+func (c *typedClient) UpdateSubResource(ctx context.Context, obj Object, subResource string, opts ...SubResourceUpdateOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+	// TODO(droot): examine the returned error and check if it error needs to be
+	// wrapped to improve the UX ?
+	// It will be nice to receive an error saying the object doesn't implement
+	// status subresource and check CRD definition
+	updateOpts := &SubResourceUpdateOptions{}
+	updateOpts.ApplyOptions(opts)
+
+	body := obj
+	if updateOpts.SubResourceBody != nil {
+		body = updateOpts.SubResourceBody
+	}
+	if body.GetName() == "" {
+		body.SetName(obj.GetName())
+	}
+	if body.GetNamespace() == "" {
+		body.SetNamespace(obj.GetNamespace())
+	}
+
+	return o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(body).
+		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
+		Do(ctx).
+		Into(body)
+}
+
+// PatchSubResource used by SubResourceWriter to write subresource.
+func (c *typedClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &SubResourcePatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	body := obj
+	if patchOpts.SubResourceBody != nil {
+		body = patchOpts.SubResourceBody
+	}
+
+	data, err := patch.Data(body)
+	if err != nil {
+		return err
+	}
+
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(data).
+		VersionedParams(patchOpts.AsPatchOptions(), c.paramCodec).
+		Do(ctx).
+		Into(body)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/unstructured_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/unstructured_client.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ Reader = &unstructuredClient{}
+var _ Writer = &unstructuredClient{}
+
+type unstructuredClient struct {
+	resources  *clientRestResources
+	paramCodec runtime.ParameterCodec
+}
+
+// Create implements client.Client.
+func (uc *unstructuredClient) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	u, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	gvk := u.GetObjectKind().GroupVersionKind()
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	createOpts := &CreateOptions{}
+	createOpts.ApplyOptions(opts)
+
+	result := o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Body(obj).
+		VersionedParams(createOpts.AsCreateOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(obj)
+
+	u.GetObjectKind().SetGroupVersionKind(gvk)
+	return result
+}
+
+// Update implements client.Client.
+func (uc *unstructuredClient) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	u, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	gvk := u.GetObjectKind().GroupVersionKind()
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	updateOpts := UpdateOptions{}
+	updateOpts.ApplyOptions(opts)
+
+	result := o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(obj).
+		VersionedParams(updateOpts.AsUpdateOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(obj)
+
+	u.GetObjectKind().SetGroupVersionKind(gvk)
+	return result
+}
+
+// Delete implements client.Client.
+func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	return o.Delete().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(deleteOpts.AsDeleteOptions()).
+		Do(ctx).
+		Error()
+}
+
+// DeleteAllOf implements client.Client.
+func (uc *unstructuredClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	deleteAllOfOpts := DeleteAllOfOptions{}
+	deleteAllOfOpts.ApplyOptions(opts)
+
+	return o.Delete().
+		NamespaceIfScoped(deleteAllOfOpts.ListOptions.Namespace, o.isNamespaced()).
+		Resource(o.resource()).
+		VersionedParams(deleteAllOfOpts.AsListOptions(), uc.paramCodec).
+		Body(deleteAllOfOpts.AsDeleteOptions()).
+		Do(ctx).
+		Error()
+}
+
+// Patch implements client.Client.
+func (uc *unstructuredClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &PatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		VersionedParams(patchOpts.AsPatchOptions(), uc.paramCodec).
+		Body(data).
+		Do(ctx).
+		Into(obj)
+}
+
+// Get implements client.Client.
+func (uc *unstructuredClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
+	u, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	gvk := u.GetObjectKind().GroupVersionKind()
+
+	getOpts := GetOptions{}
+	getOpts.ApplyOptions(opts)
+
+	r, err := uc.resources.getResource(obj)
+	if err != nil {
+		return err
+	}
+
+	result := r.Get().
+		NamespaceIfScoped(key.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(getOpts.AsGetOptions(), uc.paramCodec).
+		Name(key.Name).
+		Do(ctx).
+		Into(obj)
+
+	u.GetObjectKind().SetGroupVersionKind(gvk)
+
+	return result
+}
+
+// List implements client.Client.
+func (uc *unstructuredClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	u, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	gvk := u.GetObjectKind().GroupVersionKind()
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	r, err := uc.resources.getResource(obj)
+	if err != nil {
+		return err
+	}
+
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	return r.Get().
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(listOpts.AsListOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(obj)
+}
+
+func (uc *unstructuredClient) GetSubResource(ctx context.Context, obj, subResourceObj Object, subResource string, opts ...SubResourceGetOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	if _, ok := subResourceObj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", subResourceObj)
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	getOpts := &SubResourceGetOptions{}
+	getOpts.ApplyOptions(opts)
+
+	return o.Get().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		VersionedParams(getOpts.AsGetOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
+func (uc *unstructuredClient) CreateSubResource(ctx context.Context, obj, subResourceObj Object, subResource string, opts ...SubResourceCreateOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	if _, ok := subResourceObj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", subResourceObj)
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	createOpts := &SubResourceCreateOptions{}
+	createOpts.ApplyOptions(opts)
+
+	return o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(subResourceObj).
+		VersionedParams(createOpts.AsCreateOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
+func (uc *unstructuredClient) UpdateSubResource(ctx context.Context, obj Object, subResource string, opts ...SubResourceUpdateOption) error {
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	updateOpts := SubResourceUpdateOptions{}
+	updateOpts.ApplyOptions(opts)
+
+	body := obj
+	if updateOpts.SubResourceBody != nil {
+		body = updateOpts.SubResourceBody
+	}
+	if body.GetName() == "" {
+		body.SetName(obj.GetName())
+	}
+	if body.GetNamespace() == "" {
+		body.SetNamespace(obj.GetNamespace())
+	}
+
+	return o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(body).
+		VersionedParams(updateOpts.AsUpdateOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(body)
+}
+
+func (uc *unstructuredClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
+	u, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("unstructured client did not understand object: %T", obj)
+	}
+
+	gvk := u.GetObjectKind().GroupVersionKind()
+
+	o, err := uc.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &SubResourcePatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	body := obj
+	if patchOpts.SubResourceBody != nil {
+		body = patchOpts.SubResourceBody
+	}
+
+	data, err := patch.Data(body)
+	if err != nil {
+		return err
+	}
+
+	result := o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(data).
+		VersionedParams(patchOpts.AsPatchOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(body)
+
+	u.GetObjectKind().SetGroupVersionKind(gvk)
+	return result
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/watch.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/watch.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+// NewWithWatch returns a new WithWatch.
+func NewWithWatch(config *rest.Config, options Options) (WithWatch, error) {
+	client, err := newClient(config, options)
+	if err != nil {
+		return nil, err
+	}
+	return &watchingClient{client: client}, nil
+}
+
+type watchingClient struct {
+	*client
+}
+
+func (w *watchingClient) Watch(ctx context.Context, list ObjectList, opts ...ListOption) (watch.Interface, error) {
+	switch l := list.(type) {
+	case runtime.Unstructured:
+		return w.unstructuredWatch(ctx, l, opts...)
+	case *metav1.PartialObjectMetadataList:
+		return w.metadataWatch(ctx, l, opts...)
+	default:
+		return w.typedWatch(ctx, l, opts...)
+	}
+}
+
+func (w *watchingClient) listOpts(opts ...ListOption) ListOptions {
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
+	if listOpts.Raw == nil {
+		listOpts.Raw = &metav1.ListOptions{}
+	}
+	listOpts.Raw.Watch = true
+
+	return listOpts
+}
+
+func (w *watchingClient) metadataWatch(ctx context.Context, obj *metav1.PartialObjectMetadataList, opts ...ListOption) (watch.Interface, error) {
+	gvk := obj.GroupVersionKind()
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	listOpts := w.listOpts(opts...)
+
+	resInt, err := w.client.metadataClient.getResourceInterface(gvk, listOpts.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return resInt.Watch(ctx, *listOpts.AsListOptions())
+}
+
+func (w *watchingClient) unstructuredWatch(ctx context.Context, obj runtime.Unstructured, opts ...ListOption) (watch.Interface, error) {
+	r, err := w.client.unstructuredClient.resources.getResource(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	listOpts := w.listOpts(opts...)
+
+	return r.Get().
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(listOpts.AsListOptions(), w.client.unstructuredClient.paramCodec).
+		Watch(ctx)
+}
+
+func (w *watchingClient) typedWatch(ctx context.Context, obj ObjectList, opts ...ListOption) (watch.Interface, error) {
+	r, err := w.client.typedClient.resources.getResource(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	listOpts := w.listOpts(opts...)
+
+	return r.Get().
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(listOpts.AsListOptions(), w.client.typedClient.paramCodec).
+		Watch(ctx)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/field/selector/utils.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/field/selector/utils.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selector
+
+import (
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// RequiresExactMatch checks if the given field selector is of the form `k=v` or `k==v`.
+func RequiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+	reqs := sel.Requirements()
+	if len(reqs) != 1 {
+		return "", "", false
+	}
+	req := reqs[0]
+	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		return "", "", false
+	}
+	return req.Field, req.Value, true
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel.
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// loggerPromise knows how to populate a concrete logr.Logger
+// with options, given an actual base logger later on down the line.
+type loggerPromise struct {
+	logger        *delegatingLogSink
+	childPromises []*loggerPromise
+	promisesLock  sync.Mutex
+
+	name *string
+	tags []interface{}
+}
+
+func (p *loggerPromise) WithName(l *delegatingLogSink, name string) *loggerPromise {
+	res := &loggerPromise{
+		logger:       l,
+		name:         &name,
+		promisesLock: sync.Mutex{},
+	}
+
+	p.promisesLock.Lock()
+	defer p.promisesLock.Unlock()
+	p.childPromises = append(p.childPromises, res)
+	return res
+}
+
+// WithValues provides a new Logger with the tags appended.
+func (p *loggerPromise) WithValues(l *delegatingLogSink, tags ...interface{}) *loggerPromise {
+	res := &loggerPromise{
+		logger:       l,
+		tags:         tags,
+		promisesLock: sync.Mutex{},
+	}
+
+	p.promisesLock.Lock()
+	defer p.promisesLock.Unlock()
+	p.childPromises = append(p.childPromises, res)
+	return res
+}
+
+// Fulfill instantiates the Logger with the provided logger.
+func (p *loggerPromise) Fulfill(parentLogSink logr.LogSink) {
+	sink := parentLogSink
+	if p.name != nil {
+		sink = sink.WithName(*p.name)
+	}
+
+	if p.tags != nil {
+		sink = sink.WithValues(p.tags...)
+	}
+
+	p.logger.lock.Lock()
+	p.logger.logger = sink
+	if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+		p.logger.logger = withCallDepth.WithCallDepth(1)
+	}
+	p.logger.promise = nil
+	p.logger.lock.Unlock()
+
+	for _, childPromise := range p.childPromises {
+		childPromise.Fulfill(sink)
+	}
+}
+
+// delegatingLogSink is a logsink that delegates to another logr.LogSink.
+// If the underlying promise is not nil, it registers calls to sub-loggers with
+// the logging factory to be populated later, and returns a new delegating
+// logger.  It expects to have *some* logr.Logger set at all times (generally
+// a no-op logger before the promises are fulfilled).
+type delegatingLogSink struct {
+	lock    sync.RWMutex
+	logger  logr.LogSink
+	promise *loggerPromise
+	info    logr.RuntimeInfo
+}
+
+// Init implements logr.LogSink.
+func (l *delegatingLogSink) Init(info logr.RuntimeInfo) {
+	eventuallyFulfillRoot()
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.info = info
+}
+
+// Enabled tests whether this Logger is enabled.  For example, commandline
+// flags might be used to set the logging verbosity and disable some info
+// logs.
+func (l *delegatingLogSink) Enabled(level int) bool {
+	eventuallyFulfillRoot()
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	return l.logger.Enabled(level)
+}
+
+// Info logs a non-error message with the given key/value pairs as context.
+//
+// The msg argument should be used to add some constant description to
+// the log line.  The key/value pairs can then be used to add additional
+// variable information.  The key/value pairs should alternate string
+// keys and arbitrary values.
+func (l *delegatingLogSink) Info(level int, msg string, keysAndValues ...interface{}) {
+	eventuallyFulfillRoot()
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	l.logger.Info(level, msg, keysAndValues...)
+}
+
+// Error logs an error, with the given message and key/value pairs as context.
+// It functions similarly to calling Info with the "error" named value, but may
+// have unique behavior, and should be preferred for logging errors (see the
+// package documentations for more information).
+//
+// The msg field should be used to add context to any underlying error,
+// while the err field should be used to attach the actual error that
+// triggered this log line, if present.
+func (l *delegatingLogSink) Error(err error, msg string, keysAndValues ...interface{}) {
+	eventuallyFulfillRoot()
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	l.logger.Error(err, msg, keysAndValues...)
+}
+
+// WithName provides a new Logger with the name appended.
+func (l *delegatingLogSink) WithName(name string) logr.LogSink {
+	eventuallyFulfillRoot()
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	if l.promise == nil {
+		sink := l.logger.WithName(name)
+		if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+			sink = withCallDepth.WithCallDepth(-1)
+		}
+		return sink
+	}
+
+	res := &delegatingLogSink{logger: l.logger}
+	promise := l.promise.WithName(res, name)
+	res.promise = promise
+
+	return res
+}
+
+// WithValues provides a new Logger with the tags appended.
+func (l *delegatingLogSink) WithValues(tags ...interface{}) logr.LogSink {
+	eventuallyFulfillRoot()
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	if l.promise == nil {
+		sink := l.logger.WithValues(tags...)
+		if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+			sink = withCallDepth.WithCallDepth(-1)
+		}
+		return sink
+	}
+
+	res := &delegatingLogSink{logger: l.logger}
+	promise := l.promise.WithValues(res, tags...)
+	res.promise = promise
+
+	return res
+}
+
+// Fulfill switches the logger over to use the actual logger
+// provided, instead of the temporary initial one, if this method
+// has not been previously called.
+func (l *delegatingLogSink) Fulfill(actual logr.LogSink) {
+	if l.promise != nil {
+		l.promise.Fulfill(actual)
+	}
+}
+
+// newDelegatingLogSink constructs a new DelegatingLogSink which uses
+// the given logger before its promise is fulfilled.
+func newDelegatingLogSink(initial logr.LogSink) *delegatingLogSink {
+	l := &delegatingLogSink{
+		logger:  initial,
+		promise: &loggerPromise{promisesLock: sync.Mutex{}},
+	}
+	l.promise.logger = l
+	return l
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log contains utilities for fetching a new logger
+// when one is not already available.
+//
+// # The Log Handle
+//
+// This package contains a root logr.Logger Log.  It may be used to
+// get a handle to whatever the root logging implementation is.  By
+// default, no implementation exists, and the handle returns "promises"
+// to loggers.  When the implementation is set using SetLogger, these
+// "promises" will be converted over to real loggers.
+//
+// # Logr
+//
+// All logging in controller-runtime is structured, using a set of interfaces
+// defined by a package called logr
+// (https://pkg.go.dev/github.com/go-logr/logr).  The sub-package zap provides
+// helpers for setting up logr backed by Zap (go.uber.org/zap).
+package log
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// SetLogger sets a concrete logging implementation for all deferred Loggers.
+func SetLogger(l logr.Logger) {
+	logFullfilled.Store(true)
+	rootLog.Fulfill(l.GetSink())
+}
+
+func eventuallyFulfillRoot() {
+	if logFullfilled.Load() {
+		return
+	}
+	if time.Since(rootLogCreated).Seconds() >= 30 {
+		if logFullfilled.CompareAndSwap(false, true) {
+			fmt.Fprintf(os.Stderr, "[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:\n%s", debug.Stack())
+			SetLogger(logr.New(NullLogSink{}))
+		}
+	}
+}
+
+var (
+	logFullfilled atomic.Bool
+)
+
+// Log is the base logger used by kubebuilder.  It delegates
+// to another logr.Logger. You *must* call SetLogger to
+// get any actual logging. If SetLogger is not called within
+// the first 30 seconds of a binaries lifetime, it will get
+// set to a NullLogSink.
+var (
+	rootLog, rootLogCreated = func() (*delegatingLogSink, time.Time) {
+		return newDelegatingLogSink(NullLogSink{}), time.Now()
+	}()
+	Log = logr.New(rootLog)
+)
+
+// FromContext returns a logger with predefined values from a context.Context.
+func FromContext(ctx context.Context, keysAndValues ...interface{}) logr.Logger {
+	log := Log
+	if ctx != nil {
+		if logger, err := logr.FromContext(ctx); err == nil {
+			log = logger
+		}
+	}
+	return log.WithValues(keysAndValues...)
+}
+
+// IntoContext takes a context and sets the logger as one of its values.
+// Use FromContext function to retrieve the logger.
+func IntoContext(ctx context.Context, log logr.Logger) context.Context {
+	return logr.NewContext(ctx, log)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/null.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/null.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// NB: this is the same as the null logger logr/testing,
+// but avoids accidentally adding the testing flags to
+// all binaries.
+
+// NullLogSink is a logr.Logger that does nothing.
+type NullLogSink struct{}
+
+var _ logr.LogSink = NullLogSink{}
+
+// Init implements logr.LogSink.
+func (log NullLogSink) Init(logr.RuntimeInfo) {
+}
+
+// Info implements logr.InfoLogger.
+func (NullLogSink) Info(_ int, _ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+// Enabled implements logr.InfoLogger.
+func (NullLogSink) Enabled(level int) bool {
+	return false
+}
+
+// Error implements logr.Logger.
+func (NullLogSink) Error(_ error, _ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+// WithName implements logr.Logger.
+func (log NullLogSink) WithName(_ string) logr.LogSink {
+	return log
+}
+
+// WithValues implements logr.Logger.
+func (log NullLogSink) WithValues(_ ...interface{}) logr.LogSink {
+	return log
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/warning_handler.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/warning_handler.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// KubeAPIWarningLoggerOptions controls the behavior
+// of a rest.WarningHandler constructed using NewKubeAPIWarningLogger().
+type KubeAPIWarningLoggerOptions struct {
+	// Deduplicate indicates a given warning message should only be written once.
+	// Setting this to true in a long-running process handling many warnings can
+	// result in increased memory use.
+	Deduplicate bool
+}
+
+// KubeAPIWarningLogger is a wrapper around
+// a provided logr.Logger that implements the
+// rest.WarningHandler interface.
+type KubeAPIWarningLogger struct {
+	// logger is used to log responses with the warning header
+	logger logr.Logger
+	// opts contain options controlling warning output
+	opts KubeAPIWarningLoggerOptions
+	// writtenLock gurads written
+	writtenLock sync.Mutex
+	// used to keep track of already logged messages
+	// and help in de-duplication.
+	written map[string]struct{}
+}
+
+// HandleWarningHeader handles logging for responses from API server that are
+// warnings with code being 299 and uses a logr.Logger for its logging purposes.
+func (l *KubeAPIWarningLogger) HandleWarningHeader(code int, agent string, message string) {
+	if code != 299 || len(message) == 0 {
+		return
+	}
+
+	if l.opts.Deduplicate {
+		l.writtenLock.Lock()
+		defer l.writtenLock.Unlock()
+
+		if _, alreadyLogged := l.written[message]; alreadyLogged {
+			return
+		}
+		l.written[message] = struct{}{}
+	}
+	l.logger.Info(message)
+}
+
+// NewKubeAPIWarningLogger returns an implementation of rest.WarningHandler that logs warnings
+// with code = 299 to the provided logr.Logger.
+func NewKubeAPIWarningLogger(l logr.Logger, opts KubeAPIWarningLoggerOptions) *KubeAPIWarningLogger {
+	h := &KubeAPIWarningLogger{logger: l, opts: opts}
+	if opts.Deduplicate {
+		h.written = map[string]struct{}{}
+	}
+	return h
+}


### PR DESCRIPTION
# Changes
- Process rbac resource creation for openshift namespace reconciliation concurrently to avoid slowness on clusters with high number of namespace
- Avoid blocking the reconciliation loop on error, when errors happen on namespace rbac resource reconciliation for openshift
- Add unit tests to createRessource in rbac.go  

depends on https://github.com/tektoncd/operator/pull/2217
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
