### PR TITLE
Support for disconnected environments for resolverTasks

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -83,7 +83,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: tekton-operator-controller-config-leader-election
         - name: IMAGE_HUB_TEKTON_HUB_DB
-          value: registry.redhat.io/rhel8/postgresql-13@sha256:f0083c3398501e3b7c82e7f865cd3377ff14cbfb14b1f8f91d7889232afa4796
+          value: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
         - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
           value: registry.redhat.io/rhel8/buildah@sha256:3c2ea396a114221575a4031d90d28c43563f7b96288374e0ba8b22de3ed97b5a
         - name: IMAGE_ADDONS_PARAM_KN_IMAGE
@@ -97,7 +97,7 @@ spec:
         - name: IMAGE_ADDONS_GEN_ENV_FILE
           value: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
         - name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE
-          value: registry.redhat.io/ubi8/openjdk-17@sha256:0d12c4097e098b62f78a7a31c0d711d78e1e5a53f4c007b9a5fc6cc6ab4dc018
+          value: registry.redhat.io/ubi8/openjdk-17@sha256:e8cc2e476282b75d89c73057bfa713db22d72bdb2808d62d981a84c33beb2575
       - name: openshift-pipelines-operator-cluster-operations  # tektoninstallerset reconciler
         image: ko://github.com/tektoncd/operator/cmd/openshift/operator
         args:

--- a/hack/openshift/fetch-tektoncd-catalog-tasks.sh
+++ b/hack/openshift/fetch-tektoncd-catalog-tasks.sh
@@ -61,7 +61,6 @@ declare -A TEKTON_ECOSYSTEM_TASKS=(
   ['task-kn-apply']='0.1.0'
   ['task-kn']='0.1.0'
   ['task-maven']="0.2.1"
-  ['task-opc']="0.1.0"
   ['task-openshift-client']="0.1.0"
   ['task-s2i-dotnet']='0.3.1'
   ['task-s2i-go']='0.3.1'
@@ -73,7 +72,6 @@ declare -A TEKTON_ECOSYSTEM_TASKS=(
   ['task-s2i-ruby']='0.3.1'
   ['task-skopeo-copy']='0.3.1'
   ['task-tkn']='0.1.0'
-  ['task-buildpacks']='0.1.0'
 )
 
 download_task() {

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -62,6 +62,8 @@ image-substitutions:
       envKeys:
       - IMAGE_PIPELINES_ARG__GIT_IMAGE
       - IMAGE_ADDONS_PARAM_GITINITIMAGE
+      - IMAGE_ADDONS_GIT_RUN
+      - IMAGE_ADDONS_REPORT
 - image: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel8@
   replaceLocations:
     envTargets:
@@ -118,20 +120,24 @@ image-substitutions:
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_PARAM_KN_IMAGE
-- image: registry.redhat.io/rhel8/skopeo@sha256:4b8d3eeb55e243f7a8ecd375292bdb8f65a6dfc5b02addfdfec5d0aec70877f6
+      - IMAGE_ADDONS_KN
+- image: registry.redhat.io/rhel8/skopeo@sha256:29465586e92ed04d2878dcdeda2d508c7e8e7539762e10296b52d631929960aa
   replaceLocations:
     envTargets:
     - deploymentName: openshift-pipelines-operator
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_SKOPEO_COPY
-- image: registry.redhat.io/rhel8/buildah@sha256:3c2ea396a114221575a4031d90d28c43563f7b96288374e0ba8b22de3ed97b5a
+      - IMAGE_ADDONS_SKOPEO_RESULTS
+- image: registry.redhat.io/rhel8/buildah@sha256:aac6629389db17e99894c5bee0da01d4c8065d11d8c6f6e1602f9484290baa70
   replaceLocations:
     envTargets:
     - deploymentName: openshift-pipelines-operator
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_PARAM_BUILDER_IMAGE
+      - IMAGE_ADDONS_BUILD
+      - IMAGE_ADDONS_S2I_BUILD
 - image: registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:6a6025914296a62fdf2092c3a40011bd9b966a6806b094d51eec5e1bd5026ef4
   replaceLocations:
     envTargets:
@@ -140,14 +146,17 @@ image-substitutions:
       envKeys:
       - IMAGE_ADDONS_GENERATE
       - IMAGE_ADDONS_GEN_ENV_FILE
-
-- image: registry.redhat.io/ubi8/ubi-minimal@sha256:87bcbfedfd70e67aab3875fff103bade460aeff510033ebb36b7efa009ab6639
+      - IMAGE_ADDONS_S2I_GENERATE
+- image: registry.redhat.io/ubi8/ubi-minimal@sha256:f729a7f5685ea823e87ffd68aff988f2b8ff8d52126ade4e6de7c68088f28ebd
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_ADDONS_MVN_SETTINGS
+          - IMAGE_ADDONS_LOAD_SCRIPTS
+          - IMAGE_ADDONS_MAVEN_GENERATE
+          - IMAGE_ADDONS_PREPARE
 - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@
   replaceLocations:
     envTargets:
@@ -156,6 +165,7 @@ image-substitutions:
       envKeys:
       - IMAGE_JOB_PRUNER_TKN
       - IMAGE_ADDONS_PARAM_TKN_IMAGE
+      - IMAGE_ADDONS_TKN
 - image: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel8@
   replaceLocations:
     envTargets:
@@ -175,7 +185,7 @@ image-substitutions:
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-- image: registry.redhat.io/rhel8/postgresql-13@sha256:f0083c3398501e3b7c82e7f865cd3377ff14cbfb14b1f8f91d7889232afa4796
+- image: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator
@@ -236,14 +246,22 @@ image-substitutions:
         envKeys:
           - IMAGE_RESULTS_API
 
-- image: registry.redhat.io/ubi8/openjdk-17@sha256:0d12c4097e098b62f78a7a31c0d711d78e1e5a53f4c007b9a5fc6cc6ab4dc018
+- image: registry.redhat.io/ubi8/openjdk-17@sha256:e8cc2e476282b75d89c73057bfa713db22d72bdb2808d62d981a84c33beb2575
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_ADDONS_PARAM_MAVEN_IMAGE
+          - IMAGE_ADDONS_MAVEN_GOALS
 
+- image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+  replaceLocations:
+    envTargets:
+      - deploymentName: openshift-pipelines-operator
+        containerName: openshift-pipelines-operator-lifecycle
+        envKeys:
+          - IMAGE_ADDONS_OC
 # pipelines console plugin image
 - image: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel8@
   replaceLocations:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -850,7 +850,7 @@ spec:
                 - name: CONFIG_OBSERVABILITY_NAME
                   value: tekton-config-observability
                 - name: IMAGE_HUB_TEKTON_HUB_DB
-                  value: registry.redhat.io/rhel8/postgresql-13@sha256:f0083c3398501e3b7c82e7f865cd3377ff14cbfb14b1f8f91d7889232afa4796
+                  value: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
                 - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
                   value: registry.redhat.io/rhel8/buildah@sha256:3c2ea396a114221575a4031d90d28c43563f7b96288374e0ba8b22de3ed97b5a
                 - name: IMAGE_ADDONS_PARAM_KN_IMAGE
@@ -1030,7 +1030,7 @@ spec:
     name: TEKTON_OPERATOR_WEBHOOK
   - image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel8@
     name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-  - image: registry.redhat.io/rhel8/postgresql-13@sha256:f0083c3398501e3b7c82e7f865cd3377ff14cbfb14b1f8f91d7889232afa4796
+  - image: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
     name: IMAGE_HUB_TEKTON_HUB_DB
   - image: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel8@
     name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -310,7 +310,7 @@ func SplitsByEqual(arg string) ([]string, bool) {
 // TaskImages replaces step and params images.
 func TaskImages(images map[string]string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "ClusterTask" {
+		if u.GetKind() != "ClusterTask" && u.GetKind() != "Task" {
 			return nil
 		}
 

--- a/pkg/reconciler/openshift/tektonaddon/resolverTask.go
+++ b/pkg/reconciler/openshift/tektonaddon/resolverTask.go
@@ -21,6 +21,7 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 )
 
@@ -41,8 +42,10 @@ func (r *Reconciler) EnsureResolverTask(ctx context.Context, enable string, ta *
 func filterAndTransformResolverTask() client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
 		addon := comp.(*v1alpha1.TektonAddon)
+		addonImages := common.ToLowerCaseKeys(common.ImagesFromEnv(common.AddonsImagePrefix))
 		tfs := []mf.Transformer{
 			injectLabel(labelProviderType, providerTypeRedHat, overwrite, "Task"),
+			common.TaskImages(addonImages),
 		}
 		if err := transformers(ctx, manifest, addon, tfs...); err != nil {
 			return nil, err


### PR DESCRIPTION
# Changes

This PR adds various images that are used by the ecosystem tasks to be accessible for mirroring for running in disconnected environments, along with few other minor changes.
- removed buildpacks & opc
- added oc image to the update-image-sha script & ran the script
- updated image-substitutions in config.yaml to include all of the ecosystem images
- updated filterAndTransform function for resolverTasks to enable the images to be changed

JIRA Issue: https://issues.redhat.com/browse/SRVKP-4591

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Added support for using tasks supported by resolverTasks in tektonconfig to be used in disconnected environments as well.
```