### PR TITLE
Fix PAC config not handling hub catalogs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/manifestival/client-go-client v0.6.0
 	github.com/manifestival/manifestival v0.7.2
 	github.com/markbates/inflect v1.0.4
-	github.com/openshift-pipelines/pipelines-as-code v0.27.0
+	github.com/openshift-pipelines/pipelines-as-code v0.27.1
 	github.com/openshift/api v0.0.0-20240304080513-3e8192a10b13
 	github.com/openshift/apiserver-library-go v0.0.0-20230816171015-6bfafa975bfb
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb

--- a/go.sum
+++ b/go.sum
@@ -1506,8 +1506,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openshift-pipelines/pipelines-as-code v0.27.0 h1:uxpva7/Ad/QEvc40BCBFEWrmYlAjCZ9dZCFYPYWW61c=
-github.com/openshift-pipelines/pipelines-as-code v0.27.0/go.mod h1:rzfXtaqbUrsAock3f948p9ekXWc3DFFk9acz5BsEwA4=
+github.com/openshift-pipelines/pipelines-as-code v0.27.1 h1:srVghq9p4LWB6PJuBbW3AOcQdsAc7hLf1y8vZtaRZ7s=
+github.com/openshift-pipelines/pipelines-as-code v0.27.1/go.mod h1:rzfXtaqbUrsAock3f948p9ekXWc3DFFk9acz5BsEwA4=
 github.com/openshift/api v0.0.0-20240304080513-3e8192a10b13 h1:KNaEkpcVi4XGb86cA6FMJ8Wia7KWAembCUv8blIksTY=
 github.com/openshift/api v0.0.0-20240304080513-3e8192a10b13/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
 github.com/openshift/apiserver-library-go v0.0.0-20230816171015-6bfafa975bfb h1:UMgJny13BBcHpY+JQ9Eg1Dm9+J7nWO3eqPvV1Zpd49A=

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-expected-additional-pac-cm.yaml
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-expected-additional-pac-cm.yaml
@@ -70,7 +70,7 @@ data:
   error-detection-max-number-of-lines: "50"
 
   # The default regexp used when we use the simple error detection
-  error-detection-simple-regexp: "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([ ]*)?(?P<error>.*)"
+  error-detection-simple-regexp: "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)"
 
   # Since public bitbucket doesn't have the concept of Secret, we need to be
   # able to secure the request by querying https://ip-ranges.atlassian.com/,
@@ -89,10 +89,10 @@ data:
   # value which a user can set on pipelineRun. the value set on annotation
   # should be less than or equal to the upper limit otherwise the upper limit
   # will be used while cleaning up
-  max-keep-run-upper-limit: ""
+  max-keep-run-upper-limit: "0"
 
   # if defined then applies to all pipelineRun who doesn't have max-keep-runs annotation
-  default-max-keep-runs: ""
+  default-max-keep-runs: "0"
 
   # Whether to auto configure newly created repositories, this will create a new
   # namespace and repository CR, supported only with GitHub App
@@ -119,6 +119,7 @@ data:
   #
   custom-console-name: ""
   custom-console-url: ""
+  custom-console-url-namespace: ""
   custom-console-url-pr-details: ""
   custom-console-url-pr-tasklog: ""
 

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	mf "github.com/manifestival/manifestival"
-	pacConfigutil "github.com/openshift-pipelines/pipelines-as-code/pkg/configutil"
 	pacSettings "github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -226,8 +225,8 @@ func updateAdditionControllerConfigMap(config v1alpha1.AdditionalPACControllerCo
 		}
 
 		defaultPacSettings := pacSettings.DefaultSettings()
-		err := pacConfigutil.ValidateAndAssignValues(zap.NewNop().Sugar(), config.Settings, &defaultPacSettings, nil, false)
-		config.Settings = v1alpha1.StructToMap(&defaultPacSettings)
+		err := pacSettings.SyncConfig(zap.NewNop().Sugar(), &defaultPacSettings, config.Settings, pacSettings.DefaultValidators())
+		config.Settings = pacSettings.ConvertPacStructToConfigMap(&defaultPacSettings)
 		if err != nil {
 			return err
 		}

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform_test.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform_test.go
@@ -149,7 +149,6 @@ func TestUpdateAdditionControllerConfigMapWithDefaultCM(t *testing.T) {
 }
 
 func TestUpdateAdditionControllerConfigMap(t *testing.T) {
-	t.Skip("Need to fix based on new validation logic")
 	testData := path.Join("testdata", "test-additional-pac-cm.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)

--- a/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/convert.go
+++ b/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/convert.go
@@ -1,0 +1,65 @@
+package settings
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+func ConvertPacStructToConfigMap(settings *Settings) map[string]string {
+	config := map[string]string{}
+	if settings == nil {
+		return config
+	}
+	structValue := reflect.ValueOf(settings).Elem()
+	structType := reflect.TypeOf(settings).Elem()
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		fieldName := field.Name
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "-" {
+			continue
+		}
+		key := strings.ToLower(jsonTag)
+		element := structValue.FieldByName(fieldName)
+		if !element.IsValid() {
+			continue
+		}
+
+		//nolint
+		switch field.Type.Kind() {
+		case reflect.String:
+			config[key] = element.String()
+		case reflect.Bool:
+			config[key] = strconv.FormatBool(element.Bool())
+		case reflect.Int:
+			config[key] = strconv.FormatInt(element.Int(), 10)
+		case reflect.Ptr:
+			// for hub catalogs map
+			if key == "" {
+				data := element.Interface().(*sync.Map)
+				data.Range(func(key, value interface{}) bool {
+					catalogData := value.(HubCatalog)
+					if key == "default" {
+						config[HubURLKey] = catalogData.URL
+						config[HubCatalogNameKey] = catalogData.Name
+						return true
+					}
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "id")] = key.(string)
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "name")] = catalogData.Name
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "url")] = catalogData.URL
+					return true
+				})
+			}
+		default:
+			// Skip unsupported field types
+			continue
+		}
+	}
+
+	return config
+}

--- a/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/default.go
+++ b/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/default.go
@@ -21,26 +21,26 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 		config[HubCatalogNameKey] = HubCatalogNameDefaultValue
 	}
 	catalogs.Store("default", HubCatalog{
-		ID:   "default",
-		Name: config[HubCatalogNameKey],
-		URL:  config[HubURLKey],
+		Index: "default",
+		Name:  config[HubCatalogNameKey],
+		URL:   config[HubURLKey],
 	})
 
 	for k := range config {
 		m := hubCatalogNameRegex.FindStringSubmatch(k)
 		if len(m) > 0 {
-			id := m[1]
-			cPrefix := fmt.Sprintf("catalog-%s", id)
+			index := m[1]
+			cPrefix := fmt.Sprintf("catalog-%s", index)
 			skip := false
 			for _, kk := range []string{"id", "name", "url"} {
 				cKey := fmt.Sprintf("%s-%s", cPrefix, kk)
 				// check if key exist in config
 				if _, ok := config[cKey]; !ok {
-					logger.Warnf("CONFIG: hub %v should have the key %s, skipping catalog configuration", id, cKey)
+					logger.Warnf("CONFIG: hub %v should have the key %s, skipping catalog configuration", index, cKey)
 					skip = true
 					break
 				} else if config[cKey] == "" {
-					logger.Warnf("CONFIG: hub %v catalog configuration is empty, skipping catalog configuration", id)
+					logger.Warnf("CONFIG: hub %v catalog configuration have empty value for key %s, skipping catalog configuration", index, cKey)
 					skip = true
 					break
 				}
@@ -61,15 +61,15 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 				value, ok := catalogs.Load(catalogID)
 				if ok {
 					catalogValues, ok := value.(HubCatalog)
-					if ok && (catalogValues.Name == catalogName) && (catalogValues.URL == catalogURL) {
-						break
+					if ok && (catalogValues.Name == catalogName) && (catalogValues.URL == catalogURL) && (catalogValues.Index == index) {
+						continue
 					}
 				}
 				logger.Infof("CONFIG: setting custom hub %s, catalog %s", catalogID, catalogURL)
 				catalogs.Store(catalogID, HubCatalog{
-					ID:   catalogID,
-					Name: catalogName,
-					URL:  catalogURL,
+					Index: index,
+					Name:  catalogName,
+					URL:   catalogURL,
 				})
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -996,7 +996,7 @@ github.com/opencontainers/go-digest
 ## explicit; go 1.18
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift-pipelines/pipelines-as-code v0.27.0
+# github.com/openshift-pipelines/pipelines-as-code v0.27.1
 ## explicit; go 1.21
 github.com/openshift-pipelines/pipelines-as-code/pkg/cli
 github.com/openshift-pipelines/pipelines-as-code/pkg/configutil


### PR DESCRIPTION
This will fix the issue of PAC config not able
to set default hub catalog value and also
additional hub catalog value in configmap

Bump PAC to v0.27.1

Add tests
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix PAC config not handling hub catalogs
```