### PR TITLE
[main] fix confiMap transformer to include string pointer's empty value

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -527,8 +527,8 @@ func replaceNamespaceInContainerArg(container *corev1.Container, targetNamespace
 	}
 }
 
-// AddConfigMapValues will loop on the interface passed and add the fields in configmap
-// with key as json tag of the struct field
+// AddConfigMapValues will loop on the interface (should be a struct) and add the fields in to configMap
+// the key will be the json tag of the struct field
 func AddConfigMapValues(configMapName string, prop interface{}) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() != "ConfigMap" || u.GetName() != configMapName || prop == nil {
@@ -564,6 +564,14 @@ func AddConfigMapValues(configMapName string, prop interface{}) mf.Transformer {
 			if element.Kind() == reflect.Ptr {
 				if element.IsNil() {
 					continue
+				}
+				// empty string value will not be included in the following switch statement
+				// however, *string pointer can have empty("") string
+				// so copying the actual string value to the configMap, it can be a empty string too
+				if value, ok := element.Interface().(*string); ok {
+					if value != nil {
+						cm.Data[key] = *value
+					}
 				}
 				// extract the actual element from the pointer
 				element = values.Field(index).Elem()

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -658,6 +658,33 @@ func TestAddConfigMapValues(t *testing.T) {
 			expectedData:        map[string]string{"foo": "bar"},
 			doesConfigMapExists: true,
 		},
+		{
+			name:                "verify-with-empty-string-pointer",
+			targetConfigMapName: configMapName,
+			props: struct {
+				StringPtr      *string `json:"stringPtr"`
+				NilStringPtr   *string `json:"nilStringPtr"`
+				EmptyStringPtr *string `json:"emptyStringPtr"`
+				String         string  `json:"string"`
+				EmptyString    string  `json:"emptyString"`
+			}{
+				StringPtr:      ptr.String("hi"),
+				NilStringPtr:   nil,
+				EmptyStringPtr: ptr.String(""),
+				String:         "hello",
+				EmptyString:    "",
+			},
+			expectedData: map[string]string{
+				"stringPtr":      "hi",
+				"emptyStringPtr": "",
+				"string":         "hello",
+			},
+			keysShouldNotBeIn: []string{
+				"nilStringPtr",
+				"emptyString",
+			},
+			doesConfigMapExists: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Changes

* fixes confiMap transformer to include string pointer's empty value
* fixes: [SRVKP-4497](https://issues.redhat.com/browse/SRVKP-4497) - Chains: empty artifacts.oci.storage is not propagated from TektonConfig to the config map

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
