### PR TITLE
ArtifactsPipelineRunEnableDeepInspection making this field to accept both bool and string

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -80,10 +80,10 @@ type ChainProperties struct {
 	ArtifactsTaskRunSigner  string  `json:"artifacts.taskrun.signer,omitempty"`
 
 	// pipelinerun artifacts config
-	ArtifactsPipelineRunFormat               string  `json:"artifacts.pipelinerun.format,omitempty"`
-	ArtifactsPipelineRunStorage              *string `json:"artifacts.pipelinerun.storage,omitempty"`
-	ArtifactsPipelineRunSigner               string  `json:"artifacts.pipelinerun.signer,omitempty"`
-	ArtifactsPipelineRunEnableDeepInspection *bool   `json:"artifacts.pipelinerun.enable-deep-inspection,omitempty"`
+	ArtifactsPipelineRunFormat               string    `json:"artifacts.pipelinerun.format,omitempty"`
+	ArtifactsPipelineRunStorage              *string   `json:"artifacts.pipelinerun.storage,omitempty"`
+	ArtifactsPipelineRunSigner               string    `json:"artifacts.pipelinerun.signer,omitempty"`
+	ArtifactsPipelineRunEnableDeepInspection BoolValue `json:"artifacts.pipelinerun.enable-deep-inspection,omitempty"`
 
 	// oci artifacts config
 	ArtifactsOCIFormat  string  `json:"artifacts.oci.format,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -26,13 +26,14 @@ import (
 )
 
 var (
-	allowedArtifactsTaskRunFormat     = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
-	allowedArtifactsPipelineRunFormat = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
-	allowedX509SignerFulcioProvider   = sets.NewString("", "google", "spiffe", "github", "filesystem")
-	allowedTransparencyConfigEnabled  = sets.NewString("", "true", "false", "manual")
-	allowedArtifactsStorage           = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
-	allowedControllerEnvs             = sets.NewString("MONGO_SERVER_URL")
-	allowedBuildDefinitionType        = sets.NewString("", "https://tekton.dev/chains/v2/slsa", "https://tekton.dev/chains/v2/slsa-tekton")
+	allowedArtifactsTaskRunFormat                   = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
+	allowedArtifactsPipelineRunFormat               = sets.NewString("", "in-toto", "slsa/v1", "slsa/v2alpha2", "slsa/v2alpha3")
+	allowedX509SignerFulcioProvider                 = sets.NewString("", "google", "spiffe", "github", "filesystem")
+	allowedTransparencyConfigEnabled                = sets.NewString("", "true", "false", "manual")
+	allowedArtifactsPipelineRunEnableDeepInspection = sets.NewString("", "true", "false")
+	allowedArtifactsStorage                         = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
+	allowedControllerEnvs                           = sets.NewString("MONGO_SERVER_URL")
+	allowedBuildDefinitionType                      = sets.NewString("", "https://tekton.dev/chains/v2/slsa", "https://tekton.dev/chains/v2/slsa-tekton")
 )
 
 func (tc *TektonChain) Validate(ctx context.Context) (errs *apis.FieldError) {
@@ -133,6 +134,10 @@ func (tcs *TektonChainSpec) ValidateChainConfig(path string) (errs *apis.FieldEr
 
 	if !allowedTransparencyConfigEnabled.Has(string(tcs.TransparencyConfigEnabled)) {
 		errs = errs.Also(apis.ErrInvalidValue(tcs.TransparencyConfigEnabled, path+".transparency.enabled"))
+	}
+
+	if !allowedArtifactsPipelineRunEnableDeepInspection.Has(string(tcs.ArtifactsPipelineRunEnableDeepInspection)) {
+		errs = errs.Also(apis.ErrInvalidValue(tcs.ArtifactsPipelineRunEnableDeepInspection, path+".artifacts.pipelinerun.enable-deep-inspection"))
 	}
 
 	if !allowedBuildDefinitionType.Has(tcs.BuildDefinitionBuildType) {

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
@@ -214,6 +214,45 @@ func Test_ValidateTektonChain_ConfigPipelineRunStorageValid(t *testing.T) {
 	}
 }
 
+func Test_ValidateTektonChain_ConfigInvalidArtifactsPipelineRunEnableDeepInspection(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+
+	tc.Spec.Chain.ChainProperties.ArtifactsPipelineRunEnableDeepInspection = "foo"
+	err := tc.Validate(context.TODO())
+	assert.Equal(t, "invalid value: foo: spec.artifacts.pipelinerun.enable-deep-inspection", err.Error())
+}
+
+func Test_ValidateTektonChain_ConfigArtifactsPipelineRunEnableDeepInspection(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+
+	tc.Spec.Chain.ChainProperties.ArtifactsPipelineRunEnableDeepInspection = "true"
+	err := tc.Validate(context.TODO())
+
+	if err != nil {
+		t.Errorf("ValidateTektonChain.Validate() expected no error for the given config, but got one, ValidateTektonChain: %v", err)
+	}
+}
+
 func Test_ValidateTektonChain_ConfigInvalidX509SignerFulcioProvider(t *testing.T) {
 	tc := &TektonChain{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -218,11 +218,6 @@ func (in *ChainProperties) DeepCopyInto(out *ChainProperties) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ArtifactsPipelineRunEnableDeepInspection != nil {
-		in, out := &in.ArtifactsPipelineRunEnableDeepInspection, &out.ArtifactsPipelineRunEnableDeepInspection
-		*out = new(bool)
-		**out = **in
-	}
 	if in.ArtifactsOCIStorage != nil {
 		in, out := &in.ArtifactsOCIStorage, &out.ArtifactsOCIStorage
 		*out = new(string)


### PR DESCRIPTION
# Changes
https://issues.redhat.com/browse/SRVKP-4387

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
in Tekton config for chains now user can provide `artifacts.pipelinerun.enable-deep-inspection: true` as bool or string both are supported now, earlier only bool was supported.
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
