### PR TITLE
Remove unused variable tknVersion

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/consolecli.go
+++ b/pkg/reconciler/openshift/tektonaddon/consolecli.go
@@ -66,8 +66,6 @@ func getRouteHost(manifest *mf.Manifest) (string, error) {
 }
 
 func consoleCLITransform(ctx context.Context, manifest *mf.Manifest, baseURL string) error {
-	tknVersion := "0.33.0"
-
 	if baseURL == "" {
 		return fmt.Errorf("route url should not be empty")
 	}
@@ -75,7 +73,7 @@ func consoleCLITransform(ctx context.Context, manifest *mf.Manifest, baseURL str
 	logger.Debug("Transforming manifest")
 
 	transformers := []mf.Transformer{
-		replaceURLCCD(baseURL, tknVersion),
+		replaceURLCCD(baseURL),
 	}
 
 	transformManifest, err := manifest.Transform(transformers...)

--- a/pkg/reconciler/openshift/tektonaddon/transformer.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer.go
@@ -76,7 +76,7 @@ func itemInSlice(item string, items []string) bool {
 	return false
 }
 
-func getlinks(baseURL, tknVersion string) []console.CLIDownloadLink {
+func getlinks(baseURL string) []console.CLIDownloadLink {
 	platformURLs := []struct {
 		platform string
 		tknURL   string
@@ -107,7 +107,7 @@ func getURL(baseURL string, path string) string {
 	return fmt.Sprintf("https://%s/%s", baseURL, path)
 }
 
-func replaceURLCCD(baseURL, tknVersion string) mf.Transformer {
+func replaceURLCCD(baseURL string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() != "ConsoleCLIDownload" {
 			return nil
@@ -117,7 +117,7 @@ func replaceURLCCD(baseURL, tknVersion string) mf.Transformer {
 		if err != nil {
 			return err
 		}
-		ccd.Spec.Links = getlinks(baseURL, tknVersion)
+		ccd.Spec.Links = getlinks(baseURL)
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ccd)
 		if err != nil {
 			return err

--- a/pkg/reconciler/openshift/tektonaddon/transformer_test.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer_test.go
@@ -37,7 +37,7 @@ func TestUpdateConsoleCLIDownload(t *testing.T) {
 	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assert.NilError(t, err)
 
-	newManifest, err := manifest.Transform(replaceURLCCD("testserver.com", "1.2.3"))
+	newManifest, err := manifest.Transform(replaceURLCCD("testserver.com"))
 	assert.NilError(t, err)
 
 	got := &console.ConsoleCLIDownload{}


### PR DESCRIPTION
This isa refactor to remove unused variable tknVersion which always became a dep to bump before every release

I figured out this is not getting used now so removing


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
