### PR TITLE
Fix panic error when settings map is nil for AdditionalPACControllerConfig

### DIFF
--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
@@ -79,6 +79,9 @@ func (aps AdditionalPACControllerConfig) validate(logger *zap.SugaredLogger, pat
 	}
 
 	defaultPacSettings := pacSettings.DefaultSettings()
+	if aps.Settings == nil {
+		aps.Settings = map[string]string{}
+	}
 	if err := pacSettings.SyncConfig(logger, &defaultPacSettings, aps.Settings, pacSettings.DefaultValidators()); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("%s.settings", path)))
 	}

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
@@ -108,3 +108,28 @@ func TestValidateAddtionalPACControllerInvalidNameLength(t *testing.T) {
 	err := opacCR.Validate(context.TODO())
 	assert.Equal(t, fmt.Sprintf("invalid value: invalid resource name %q: length must be no more than 25 characters: name: spec.additionalPACControllers", "testlengthwhichexceedsthemaximumlength"), err.Error())
 }
+
+func TestValidateAddtionalPACControllerWhenNoSettings(t *testing.T) {
+	opacCR := &OpenShiftPipelinesAsCode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: OpenShiftPipelinesAsCodeSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "Openshift-Pipelines",
+			},
+			PACSettings: PACSettings{
+				Settings: map[string]string{},
+				AdditionalPACControllers: map[string]AdditionalPACControllerConfig{
+					"test": {
+						ConfigMapName: "test-configmap",
+						SecretName:    "test-secret",
+					},
+				},
+			},
+		},
+	}
+	err := opacCR.Validate(context.TODO())
+	assert.Assert(t, nil, err)
+}


### PR DESCRIPTION
# Changes

Right now when we do 
```
kubectl patch tektonconfig config --type=merge -p '{"spec": {"platforms":{"openshift":{"pipelinesAsCode": {"additionalPACControllers": {"ghe": {"enable": true, "secretName":"ghe-pac-secret"}}}}}}}'
```
Its failing with below error
```
Error from server (InternalError): Internal error occurred: failed calling webhook "validation.webhook.operator.tekton.dev": failed to call webhook: Post "[https://tekton-operator-webhook.openshift-operators.svc:443/resource-validation?timeout=10s](https://tekton-operator-webhook.openshift-operators.svc/resource-validation?timeout=10s)": EOF
```
When looked at the log of the pod i see a panic error
```
{"level":"error","logger":"tekton-operator-webhook","caller":"webhook/webhook.go:245","msg":"http: panic serving 10.130.0.2:60956: assignment to entry in nil map\ngoroutine 612 [running]:\nnet/http.(*conn).serve.func1()\n\t/usr/lib/golang/src/net/http/server.go:1898 +0xbe\npanic({0x1b1b560?, 0x20af3e0?})\n\t/usr/lib/golang/src/runtime/panic.go:770 +0x132\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/params/settings.getHubCatalogs(0xc000b7f6d8, 0xc000b84c40?, 0x0)\n\t/go/src/github.com/tektoncd/operator/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/default.go:16 +0x9b\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/params/settings.SyncConfig(0xc000b7f6d8, 0xc000ce0b08, 0x0, 0xc000ce0cd8)\n\t/go/src/github.com/tektoncd/operator/vendor/github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings/config.go:105 +0x46\ngithub.com/tektoncd/operator/pkg/apis/operator/v1alpha1.AdditionalPACControllerConfig.validate({0xc00053f74a, {0xc000c97220, 0x1f}, {0xc00053f750, 0xe}, 0x0}, 0xc000b7f6d8, {0xc00095f6d0, 0x41})\n\t/go/src/github.com/tektoncd/operator/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go:82 +0x417\ngithub.com/tektoncd/operator/pkg/apis/operator/v1alpha1.(*PACSettings).validate(0xc000b82988, 0xc000b7f6d8, {0x1e21620, 0x28})\n\t/go/src/github.com/tektoncd/operator/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go:64 +0x425\ngithub.com/tektoncd/operator/pkg/apis/operator/v1alpha1.(*TektonConfig).Validate(0xc000b8a0
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
