### PR TITLE
Fix validation for additionalPacController settings

### DIFF
--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	pacSettings "github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"go.uber.org/zap"
@@ -61,13 +62,13 @@ func (ps *PACSettings) validate(logger *zap.SugaredLogger, path string) *apis.Fi
 			errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("%s.additionalPACControllers", path)))
 		}
 
-		errs = errs.Also(additionalPACControllerConfig.validate(logger, fmt.Sprintf("%s.additionalPACControllers", path)))
+		errs = errs.Also(additionalPACControllerConfig.validate(fmt.Sprintf("%s.additionalPACControllers", path)))
 	}
 
 	return errs
 }
 
-func (aps AdditionalPACControllerConfig) validate(logger *zap.SugaredLogger, path string) *apis.FieldError {
+func (aps AdditionalPACControllerConfig) validate(path string) *apis.FieldError {
 	var errs *apis.FieldError
 
 	if err := validateKubernetesName(aps.ConfigMapName); err != nil {
@@ -78,8 +79,7 @@ func (aps AdditionalPACControllerConfig) validate(logger *zap.SugaredLogger, pat
 		errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("%s.secretName", path)))
 	}
 
-	defaultPacSettings := pacSettings.DefaultSettings()
-	if err := pacSettings.SyncConfig(logger, &defaultPacSettings, aps.Settings, pacSettings.DefaultValidators()); err != nil {
+	if err := validateAdditionalPACControllerSettings(aps.Settings); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("%s.settings", path)))
 	}
 
@@ -120,4 +120,42 @@ func validateKubernetesName(name string) *apis.FieldError {
 		}
 	}
 	return nil
+}
+
+// validates the settings of the additionalPACController
+func validateAdditionalPACControllerSettings(settings map[string]string) *apis.FieldError {
+	var errs *apis.FieldError
+	validators := pacSettings.DefaultValidators()
+	if len(settings) > 0 {
+		fieldTagMapDetails := getFieldTagMap()
+		for key, value := range settings {
+			fieldName, ok := fieldTagMapDetails[key]
+			if !ok {
+				continue
+			}
+			if validationFunc, ok := validators[fieldName]; ok && value != "" {
+				if err := validationFunc(value); err != nil {
+					errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("validation failed for field %s", key)))
+					continue
+				}
+			}
+		}
+		return errs
+	}
+	return nil
+}
+
+// this will return map with all the json tags with value equal to their field names
+func getFieldTagMap() map[string]string {
+	var fieldTagMapping = make(map[string]string)
+	rt := reflect.TypeOf(pacSettings.Settings{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		v := f.Tag.Get("json")
+		if v == "" || v == "-" {
+			continue
+		}
+		fieldTagMapping[v] = f.Name
+	}
+	return fieldTagMapping
 }

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
@@ -25,6 +25,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestValidateAddtionalPACControllerEmptySettings(t *testing.T) {
+	opacCR := &OpenShiftPipelinesAsCode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: OpenShiftPipelinesAsCodeSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "openshift-pipelines",
+			},
+			PACSettings: PACSettings{
+				Settings: map[string]string{},
+				AdditionalPACControllers: map[string]AdditionalPACControllerConfig{
+					"test": {
+						ConfigMapName: "test-configmap",
+						SecretName:    "test-secret",
+					},
+				},
+			},
+		},
+	}
+	err := opacCR.Validate(context.TODO())
+	assert.Error(t, err, "")
+}
+
 func TestValidateAddtionalPACControllerInvalidName(t *testing.T) {
 	opacCR := &OpenShiftPipelinesAsCode{
 		ObjectMeta: metav1.ObjectMeta{
@@ -107,4 +132,33 @@ func TestValidateAddtionalPACControllerInvalidNameLength(t *testing.T) {
 	}
 	err := opacCR.Validate(context.TODO())
 	assert.Equal(t, fmt.Sprintf("invalid value: invalid resource name %q: length must be no more than 25 characters: name: spec.additionalPACControllers", "testlengthwhichexceedsthemaximumlength"), err.Error())
+}
+
+func TestValidateAddtionalPACControllerInvalidSetting(t *testing.T) {
+	opacCR := &OpenShiftPipelinesAsCode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: OpenShiftPipelinesAsCodeSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "Openshift-Pipelines",
+			},
+			PACSettings: PACSettings{
+				Settings: map[string]string{},
+				AdditionalPACControllers: map[string]AdditionalPACControllerConfig{
+					"testlength": {
+						ConfigMapName: "test-configmap",
+						SecretName:    "test-secret",
+						Settings: map[string]string{
+							"custom-console-url": "test/path",
+							"application-name":   "Additional PACController CI",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := opacCR.Validate(context.TODO())
+	assert.Equal(t, "invalid value: invalid value: invalid value for URL, error: parse \"test/path\": invalid URI for request: validation failed for field custom-console-url: spec.additionalPACControllers.settings", err.Error())
 }


### PR DESCRIPTION
This will fix the panic error on additionalPacController if provided with no settings, as we dont need to set all the fields here of settings in additional PAC controller, we dont need to perform defaulting, we just need to perform validations on the provided fields if any

also added test for the scenario

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix validation for additionalPacController settings
```