### PR TITLE
skip ManualApprovalgate tests on s390x/ppc64le arch

### DIFF
--- a/test/e2e/common/06_manualapprovalgatedeployment_test.go
+++ b/test/e2e/common/06_manualapprovalgatedeployment_test.go
@@ -39,6 +39,10 @@ func TestManualApprovalGateDeployment(t *testing.T) {
 	if os.Getenv("TARGET") == "openshift" {
 		crNames.TargetNamespace = "openshift-pipelines"
 	}
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("ManualApprovalgate is not available for %q", platform)
+	}
 
 	clients := client.Setup(t, crNames.TargetNamespace)
 


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

As of now manual approval gate supports only x86 in upstream. its not supporting for s390x/ppc64le arch. so we need to exclude the tests related manual approval gate on s390x/ppc64le CI.

https://github.com/openshift-pipelines/manual-approval-gate/issues/168

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
