### PR TITLE
docs: remove unsupported feature flag `scope-when-expressions-to-task`

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -73,7 +73,6 @@ The TektonConfig CR provides the following features
       require-git-ssh-secret-known-hosts: false
       results-from: termination-message
       running-in-environment-with-injected-sidecars: true
-      scope-when-expressions-to-task: false
       send-cloudevents-for-runs: false
       set-security-context: false
       trusted-resources-verification-no-match-policy: ignore

--- a/docs/TektonPipeline.md
+++ b/docs/TektonPipeline.md
@@ -47,7 +47,6 @@ spec:
   require-git-ssh-secret-known-hosts: false
   results-from: termination-message
   running-in-environment-with-injected-sidecars: true
-  scope-when-expressions-to-task: false
   send-cloudevents-for-runs: false
   set-security-context: false
   trusted-resources-verification-no-match-policy: ignore
@@ -171,10 +170,6 @@ and thus should still be considered an alpha feature.
 - `enable-cel-in-whenexpression` (Default: `false`)
 
     Setting this flag to "true" will enable using CEL in when expressions.
-
-- `scope-when-expressions-to-task` (Default: `false`)
-
-    Setting this flag to "true" scopes when expressions to guard a Task only instead of a Task and its dependent Tasks.
 
 - `trusted-resources-verification-no-match-policy` (Default: `ignore`)
 

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -106,7 +106,7 @@ type PipelineProperties struct {
 	VerificationNoMatchPolicy string `json:"trusted-resources-verification-no-match-policy,omitempty"`
 	EnableProvenanceInStatus  *bool  `json:"enable-provenance-in-status,omitempty"`
 
-	// ScopeWhenExpressionsToTask Deprecated: remove in next release
+	// ScopeWhenExpressionsToTask is deprecated and never used.
 	ScopeWhenExpressionsToTask *bool `json:"scope-when-expressions-to-task,omitempty"`
 
 	EnforceNonfalsifiability  string `json:"enforce-nonfalsifiability,omitempty"`


### PR DESCRIPTION
# Changes
This feature flag has been completely removed in v0.35.

Ref: https://github.com/tektoncd/pipeline/pull/4715

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

docs: remove unsupported feature flag `scope-when-expressions-to-task`

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
chore: remove unsupported feature flag `scope-when-expressions-to-task`
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
