### PR TITLE
[main] update default logger options for production environment

### DIFF
--- a/config/base/config-logging.yaml
+++ b/config/base/config-logging.yaml
@@ -22,8 +22,8 @@ metadata:
 data:
   zap-logger-config: |
     {
-      "level": "debug",
-      "development": true,
+      "level": "info",
+      "development": false,
       "sampling": {
         "initial": 100,
         "thereafter": 100
@@ -32,7 +32,7 @@ data:
       "errorOutputPaths": ["stderr"],
       "encoding": "json",
       "encoderConfig": {
-        "timeKey": "",
+        "timeKey": "timestamp",
         "levelKey": "level",
         "nameKey": "logger",
         "callerKey": "caller",
@@ -40,14 +40,17 @@ data:
         "stacktraceKey": "stacktrace",
         "lineEnding": "",
         "levelEncoder": "",
-        "timeEncoder": "",
+        "timeEncoder": "iso8601",
         "durationEncoder": "",
         "callerEncoder": ""
       }
     }
+
   # Log level overrides
-  loglevel.controller: "info"
-  loglevel.webhook: "info"
+  loglevel.tekton-operator-lifecycle: "info"
+  loglevel.tekton-operator-cluster-operations: "info"
+  loglevel.tekton-operator-webhook: "info"
+
   _example: |
     ################################
     #                              #


### PR DESCRIPTION
# Changes

* update the default logger options to production mode
* fix level overrides name

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
default logger options updated to production mode. Now the default log level is `info` and fixed the logger overrides names
```
