### PR TITLE
Added KMSAuthTokenDir field for managing KMS auth tokens via file

### DIFF
--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -89,6 +89,8 @@ spec:
   storage.oci.repository: #value
   storage.oci.repository.insecure: #value (boolean - true/false)
   storage.docdb.url: #value
+  storage.docdb.mongo-server-url: #value
+  storage.docdb.mongo-server-url-dir: #value
   storage.grafeas.projectid: #value
   storage.grafeas.noteid: #value
   storage.grafeas.notehint: #value
@@ -103,6 +105,7 @@ spec:
   signers.kms.kmsref: #value
   signers.kms.kmsref.auth.address: #value
   signers.kms.kmsref.auth.token: #value
+  signers.kms.kmsref.auth.token-dir: #value
   signers.kms.kmsref.auth.oidc.path: #value
   signers.kms.kmsref.auth.oidc.role: #value
   signers.kms.kmsref.auth.spire.sock: #value

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -91,13 +91,15 @@ type ChainProperties struct {
 	ArtifactsOCISigner  string  `json:"artifacts.oci.signer,omitempty"`
 
 	// storage configs
-	StorageGCSBucket             string `json:"storage.gcs.bucket,omitempty"`
-	StorageOCIRepository         string `json:"storage.oci.repository,omitempty"`
-	StorageOCIRepositoryInsecure *bool  `json:"storage.oci.repository.insecure,omitempty"`
-	StorageDocDBURL              string `json:"storage.docdb.url,omitempty"`
-	StorageGrafeasProjectID      string `json:"storage.grafeas.projectid,omitempty"`
-	StorageGrafeasNoteID         string `json:"storage.grafeas.noteid,omitempty"`
-	StorageGrafeasNoteHint       string `json:"storage.grafeas.notehint,omitempty"`
+	StorageGCSBucket              string `json:"storage.gcs.bucket,omitempty"`
+	StorageOCIRepository          string `json:"storage.oci.repository,omitempty"`
+	StorageOCIRepositoryInsecure  *bool  `json:"storage.oci.repository.insecure,omitempty"`
+	StorageDocDBURL               string `json:"storage.docdb.url,omitempty"`
+	StorageDocDBMongoServerURL    string `json:"storage.docdb.mongo-server-url,omitempty"`
+	StorageDocDBMongoServerURLDir string `json:"storage.docdb.mongo-server-url-dir,omitempty"`
+	StorageGrafeasProjectID       string `json:"storage.grafeas.projectid,omitempty"`
+	StorageGrafeasNoteID          string `json:"storage.grafeas.noteid,omitempty"`
+	StorageGrafeasNoteHint        string `json:"storage.grafeas.notehint,omitempty"`
 
 	// builder config
 	BuilderID                string `json:"builder.id,omitempty"`
@@ -115,6 +117,7 @@ type ChainProperties struct {
 	KMSRef               string `json:"signers.kms.kmsref,omitempty"`
 	KMSAuthAddress       string `json:"signers.kms.auth.address,omitempty"`
 	KMSAuthToken         string `json:"signers.kms.auth.token,omitempty"`
+	KMSAuthTokenDir      string `json:"signers.kms.auth.token-dir,omitempty"`
 	KMSAuthOIDCPath      string `json:"signers.kms.auth.oidc.path,omitempty"`
 	KMSAuthOIDCRole      string `json:"signers.kms.auth.oidc.role,omitempty"`
 	KMSAuthSpireSock     string `json:"signers.kms.auth.spire.sock,omitempty"`

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -7,7 +7,7 @@ We dogfood our projects by using Tekton Pipelines to build, test and release
 Tekton Projects! This directory contains the
 [`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
 [`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
-that we use for Tekton Operator buind, test and release.
+that we use for Tekton Operator build, test and release.
 
 * [How to create a release](#create-an-official-release)
 * [How to create a patch release](#create-a-patch-release)

--- a/test/e2e/common/05_tektonhubdeployment_test.go
+++ b/test/e2e/common/05_tektonhubdeployment_test.go
@@ -94,6 +94,12 @@ func NewTektonHubTestSuite(t *testing.T) *TektonHubTestSuite {
 // before suite
 func (s *TektonHubTestSuite) SetupSuite() {
 	resources.PrintClusterInformation(s.logger, s.resourceNames)
+
+	// reset the tekton config into default state
+	s.logger.Debug("resetting TektonConfig to it's default state")
+	tcSuite := NewTestTektonConfigTestSuite(s.T())
+	tcSuite.recreateOperatorPod()
+	tcSuite.resetToDefaults()
 }
 
 // after suite


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Currently, the KMSAuthToken in Tekton chains is stored as plain text in the configuration, which poses a security risk. To enhance security, we're introducing a new field KMSAuthTokenDir in the chains configuration. This feature allows to specify a directory path where a token file named "KMS_AUTH_TOKEN" can be mounted.

Introduced two new configuration fields for Chains as listed: 
StorageDocDBMongoServerURL - simply allows supplying the value of MONGO_SERVER_URL as a field.
StorageDocDBMongoServerURLDir - This allows mounting the value of MONGO_SERVER_URL from a secret or other mechanisms.  These fields enable configuring the MongoDB server URL directly or specifying a directory where the URL can be dynamically updated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Following new configuration options are allowed in chains config:
1. signers.kms.kmsref.auth.token-dir - This field specifies the directory path to the file named KMS_AUTH_TOKEN that contains the KMS auth token. This is secure than specifying as plain text in field signers.kms.kmsref.auth.token.
2. storage.docdb.mongo-server-url - allows supplying the value of MONGO_SERVER_URL as a field. 
3. storage.docdb.mongo-server-url-dir - allows reading MONGO_SERVER_URL
from a file in the specified directory. This allows mounting the value of MONGO_SERVER_URL from a secret or other mechanisms. 

action required:  If utilizing the new field  signers.kms.kmsref.auth.token-dir then store KMS_AUTH_TOKEN value in a secret with key KMS_AUTH_TOKEN. Mount the secret at the path specified in signers.kms.auth.token-dir. This enables Tekton Chains to fetch the updated token value when the secret is updated.
To use the new field  storage.docdb.mongo-server-url-dir then store MONGO_SERVER_URL value in a secret with key MONGO_SERVER_URL. Mount the secret at the path specified in storage.docdb.mongo-server-url-dir This enables Tekton Chains to fetch the updated connection url value when the secret is updated.
Important Note: To reflect latest values from secret in case of rotation of secret values without recreating the pod, avoid using subPath in volume mounts.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note

Following new configuration options are allowed in chains config:
1.  signers.kms.kmsref.auth.token-dir - This field specifies the directory path to the file named KMS_AUTH_TOKEN that contains the KMS auth token. This is secure than specifying as plain text in field signers.kms.kmsref.auth.token.
2. storage.docdb.mongo-server-url - allows supplying the value of MONGO_SERVER_URL as a field. 
3. storage.docdb.mongo-server-url-dir - allows reading MONGO_SERVER_URL
from a file in the specified directory. This allows mounting the value of MONGO_SERVER_URL from a secret or other mechanisms. 

```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required:  If utilizing the new field  signers.kms.kmsref.auth.token-dir then store KMS_AUTH_TOKEN value in a secret with key KMS_AUTH_TOKEN. Mount the secret at the path specified in signers.kms.auth.token-dir. This enables Tekton Chains to fetch the updated token value when the secret is updated.

To use the new field  storage.docdb.mongo-server-url-dir then store MONGO_SERVER_URL value in a secret with key MONGO_SERVER_URL. Mount the secret at the path specified in storage.docdb.mongo-server-url-dir This enables Tekton Chains to fetch the updated connection url value when the secret is updated.

Important Note: To reflect latest values from secret in case of rotation of secret values without recreating the pod, avoid using subPath in volume mounts.
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
