### PR TITLE
Delete tekton hub db migration job pod during uninstall 

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektoninstallerset_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/tektoninstallerset_lifecycle.go
@@ -30,6 +30,7 @@ const (
 	WebhookReady         apis.ConditionType = "WebhooksReady"
 	ControllerReady      apis.ConditionType = "ControllersReady"
 	AllDeploymentsReady  apis.ConditionType = "AllDeploymentsReady"
+	JobsInstalled        apis.ConditionType = "JobsInstalled"
 )
 
 var (
@@ -42,6 +43,7 @@ var (
 		WebhookReady,
 		ControllerReady,
 		AllDeploymentsReady,
+		JobsInstalled,
 	)
 )
 
@@ -95,6 +97,10 @@ func (tis *TektonInstallerSetStatus) MarkControllerReady() {
 
 func (tis *TektonInstallerSetStatus) MarkAllDeploymentsReady() {
 	installerSetCondSet.Manage(tis).MarkTrue(AllDeploymentsReady)
+}
+
+func (tis *TektonInstallerSetStatus) MarkJobsInstalled() {
+	installerSetCondSet.Manage(tis).MarkTrue(JobsInstalled)
 }
 
 func (tis *TektonInstallerSetStatus) MarkNotReady(msg string) {
@@ -166,4 +172,12 @@ func (tis *TektonInstallerSetStatus) MarkAllDeploymentsNotReady(msg string) {
 		AllDeploymentsReady,
 		"Error",
 		"Deployment: %s", msg)
+}
+
+func (tis *TektonInstallerSetStatus) MarkJobsInstallationFailed(msg string) {
+	tis.MarkNotReady("Job resources installation failed")
+	installerSetCondSet.Manage(tis).MarkFalse(
+		JobsInstalled,
+		"Error",
+		"Install failed with message: %s", msg)
 }

--- a/pkg/apis/operator/v1alpha1/tektoninstallerset_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/tektoninstallerset_lifecycle_test.go
@@ -47,6 +47,7 @@ func TestTektonInstallerSetHappyPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tis, WebhookReady, t)
 	apistest.CheckConditionOngoing(tis, ControllerReady, t)
 	apistest.CheckConditionOngoing(tis, AllDeploymentsReady, t)
+	apistest.CheckConditionOngoing(tis, JobsInstalled, t)
 
 	// Install succeeds.
 	tis.MarkCRDsInstalled()
@@ -63,6 +64,9 @@ func TestTektonInstallerSetHappyPath(t *testing.T) {
 
 	tis.MarkStatefulSetReady()
 	apistest.CheckConditionSucceeded(tis, StatefulSetReady, t)
+
+	tis.MarkJobsInstalled()
+	apistest.CheckConditionSucceeded(tis, JobsInstalled, t)
 
 	// Initially Webhook will not be available
 	tis.MarkWebhookNotReady("waiting for pods")
@@ -94,6 +98,7 @@ func TestTektonInstallerSetErrorPath(t *testing.T) {
 	apistest.CheckConditionOngoing(tis, WebhookReady, t)
 	apistest.CheckConditionOngoing(tis, ControllerReady, t)
 	apistest.CheckConditionOngoing(tis, AllDeploymentsReady, t)
+	apistest.CheckConditionOngoing(tis, JobsInstalled, t)
 
 	// CrdsInstall succeeds
 	tis.MarkCRDsInstalled()
@@ -126,6 +131,10 @@ func TestTektonInstallerSetErrorPath(t *testing.T) {
 
 	tis.MarkAllDeploymentsReady()
 	apistest.CheckConditionSucceeded(tis, AllDeploymentsReady, t)
+
+	// JobsAvailable succeeds
+	tis.MarkJobsInstalled()
+	apistest.CheckConditionSucceeded(tis, JobsInstalled, t)
 
 	if ready := tis.IsReady(); !ready {
 		t.Errorf("tt.IsReady() = %v, want true", ready)

--- a/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
+++ b/pkg/reconciler/kubernetes/tektonhub/tektonhub.go
@@ -138,7 +138,6 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 	if err != nil {
 		return err
 	}
-
 	if err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 		DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: labelSelector,

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set_test.go
@@ -92,4 +92,5 @@ func markStatusReady(is *v1alpha1.TektonInstallerSet) {
 	is.Status.MarkWebhookReady()
 	is.Status.MarkAllDeploymentsReady()
 	is.Status.MarkReady()
+	is.Status.MarkJobsInstalled()
 }

--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -126,6 +126,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	// Update Status for NamespaceScope Condition
 	installerSet.Status.MarkNamespaceScopedResourcesInstalled()
 
+	// Install Job Resources
+	err = installer.EnsureJobResources()
+	if err != nil {
+		installerSet.Status.MarkJobsInstallationFailed(err.Error())
+		return r.handleError(err, installerSet)
+	}
+
+	// Update Status for Job Resources
+	installerSet.Status.MarkJobsInstalled()
+
 	// Install Deployment Resources
 	err = installer.EnsureDeploymentResources(ctx)
 	if err != nil {


### PR DESCRIPTION
# Changes

This patch fixes the issue regarding tekton hub db migration
job pod not getting deleted while uninstalling and upgrades.
Now tektoninstallerset reconciler handles job resources separately
and jobs are deleted with deletePropagationPolicy foreground so that
pod created by job will also be deleted.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Delete tekton hub db migration job pod during uninstall
```

