### PR TITLE
Fix chains default config

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
@@ -23,77 +23,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorFake "github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sFake "k8s.io/client-go/kubernetes/fake"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/logging"
 )
 
-func TestUpgradeChainProperties(t *testing.T) {
-	ctx := context.TODO()
-	operatorClient := operatorFake.NewSimpleClientset()
-	k8sClient := k8sFake.NewSimpleClientset()
-	logger := logging.FromContext(ctx).Named("unit-test")
-
-	// there is no tektonConfig CR available, returns error
-	err := upgradeChainProperties(ctx, logger, k8sClient, operatorClient, nil)
-	assert.Error(t, err)
-
-	// create tekconConfig CR
-	tc := &v1alpha1.TektonConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: v1alpha1.ConfigResourceName,
-		},
-		Spec: v1alpha1.TektonConfigSpec{
-			CommonSpec: v1alpha1.CommonSpec{
-				TargetNamespace: "foo",
-			},
-			Chain: v1alpha1.Chain{
-				ChainProperties: v1alpha1.ChainProperties{
-					BuilderID: "bar",
-				},
-			},
-		},
-	}
-	_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Create(ctx, tc, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	// there is no chains-config configMap, return no error
-	err = upgradeChainProperties(ctx, logger, k8sClient, operatorClient, nil)
-	assert.NoError(t, err)
-
-	// verify chains existing field, should not be empty
-	tc, err = operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, "", tc.Spec.Chain.ChainProperties.BuilderID)
-
-	// create a config map with values
-	config := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "chains-config",
-			Namespace: tc.Spec.GetTargetNamespace(),
-		},
-		Data: map[string]string{
-			"builder.id":           "123",
-			"transparency.enabled": "false",
-			"unknown_field":        "hello",
-		},
-	}
-	_, err = k8sClient.CoreV1().ConfigMaps(tc.Spec.GetTargetNamespace()).Create(ctx, config, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	// execute chains upgrade
-	err = upgradeChainProperties(ctx, logger, k8sClient, operatorClient, nil)
-	assert.NoError(t, err)
-
-	// verify chains with new configMap, map values should be updated
-	tc, err = operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, "123", tc.Spec.Chain.ChainProperties.BuilderID)
-	assert.Equal(t, v1alpha1.BoolValue("false"), tc.Spec.Chain.ChainProperties.TransparencyConfigEnabled)
-
-}
 func TestResetTektonConfigConditions(t *testing.T) {
 	ctx := context.TODO()
 	operatorClient := operatorFake.NewSimpleClientset()

--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -32,8 +32,7 @@ import (
 var (
 	// pre upgrade functions
 	preUpgradeFunctions = []upgradeFunc{
-		upgradeChainProperties,      // upgrade #1: upgrade chain properties
-		resetTektonConfigConditions, // upgrade #2: removes conditions from TektonConfig CR, clears outdated conditions
+		resetTektonConfigConditions, // upgrade #1: removes conditions from TektonConfig CR, clears outdated conditions
 	}
 
 	// post upgrade functions


### PR DESCRIPTION
* After making Chains install through TektonConfig, for backward compatibility to keep chains configured data preserved a mechanism was added to add the data from chains-config configMap to TektonConfig

* But if Chains is installed through TektonConfig and some default chains config, then those were getting over written because chains-config configMap was empty.

* Hence with this patch removing this support for backward compatibilty

Fixes: https://github.com/tektoncd/operator/issues/2160

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
