### PR TITLE
Add default config properties to chains configMap

### DIFF
--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -45,6 +45,14 @@ It is recommended to install the component through [TektonConfig](./TektonConfig
 ## Chain Config
 
 There are some fields which you can define on Tekton Chains CR to configure the behaviour of the chains
+If nothing is set, the operator sets these default properties:
+  artifacts.taskrun.format: in-toto
+  artifacts.taskrun.storage: oci
+  artifacts.oci.storage: oci
+  artifacts.oci.format: simplesigning
+  artifacts.pipelinerun.format: in-toto
+  artifacts.pipelinerun.storage: oci
+
 
 ### Properties (Mandatory)
 

--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -71,7 +71,6 @@ values then those will be set for the particular field.
 Details of the field can be found in [Tekton Chains Config][chains-config]
 
 Chains CR will look like this after providing all the fields.
-
 ```yaml
 apiVersion: operator.tekton.dev/v1alpha1
 kind: TektonChain
@@ -80,17 +79,18 @@ metadata:
 spec:
   disabled: false
   targetNamespace: tekton-pipelines
+  generateSigningSecret: true # default value: false
   controllerEnvs:
     - name: MONGO_SERVER_URL      # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller
       value: #value               # This can be provided same as env field of container
-  artifacts.taskrun.format: in-toto
-  artifacts.taskrun.storage: tekton,oci (comma separated values)
+  artifacts.taskrun.format: in-toto # default value: in-toto
+  artifacts.taskrun.storage: tekton,oci (comma separated values) # default value: oci
   artifacts.taskrun.signer: x509
   artifacts.oci.storage: oci (comma separated values)
   artifacts.oci.format: simplesigning
   artifacts.oci.signer: x509
-  artifacts.pipelinerun.format: in-toto
-  artifacts.pipelinerun.storage: tekton,oci (comma separated values)
+  artifacts.pipelinerun.format: in-toto # default value: in-toto
+  artifacts.pipelinerun.storage: tekton,oci (comma separated values) # default value: oci
   artifacts.pipelinerun.signer: x509
   artifacts.pipelinerun.enable-deep-inspection: #value (boolean - true/false)
   storage.gcs.bucket: #value
@@ -121,6 +121,14 @@ spec:
   transparency.enabled: #value (boolean - true/false)
   transparency.url: #value
 ```
+- `disabled` : if the value set as `true`, chains feature will be disabled (default: `false`)
+- `generateSigningSecret`: If set to true, the operator will generate an ECDSA key pair (x509.pem private key and x509-pub.pem public key) and store it in the "signing-secrets" secret in the "tekton-pipelines" namespace. the secret is used by chains controller to sign tekton artifacts(tasjruns, pipelineruns). it is important to mention that: 
+ * The user should retrieve and store in a safe place the x509-pub.pem public key to verify later artifact attestations.
+ * the operator doesnt provide any function about key rotation to limit potential security issues
+ * the operator doesnt provide any function for auditing key usage
+ * the operator doesnt provide any function for proper access control to the key
+
+
 
 [chains]:https://github.com/tektoncd/chains
 [chains-config]:https://github.com/tektoncd/chains/blob/main/docs/config.md

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -248,6 +248,7 @@ Example:
 chain:
   disabled: false                  # - `disabled` : if the value set as `true`, chains feature will be disabled (default: `false`)
   targetNamespace: tekton-pipelines
+  generateSigningSecret: true # default value: false
   controllerEnvs:
     - name: MONGO_SERVER_URL      # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller
       value: #value               # This can be provided same as env field of container

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -65,7 +65,11 @@ type TektonChainSpec struct {
 
 type Chain struct {
 	// enable or disable chains feature
-	Disabled        bool `json:"disabled"`
+	Disabled bool `json:"disabled"`
+
+	// generate signing key
+	GenerateSigningSecret bool `json:"generateSigningSecret,omitempty"`
+
 	ChainProperties `json:",inline"`
 	ControllerEnvs  []corev1.EnvVar `json:"controllerEnvs,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -953,3 +953,40 @@ func ReplaceNamespace(newNamespace string) mf.Transformer {
 		return nil
 	}
 }
+
+func AddSecretData(data map[string][]byte) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		// If input data is empty, do not transform
+		if len(data) == 0 {
+			return nil
+		}
+
+		// Check if the resource is a Secret
+		if u.GetKind() != "Secret" {
+			return nil
+		}
+
+		// Convert unstructured to Secret
+		secret := &corev1.Secret{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, secret)
+		if err != nil {
+			return err
+		}
+
+		// Update the Secret's data only if it is nil or empty
+		if secret.Data == nil || len(secret.Data) == 0 {
+			secret.Data = data
+
+			// Convert back to unstructured
+			unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+			if err != nil {
+				return err
+			}
+
+			// Update the original unstructured object
+			u.SetUnstructuredContent(unstrObj)
+		}
+
+		return nil
+	}
+}

--- a/pkg/reconciler/kubernetes/tektonchain/transform.go
+++ b/pkg/reconciler/kubernetes/tektonchain/transform.go
@@ -47,6 +47,9 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddDeploymentRestrictedPSA(),
 			AddControllerEnv(chainCR.Spec.Chain.ControllerEnvs),
 		}
+		if chainCR.Spec.GenerateSigningSecret {
+			extra = append(extra, common.AddSecretData(GenerateSigningSecrets(ctx)))
+		}
 		extra = append(extra, extension.Transformers(chainCR)...)
 		err := common.Transform(ctx, manifest, chainCR, extra...)
 		if err != nil {

--- a/pkg/reconciler/kubernetes/tektonchain/transform.go
+++ b/pkg/reconciler/kubernetes/tektonchain/transform.go
@@ -23,7 +23,17 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	"knative.dev/pkg/ptr"
 )
+
+var defaultChainProperties v1alpha1.ChainProperties = v1alpha1.ChainProperties{
+	ArtifactsTaskRunFormat:      "in-toto",
+	ArtifactsTaskRunStorage:     ptr.String("oci"),
+	ArtifactsPipelineRunFormat:  "in-toto",
+	ArtifactsPipelineRunStorage: ptr.String("oci"),
+	ArtifactsOCIFormat:          "simplesigning",
+	ArtifactsOCIStorage:         ptr.String("oci"),
+}
 
 func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
@@ -33,7 +43,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdChains),
 			common.DeploymentImages(chainImages),
 			common.AddConfiguration(chainCR.Spec.Config),
-			common.AddConfigMapValues(ChainsConfig, chainCR.Spec.Chain.ChainProperties),
+			common.AddConfigMapValues(ChainsConfig, chainCR.Spec.Chain.ChainProperties, defaultChainProperties),
 			common.AddDeploymentRestrictedPSA(),
 			AddControllerEnv(chainCR.Spec.Chain.ControllerEnvs),
 		}

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -62,10 +62,10 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		trns := extension.Transformers(instance)
 		extra := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdPipeline),
-			common.AddConfigMapValues(FeatureFlag, pipeline.Spec.PipelineProperties),
-			common.AddConfigMapValues(ConfigDefaults, pipeline.Spec.OptionalPipelineProperties),
-			common.AddConfigMapValues(ConfigMetrics, pipeline.Spec.PipelineMetricsProperties),
-			common.AddConfigMapValues(ResolverFeatureFlag, pipeline.Spec.Resolvers),
+			common.AddConfigMapValues(FeatureFlag, pipeline.Spec.PipelineProperties, nil),
+			common.AddConfigMapValues(ConfigDefaults, pipeline.Spec.OptionalPipelineProperties, nil),
+			common.AddConfigMapValues(ConfigMetrics, pipeline.Spec.PipelineMetricsProperties, nil),
+			common.AddConfigMapValues(ResolverFeatureFlag, pipeline.Spec.Resolvers, nil),
 			common.DeploymentImages(images),
 			common.InjectLabelOnNamespace(proxyLabel),
 			common.AddConfiguration(pipeline.Spec.Config),
@@ -73,7 +73,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.CopyConfigMap(hubResolverConfig, pipeline.Spec.HubResolverConfig),
 			common.CopyConfigMap(clusterResolverConfig, pipeline.Spec.ClusterResolverConfig),
 			common.CopyConfigMap(gitResolverConfig, pipeline.Spec.GitResolverConfig),
-			common.AddConfigMapValues(leaderElectionConfig, pipeline.Spec.Performance.PipelinePerformanceLeaderElectionConfig),
+			common.AddConfigMapValues(leaderElectionConfig, pipeline.Spec.Performance.PipelinePerformanceLeaderElectionConfig, nil),
 			updatePerformanceFlagsInDeployment(pipeline),
 			updateResolverConfigEnvironmentsInDeployment(pipeline),
 		}

--- a/pkg/reconciler/kubernetes/tektontrigger/transform.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/transform.go
@@ -40,8 +40,8 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		trns := extension.Transformers(trigger)
 		extra := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdTriggers),
-			common.AddConfigMapValues(ConfigDefaults, trigger.Spec.OptionalTriggersProperties),
-			common.AddConfigMapValues(FeatureFlag, trigger.Spec.TriggersProperties),
+			common.AddConfigMapValues(ConfigDefaults, trigger.Spec.OptionalTriggersProperties, nil),
+			common.AddConfigMapValues(FeatureFlag, trigger.Spec.TriggersProperties, nil),
 			common.DeploymentImages(triggerImages),
 			common.AddConfiguration(trigger.Spec.Config),
 		}

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -54,7 +54,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundles,
-		common.AddConfigMapValues(tektontrigger.ConfigDefaults, triggersData),
+		common.AddConfigMapValues(tektontrigger.ConfigDefaults, triggersData, nil),
 		replaceDeploymentArgs("-el-events", "enable"),
 	}
 }


### PR DESCRIPTION
# Changes
- Add chains option to allow users to opt-in to generate a chains signing secret and generate and ecdsa key pair as signing secret
- Addition of Sane Default Configuration Properties:
This update introduces sensible default configuration properties to the Chains controller, enhancing its initial setup and performance.
- Storage Backend Update:
Previously, the Chains controller used Tekton storage, where payloads and signatures were stored in the annotations of Tekton objects (such as TaskRuns and PipelineRuns). This approach significantly increased the size of these objects. To address this issue, this pull request changes the default storage backend to OCI, thereby reducing the object size and improving overall efficiency.

By default chains controller uses storage type tekton for its differents added annotation
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Adds sane default config properties to chains controller and switches the default chain storage backend from Tekton to OCI to optimize object storage management.

```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
