### PR TITLE
Add annotation to PaC route test

### DIFF
--- a/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-expected-additional-pac-route.yaml
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-expected-additional-pac-route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 600s
   labels:
     app: test-pac-controller
     app.kubernetes.io/component: controller

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-filter-manifest.yaml
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/testdata/test-filter-manifest.yaml
@@ -706,6 +706,8 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 600s
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default


### PR DESCRIPTION
With annotation used in PaC to control the route timeout, adding it also here in test to verify the annotation is not dropped in filtering.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
