### PR TITLE
Update triggers default configmap for FSGroup to handle restricted securityContext for Triggers

### DIFF
--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -31,6 +31,7 @@ import (
 type triggersProperties struct {
 	DefaultRunAsUser  *string `json:"default-run-as-user,omitempty"`
 	DefaultRunAsGroup *string `json:"default-run-as-group,omitempty"`
+	DefaultFSGroup    *string `json:"default-fs-group,omitempty"`
 }
 
 // Updating the default values of runAsUser and runAsGroup to an empty string
@@ -39,6 +40,7 @@ type triggersProperties struct {
 var triggersData = triggersProperties{
 	DefaultRunAsUser:  ptr.String(""),
 	DefaultRunAsGroup: ptr.String(""),
+	DefaultFSGroup:    ptr.String(""),
 }
 
 func OpenShiftExtension(ctx context.Context) common.Extension {


### PR DESCRIPTION
as part of this PR https://github.com/tektoncd/triggers/pull/1740 we've introduced an FSGroup setting to comply with restricted pod security standards for the podTemplate. 
But the default value `65532` won't work on OpenShift so setting  `""` by default for FSGroup

Remaining part of the work is done here https://github.com/tektoncd/operator/pull/2125

Signed-off-by: Savita Ashture <sashture@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
