### PR TITLE
Includes RBAC for results api to query openshift loki

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/logs-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/logs-rbac/rbac.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fine grained RBAC control mandated by OpenShift logging operator
+# For further deatils refer https://access.redhat.com/solutions/7060300
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-viewlogs
+rules:
+- verbs:
+  - get
+  apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - namespaces
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-api-logs-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-viewlogs
+subjects:
+- kind: ServiceAccount
+  name: tekton-results-api
+  namespace: tekton-pipelines
+
+---
+# RBAC permission that allows results query API
+# to query application logs from openshift logging stack
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-logs-viewer-app-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-results-api
+  namespace: tekton-pipelines

--- a/config/crs/kubernetes/result/operator_v1alpha1_result_cr.yaml
+++ b/config/crs/kubernetes/result/operator_v1alpha1_result_cr.yaml
@@ -21,7 +21,6 @@ spec:
   logs_api: true
   log_level: debug
   db_port: 5432
-  db_user: result
   db_host: tekton-results-postgres-service.tekton-pipelines.svc.cluster.local
   logging_pvc_name: tekton-logs
   logs_path: /logs

--- a/config/crs/openshift/result/operator_v1alpha1_result_cr.yaml
+++ b/config/crs/openshift/result/operator_v1alpha1_result_cr.yaml
@@ -21,7 +21,6 @@ spec:
   logs_api: true
   log_level: debug
   db_port: 5432
-  db_user: result
   db_host: tekton-results-postgres-service.openshift-pipelines.svc.cluster.local
   logging_pvc_name: tekton-logs
   logs_path: /logs

--- a/pkg/reconciler/openshift/tektonresult/extension_test.go
+++ b/pkg/reconciler/openshift/tektonresult/extension_test.go
@@ -55,6 +55,46 @@ func assertNoEror(t *testing.T, err error) {
 	}
 }
 
+func TestGetLoggingRBACManifest(t *testing.T) {
+
+	// Set expected manifest data in the testdata set with exact rbac manifest expected as mock data
+	testData := path.Join("testdata", "static/tekton-results/logs-rbac/rbac.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	//Assert that the first resource of expected manifest is ClusterRole
+	expectedCr := &rbac.ClusterRole{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expectedCr)
+	assert.NilError(t, err)
+
+	//Assert that the secound resource of expected manifest is ClusterRoleBinding
+	expectedCrb := &rbac.ClusterRoleBinding{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[1].Object, expectedCrb)
+	assert.NilError(t, err)
+
+	// Invoke the function to get the actual mainfests
+	returnedManifest, err := getloggingRBACManifest()
+	//Assert that the function executes without error
+	assert.NilError(t, err)
+
+	//Assert that the first resource of returned manifest is ClusterRole
+	returnedCr := &rbac.ClusterRole{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(returnedManifest.Resources()[0].Object, returnedCr)
+	assert.NilError(t, err)
+
+	//Assert that the first resource of returned manifest is ClusterRole
+	returnedCrb := &rbac.ClusterRoleBinding{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(returnedManifest.Resources()[1].Object, returnedCrb)
+	assert.NilError(t, err)
+
+	//Assert that cluster role name matches between expected and returned
+	assert.DeepEqual(t, expectedCr.GetName(), returnedCr.GetName())
+
+	//Assert that cluster role binding name matches between expected and returned
+	assert.DeepEqual(t, expectedCr.GetName(), returnedCr.GetName())
+
+}
+
 func Test_injecBoundSAToken(t *testing.T) {
 	testData := path.Join("testdata", "api-deployment.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))

--- a/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/logs-rbac/rbac.yaml
+++ b/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/logs-rbac/rbac.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fine grained RBAC control mandated by OpenShift logging operator
+# For further deatils refer https://access.redhat.com/solutions/7060300
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-viewlogs
+rules:
+- verbs:
+  - get
+  apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - namespaces
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-api-logs-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-viewlogs
+subjects:
+- kind: ServiceAccount
+  name: tekton-results-api
+  namespace: tekton-pipelines
+
+---
+# RBAC permission that allows results query API
+# to query application logs from openshift logging stack
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-logs-viewer-app-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-results-api
+  namespace: tekton-pipelines


### PR DESCRIPTION
# Changes

* If tekton-results logs_type is `LOKI` and preferred logging stack is OpenShift logging, additional cluster role and cluster role binding will be created. 
* pre-request: Users should ensure that for this scenario logging and loki operator are installed as pre-requisite in the cluster before installing the pipelines operator.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
If tekton-results logs_type is `LOKI` and preferred logging stack is OpenShift logging, additional cluster role and cluster role binding will be created. 
pre-request: Users should ensure that for this scenario logging and loki operator are installed as pre-requisite in the cluster before installing the pipelines operator.
```