### PR TITLE
Fix installerset issue for resolver task and stepaction

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/resolver_task.go
+++ b/pkg/reconciler/openshift/tektonaddon/resolver_task.go
@@ -26,12 +26,12 @@ import (
 )
 
 func (r *Reconciler) EnsureResolverTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
-	manifest := r.resolverTaskManifest
+	manifest := *r.resolverTaskManifest
 	return r.ensureCustomSet(ctx, enable, ResolverTaskInstallerSet, ta, manifest, r.getTransformer(ctx, KindTask, false))
 }
 
 func (r *Reconciler) EnsureResolverStepAction(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
-	manifest := r.resolverStepActionManifest
+	manifest := *r.resolverStepActionManifest
 	return r.ensureCustomSet(ctx, enable, ResolverStepActionInstallerSet, ta, manifest, r.getTransformer(ctx, KindStepAction, false))
 }
 
@@ -57,9 +57,9 @@ func (r *Reconciler) getTransformer(ctx context.Context, kind string, isVersione
 }
 
 func (r *Reconciler) ensureCustomSet(ctx context.Context, enable, installerSetName string, ta *v1alpha1.TektonAddon,
-	manifest *mf.Manifest, tfs []mf.Transformer) error {
+	manifest mf.Manifest, tfs []mf.Transformer) error {
 	if enable == "true" {
-		if err := r.installerSetClient.CustomSet(ctx, ta, installerSetName, manifest, filterAndTransformResolverTask(tfs), nil); err != nil {
+		if err := r.installerSetClient.CustomSet(ctx, ta, installerSetName, &manifest, filterAndTransformResolverTask(tfs), nil); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/reconciler/openshift/tektonaddon/resolver_task_versioned.go
+++ b/pkg/reconciler/openshift/tektonaddon/resolver_task_versioned.go
@@ -24,19 +24,19 @@ import (
 )
 
 func (r *Reconciler) EnsureVersionedResolverTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
-	manifest := r.resolverTaskManifest
+	manifest := *r.resolverTaskManifest
 	return r.ensureVersionedCustomSet(ctx, enable, VersionedResolverTaskInstallerSet, installerSetNameForResolverTasks, ta, manifest, r.getTransformer(ctx, KindTask, true))
 }
 
 func (r *Reconciler) EnsureVersionedResolverStepAction(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
-	manifest := r.resolverStepActionManifest
+	manifest := *r.resolverStepActionManifest
 	return r.ensureVersionedCustomSet(ctx, enable, VersionedResolverStepActionInstallerSet, installerSetNameForResolverStepAction, ta, manifest, r.getTransformer(ctx, KindStepAction, true))
 }
 
 func (r *Reconciler) ensureVersionedCustomSet(ctx context.Context, enable, installerSetType, installerSetName string, ta *v1alpha1.TektonAddon,
-	manifest *mf.Manifest, tfs []mf.Transformer) error {
+	manifest mf.Manifest, tfs []mf.Transformer) error {
 	if enable == "true" {
-		if err := r.installerSetClient.VersionedTaskSet(ctx, ta, manifest, filterAndTransformResolverTask(tfs),
+		if err := r.installerSetClient.VersionedTaskSet(ctx, ta, &manifest, filterAndTransformResolverTask(tfs),
 			installerSetType, installerSetName); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Changes
Issue
```
$ oc get tektoninstallerset
NAME                                             READY   REASON
addon-custom-clustertask-hfbf9                   True    
addon-custom-communityclustertask-vpwb7          True    
addon-custom-consolecli-hjq86                    True    
addon-custom-openshiftconsole-kgmt6              True    
addon-custom-pipelinestemplate-rwqmr             True    
addon-custom-resolverstepaction-dkkm5            False   Install failed with message: StepAction.tekton.dev "git-clone-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0" is invalid: metadata.name: Invalid value: "git-clone-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0": must be no more than 253 characters
addon-custom-resolvertask-cl7tc                  False   Install failed with message: Task.tekton.dev "buildah-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0" is invalid: metadata.name: Invalid value: "buildah-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0-1-16-0": must be no more than 253 characters
addon-custom-triggersresources-lhfms             True    
addon-versioned-clustertasks-1.16-mj5pg          True    
addon-versioned-resolverstepactions-1.16-597rq   False   Install failed with message: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name
addon-versioned-resolvertasks-1.16-cxm5g         False   Install failed with message: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
