### PR TITLE
fix(pipelines-scc): add ephemeral volumes

### DIFF
--- a/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
+++ b/cmd/openshift/operator/kodata/openshift/00-prereconcile/openshift-pipelines-scc.yaml
@@ -34,9 +34,10 @@ supplementalGroups:
   type: RunAsAny
 volumes:
 - configMap
+- csi
 - downwardAPI
 - emptyDir
+- ephemeral
 - persistentVolumeClaim
 - projected
 - secret
-- csi


### PR DESCRIPTION
# Changes
Adding Ephermal Volumes to Piplines-SCC

This is included in the restricted-v2 scc: 
- https://github.com/openshift/cluster-kube-apiserver-operator/pull/1380
- https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/bindata/bootkube/scc-manifests/0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml#L42C1-L49C9



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
`pipelines-scc` supports `ephemeral` volumes
```
