### PR TITLE
make rbac max concurrent calls configurable

### DIFF
--- a/pkg/reconciler/openshift/const.go
+++ b/pkg/reconciler/openshift/const.go
@@ -5,4 +5,8 @@ const (
 	OperandOpenShiftPipelineAsCode  = "openshift-pipeline-as-code"
 	// NamespaceSCCAnnotation is used to set SCC for a given namespace
 	NamespaceSCCAnnotation = "operator.tekton.dev/scc"
+
+	// RbacProvisioningMaxConcurrentCalls is used to set a go routine pool size when
+	// we reconcile namespaces and do rbac provisonning
+	RbacProvisioningMaxConcurrentCalls = "OCP_RBAC_MAX_CONCURRENT_CALLS"
 )

--- a/pkg/reconciler/openshift/tektonconfig/init.go
+++ b/pkg/reconciler/openshift/tektonconfig/init.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	defaultRbacMaxConcurrentCalls = 20
+	minRbacMaxConcurrentCalls     = 1
+	maxRbacMaxConcurrentCalls     = 50
+)
+
+var rbacMaxConcurrentCalls int
+
+func init() {
+	rbacMaxConcurrentCalls = loadRbacMaxConcurrentCalls()
+}
+
+func loadRbacMaxConcurrentCalls() int {
+	logger := logging.FromContext(context.TODO())
+	envValue := os.Getenv(openshift.RbacProvisioningMaxConcurrentCalls)
+	if envValue == "" {
+		return defaultRbacMaxConcurrentCalls
+	}
+	parsedValue, err := strconv.Atoi(envValue)
+	if err != nil {
+		logger.Infof("Failed to parse %s, setting to default: %d", openshift.RbacProvisioningMaxConcurrentCalls, defaultRbacMaxConcurrentCalls)
+		return defaultRbacMaxConcurrentCalls
+	}
+	if parsedValue < minRbacMaxConcurrentCalls || parsedValue > maxRbacMaxConcurrentCalls {
+		logger.Infof("Invalid value %d for %s. Valid range is [%d, %d]. Setting to default: %d",
+			parsedValue,
+			openshift.RbacProvisioningMaxConcurrentCalls,
+			minRbacMaxConcurrentCalls,
+			maxRbacMaxConcurrentCalls,
+			defaultRbacMaxConcurrentCalls)
+		return defaultRbacMaxConcurrentCalls
+	}
+
+	return parsedValue
+}
+
+func init() {
+	rbacMaxConcurrentCalls = loadRbacMaxConcurrentCalls()
+}
+
+func getRBACMaxCalls() int {
+	return rbacMaxConcurrentCalls
+}

--- a/pkg/reconciler/openshift/tektonconfig/init_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/init_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
+)
+
+func TestLoadRbacMaxConcurrentCalls(t *testing.T) {
+	for _, tt := range []struct {
+		desc          string
+		envValue      string
+		expectedValue int
+	}{
+		{"empty envValue", "", defaultRbacMaxConcurrentCalls},
+		{"valid envValue", "10", 10},
+		{"below min envValue", "-1", defaultRbacMaxConcurrentCalls},
+		{"above max envValye", "60", defaultRbacMaxConcurrentCalls},
+		{"invalid envValue", "xyz", defaultRbacMaxConcurrentCalls},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			os.Setenv(openshift.RbacProvisioningMaxConcurrentCalls, tt.envValue)
+			result := loadRbacMaxConcurrentCalls()
+			require.Equal(t, result, tt.expectedValue)
+		})
+	}
+}

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -67,8 +67,6 @@ const (
 	rbacInstallerSetNamePrefix  = "rhosp-rbac-"
 	rbacParamName               = "createRbacResource"
 	serviceAccountCreationLabel = "openshift-pipelines.tekton.dev/sa-created"
-
-	rbacMaxConcurrentCalls = 20
 )
 
 var (
@@ -402,7 +400,7 @@ func (r *rbac) createResources(ctx context.Context) error {
 	var wg sync.WaitGroup
 
 	// Start worker pool
-	for i := 0; i < rbacMaxConcurrentCalls; i++ {
+	for i := 0; i < getRBACMaxCalls(); i++ {
 		wg.Add(1)
 		go r.nsWorker(ctx, &wg, jobs, errCh)
 	}

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -38,10 +38,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/wait"
 	nsV1 "k8s.io/client-go/informers/core/v1"
 	rbacV1 "k8s.io/client-go/informers/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
 	"knative.dev/pkg/logging"
 )
 
@@ -389,52 +391,69 @@ func (r *rbac) createResources(ctx context.Context) error {
 	}
 	logger.Debugf("RBAC: found %d namespaces to be reconciled", len(namespacesToBeReconciled))
 
+	// Check and create clusterrole clusterInterceptors if doesnt exist
+	if err := r.createClusterRole(ctx); err != nil {
+		logger.Error(err)
+		return err
+	}
+
 	// remove and update namespaces from Cluster Interceptors
 	if err := r.removeAndUpdateNSFromCI(ctx); err != nil {
 		logger.Error(err)
 		return err
 	}
+	if len(namespacesToBeReconciled) > 0 {
+		jobs := make(chan corev1.Namespace, len(namespacesToBeReconciled))
+		errCh := make(chan error, len(namespacesToBeReconciled))
+		var wg sync.WaitGroup
 
-	jobs := make(chan corev1.Namespace, len(namespacesToBeReconciled))
-	errCh := make(chan error, len(namespacesToBeReconciled))
-	var wg sync.WaitGroup
-
-	// Start worker pool
-	for i := 0; i < getRBACMaxCalls(); i++ {
-		wg.Add(1)
-		go r.nsWorker(ctx, &wg, jobs, errCh)
-	}
-
-	// Send namespaces to be processed
-	for _, ns := range namespacesToBeReconciled {
-		jobs <- ns
-	}
-	close(jobs) // Close the jobs channel after sending all namespaces
-
-	wg.Wait()
-	close(errCh) // Close the errCh after all workers have finished
-
-	// Collect errors from the channel
-	var errs []error
-	for err := range errCh {
-		if err != nil {
-			errs = append(errs, err)
+		nWorkers := getRBACMaxCalls()
+		if len(namespacesToBeReconciled) < getRBACMaxCalls() {
+			nWorkers = len(namespacesToBeReconciled)
 		}
-	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("errors occurred in createResource during processing namespaces")
-	}
+		logger.Infof("Starting %d goroutines for namespace rbac reconcile", nWorkers)
 
+		// Start worker pool
+		for i := 0; i < nWorkers; i++ {
+			wg.Add(1)
+			go r.nsWorker(ctx, &wg, jobs, errCh)
+		}
+
+		// Send namespaces to be processed
+		for _, ns := range namespacesToBeReconciled {
+			jobs <- ns
+		}
+		close(jobs)
+
+		wg.Wait()
+		close(errCh)
+
+		// Collect errors from the channel
+		var errs []error
+		for err := range errCh {
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if len(errs) > 0 {
+			return fmt.Errorf("errors occurred in createResource during namespaces rbac reconcile")
+		}
+	} else {
+		logger.Info("No namespaces to be reconciled, skipping worker creation")
+	}
 	return nil
 }
 
 func (r *rbac) nsWorker(ctx context.Context, wg *sync.WaitGroup, jobs <-chan corev1.Namespace, errCh chan<- error) {
 	defer wg.Done()
 	for ns := range jobs {
+		logging.FromContext(ctx).Infof("Processing namespace %s", ns.Name)
 		if err := r.processResourcesForSingleNamespace(ctx, ns); err != nil {
 			errCh <- fmt.Errorf("error processing namespace %s: %w", ns.Name, err)
 		}
+		logging.FromContext(ctx).Infof("Finished processing namespace %s", ns.Name)
 	}
 }
 
@@ -443,50 +462,56 @@ func (r *rbac) processResourcesForSingleNamespace(ctx context.Context, ns corev1
 	baseLogger := logging.FromContext(ctx)
 	logger := baseLogger.Desugar().With(zap.String("namespace", ns.Name)).Sugar()
 
-	var hasError bool
+	var withError bool
 
-	logger.Infof("ensure ca bundle configmap in this namespace")
+	logger.Infof("ensure ca bundle configmap in namespace %s", ns.Name)
 	if err := r.ensureCABundles(ctx, &ns); err != nil {
-		hasError = true
-		logger.Errorf("failed to ensure ca bundles presence in this namespace, %v", err)
+		withError = true
+		logger.Errorf("failed to ensure ca bundles presence namespace %s, %v", ns.Name, err)
 	}
 
-	logger.Infof("ensures default pipelines service account in this namespace")
+	logger.Infof("ensures default pipelines service account namespace %s", ns.Name)
 	sa, err := r.ensureSA(ctx, &ns)
 	if err != nil {
-		hasError = true
-		logger.Errorf("failed to ensure default SA in this namespace %v", err)
+		withError = true
+		logger.Errorf("failed to ensure serviceaccount pipeline namespace %s, %v", ns.Name, err)
 	}
 
 	// If "operator.tekton.dev/scc" exists in the namespace, then bind
 	// that SCC to the SA
 	err = r.handleSCCInNamespace(ctx, &ns)
 	if err != nil {
-		hasError = true
-		logger.Errorf("failed to bind scc to this namespace %v", err)
+		withError = true
+		logger.Errorf("failed to bind scc to namespace %s, %v", ns.Name, err)
 	}
+	if sa != nil {
+		// We use a namespace scoped Role when SCC annotation is present, and
+		// a cluster scoped ClusterRole when the default SCC is used
+		roleRef := r.getSCCRoleInNamespace(&ns)
+		if roleRef != nil {
+			if err := r.ensurePipelinesSCCRoleBinding(ctx, sa, roleRef); err != nil {
+				withError = true
+				logger.Errorf("failed to create Pipeline Scc Role Binding in namespace %s, %v", ns.Name, err)
+			}
+		}
 
-	// We use a namespace scoped Role when SCC annotation is present, and
-	// a cluster scoped ClusterRole when the default SCC is used
-	roleRef := r.getSCCRoleInNamespace(&ns)
-	if err := r.ensurePipelinesSCCRoleBinding(ctx, sa, roleRef); err != nil {
-		hasError = true
-		logger.Errorf("failed to create Pipeline Scc Role Binding in this namespace %v", err)
-	}
+		if err := r.ensureRoleBindings(ctx, sa); err != nil {
+			withError = true
+			logger.Errorf("failed to create rolebinding in namespace %s, %v", ns.Name, err)
+		}
 
-	if err := r.ensureRoleBindings(ctx, sa); err != nil {
-		hasError = true
-		logger.Errorf("failed to create rolebinding in this namespace %v", err)
-	}
-
-	if err := r.ensureClusterRoleBindings(ctx, sa); err != nil {
-		hasError = true
-		logger.Errorf("failed to create clusterrolebinding in this namespace %v", err)
+		if err := r.ensureClusterRoleBindings(ctx, sa); err != nil {
+			withError = true
+			logger.Errorf("failed to create clusterrolebinding in namespace %s, %v", ns.Name, err)
+		}
+	} else {
+		withError = true
+		logger.Errorf("Could not create servicaccount %s for namespace %s", "pipeline", ns.Name)
 	}
 
 	// if No error add `openshift-pipelines.tekton.dev/namespace-reconcile-version` label to namespace
 	// so that rbac won't loop on it again
-	if !hasError {
+	if !withError {
 		logger.Infof("namespace %s sucessfully reconciled. Adding label namespace-reconcile-version to mark it as reconciled", ns.Name)
 		nsLabels := ns.GetLabels()
 		if len(nsLabels) == 0 {
@@ -651,7 +676,7 @@ func (r *rbac) ensureSA(ctx context.Context, ns *corev1.Namespace) (*corev1.Serv
 		return nil, err
 	}
 	if err != nil && errors.IsNotFound(err) {
-		logger.Info("creating sa ", pipelineSA, " ns", ns.Name)
+		logger.Info("creating sa ", pipelineSA, " for ns:", ns.Name)
 		return createSA(ctx, saInterface, ns.Name, *r.tektonConfig)
 	}
 
@@ -955,20 +980,26 @@ func (r *rbac) ensureClusterRoleBindings(ctx context.Context, sa *corev1.Service
 	logger := logging.FromContext(ctx)
 
 	rbacClient := r.kubeClientSet.RbacV1()
-	logger.Info("finding cluster-role ", clusterInterceptors)
-	if _, err := rbacClient.ClusterRoles().Get(ctx, clusterInterceptors, metav1.GetOptions{}); errors.IsNotFound(err) {
-		if e := r.createClusterRole(ctx); e != nil {
-			return e
-		}
-	}
-
 	logger.Info("finding cluster-role-binding ", clusterInterceptors)
 
+	// Fetch the ClusterRoleBinding
 	viewCRB, err := rbacClient.ClusterRoleBindings().Get(ctx, clusterInterceptors, metav1.GetOptions{})
-
 	if err == nil {
 		logger.Infof("found clusterrolebinding %s", viewCRB.Name)
-		return r.updateClusterRoleBinding(ctx, viewCRB, sa)
+
+		// Retry the update operation on conflict
+		backoff := wait.Backoff{
+			Steps:    10,                     // Number of retry attempts
+			Duration: 300 * time.Millisecond, // Initial backoff duration
+			Factor:   1.5,                    // Factor to increase backoff
+			Jitter:   0.2,                    // Jitter to avoid thundering herd
+		}
+
+		err = retry.OnError(backoff, errors.IsConflict, func() error {
+			return r.updateClusterRoleBinding(ctx, viewCRB, sa)
+		})
+
+		return err
 	}
 
 	if errors.IsNotFound(err) {
@@ -1100,25 +1131,28 @@ func (r *rbac) createClusterRoleBinding(ctx context.Context, sa *corev1.ServiceA
 
 func (r *rbac) createClusterRole(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
-
-	logger.Info("create new clusterrole ", clusterInterceptors)
 	rbacClient := r.kubeClientSet.RbacV1()
+	logger.Info("finding cluster-role ", clusterInterceptors)
+	if _, err := rbacClient.ClusterRoles().Get(ctx, clusterInterceptors, metav1.GetOptions{}); errors.IsNotFound(err) {
+		logger.Info("cluser-role %s is not found, creating new clusterrole %s", clusterInterceptors, clusterInterceptors)
 
-	cr := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            clusterInterceptors,
-			OwnerReferences: []metav1.OwnerReference{r.ownerRef},
-		},
-		Rules: []rbacv1.PolicyRule{{
-			APIGroups: []string{"triggers.tekton.dev"},
-			Resources: []string{"clusterinterceptors"},
-			Verbs:     []string{"get", "list", "watch"},
-		}},
-	}
+		cr := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            clusterInterceptors,
+				OwnerReferences: []metav1.OwnerReference{r.ownerRef},
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{"triggers.tekton.dev"},
+				Resources: []string{"clusterinterceptors"},
+				Verbs:     []string{"get", "list", "watch"},
+			}},
+		}
 
-	if _, err := rbacClient.ClusterRoles().Create(ctx, cr, metav1.CreateOptions{}); err != nil {
-		logger.Error(err, "creation of "+clusterInterceptors+" clusterrole failed")
-		return err
+		if _, err := rbacClient.ClusterRoles().Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+			logger.Error(err, "creation of "+clusterInterceptors+" clusterrole failed")
+			return err
+		}
+
 	}
 	return nil
 }

--- a/pkg/reconciler/openshift/tektonconfig/rbac_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac_test.go
@@ -160,7 +160,7 @@ func TestCreateResources(t *testing.T) {
 			},
 			iSet: &v1alpha1.TektonInstallerSet{ObjectMeta: metav1.ObjectMeta{Name: "rhosp-rbac-001", Labels: map[string]string{v1alpha1.CreatedByKey: createdByValue, v1alpha1.InstallerSetType: componentNameRBAC}, Annotations: map[string]string{
 				v1alpha1.ReleaseVersionKey: "devel", v1alpha1.TargetNamespaceKey: tc.Spec.TargetNamespace}}, Spec: v1alpha1.TektonInstallerSetSpec{}},
-			err: fmt.Errorf("errors occurred in createResource during processing namespaces"),
+			err: fmt.Errorf("errors occurred in createResource during namespaces rbac reconcile"),
 		},
 		{
 			desc: "existing installer set, all ok",


### PR DESCRIPTION
# Changes
Improvements for Namespace RBAC Reconciliation on OpenShift

- Pre-Reconciliation Check: Implement a check to verify if there are any namespaces to reconcile. If none are found, cancel the reconciliation process early.
- Adjust Worker Count: Modify the number of workers handling namespace reconciliation to optimize performance.
- Retry Mechanism for ClusterRoleBinding Updates: Introduce a retry mechanism for updating shared resources like ClusterRoleBinding to prevent job failures caused by concurrent update conflicts.
- Environment Variable for Concurrency Control: Add an environment variable `OCP_RBAC_MAX_CONCURRENT_CALLS` to configure the maximum number of concurrent calls for namespace RBAC reconciliation. This is particularly useful for clusters with a large number of namespaces.
- default concurrent calls: 20
- supported range: 1 to 50

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add an environment variable OCP_RBAC_MAX_CONCURRENT_CALLS to configure the maximum number of concurrent calls for namespace RBAC reconciliation.
This is particularly useful for clusters with a large number of namespaces.
```
