### PR TITLE
Add resolverStepActions flag to enable/disable stepaction

### DIFF
--- a/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
@@ -29,6 +29,8 @@ spec:
       value: "true"
     - name: resolverTasks
       value: "true"
+    - name: resolverStepActions
+      value: "true"
   params:
   - name: createRbacResource
     value: "true"

--- a/docs/TektonAddon.md
+++ b/docs/TektonAddon.md
@@ -28,6 +28,8 @@ spec:
     value: "true"
   - name: resolverTasks
     value: "true"
+  - name: resolverStepActions
+    value: "true"
 ```
 You can install this component using [TektonConfig](./TektonConfig.md) by choosing appropriate `profile`.
 
@@ -39,6 +41,7 @@ Available params are
 - `clusterTasks` (Default: `true`)
 - `pipelineTemplates` (Default: `true`)
 - `resolverTasks` (Default: `true`)
+- `resolverStepActions` (Default: `true`)
 
 User can disable the installation of resources by changing the value to `false`.
 

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -345,6 +345,8 @@ addon:
       value: "true"
     - name: "resolverTasks"
       value: "true"
+    - name: "resolverStepActions"
+      value: "true"
 ```
 
 **NOTE**: TektonAddon is currently available for OpenShift Platform only. Enabling this for Kubernetes platform is in roadmap

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -37,6 +37,7 @@ const (
 	PipelineTemplatesParam = "pipelineTemplates"
 	CommunityClusterTasks  = "communityClusterTasks"
 	ResolverTasks          = "resolverTasks"
+	ResolverStepActions    = "resolverStepActions"
 
 	// Hub Params
 	EnableDevconsoleIntegrationParam = "enable-devconsole-integration"
@@ -114,6 +115,7 @@ var (
 		PipelineTemplatesParam: defaultParamValue,
 		CommunityClusterTasks:  defaultParamValue,
 		ResolverTasks:          defaultParamValue,
+		ResolverStepActions:    defaultParamValue,
 	}
 
 	HubParams = map[string]ParamValue{

--- a/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
@@ -39,7 +39,7 @@ func Test_AddonSetDefaults_DefaultParamsWithValues(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 4, len(ta.Spec.Params))
+	assert.Equal(t, 5, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[ClusterTasksParam]
@@ -70,7 +70,7 @@ func Test_AddonSetDefaults_ClusterTaskIsFalse(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 4, len(ta.Spec.Params))
+	assert.Equal(t, 5, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[PipelineTemplatesParam]

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -90,7 +90,7 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	tc.SetDefaults(context.TODO())
-	if len(tc.Spec.Addon.Params) != 4 {
+	if len(tc.Spec.Addon.Params) != 5 {
 		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
 	}
 }

--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -136,6 +136,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 	ctVal, _ := findValue(ta.Spec.Params, v1alpha1.ClusterTasksParam)
 	cctVal, _ := findValue(ta.Spec.Params, v1alpha1.CommunityClusterTasks)
 	rtVal, _ := findValue(ta.Spec.Params, v1alpha1.ResolverTasks)
+	rsaVal, _ := findValue(ta.Spec.Params, v1alpha1.ResolverStepActions)
 
 	if ptVal == "true" && ctVal == "false" {
 		ta.Status.MarkNotReady("pipelineTemplates cannot be true if clusterTask is false")
@@ -169,13 +170,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ta *v1alpha1.TektonAddon
 		logger.Error(errorMsg)
 	}
 
-	if err := r.EnsureResolverStepAction(ctx, rtVal, ta); err != nil {
+	if err := r.EnsureResolverStepAction(ctx, rsaVal, ta); err != nil {
 		ready = false
 		errorMsg = fmt.Sprintf("namespaced stepactions not yet ready: %v", err)
 		logger.Error(errorMsg)
 	}
 
-	if err := r.EnsureVersionedResolverStepAction(ctx, rtVal, ta); err != nil {
+	if err := r.EnsureVersionedResolverStepAction(ctx, rsaVal, ta); err != nil {
 		ready = false
 		errorMsg = fmt.Sprintf("versioned namespaced stepactions not yet ready:  %v", err)
 		logger.Error(errorMsg)


### PR DESCRIPTION
Instead of using resolverTasks flag added new resolverStepActions flag to enable or disable stepactions separately

Signed-off-by: Savita Ashture <sashture@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
