### PR TITLE
[main] ignore enable-tekton-oci-bundles feature flag

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -61,7 +61,6 @@ The TektonConfig CR provides the following features
       enable-param-enum: false
       enable-provenance-in-status: true
       enable-step-actions: false
-      enable-tekton-oci-bundles: false
       enforce-nonfalsifiability: none
       keep-pod-on-cancel: false
       max-result-size: 4096
@@ -218,7 +217,6 @@ pipeline:
   disable-working-directory-overwrite: true
   enable-api-fields: stable
   enable-custom-tasks: false
-  enable-tekton-oci-bundles: false
   metrics.pipelinerun.duration-type: histogram
   metrics.pipelinerun.level: pipelinerun
   metrics.taskrun.duration-type: histogram

--- a/docs/TektonPipeline.md
+++ b/docs/TektonPipeline.md
@@ -35,7 +35,6 @@ spec:
   enable-param-enum: false
   enable-provenance-in-status: true
   enable-step-actions: false
-  enable-tekton-oci-bundles: false
   enforce-nonfalsifiability: none
   keep-pod-on-cancel: false
   max-result-size: 4096
@@ -111,12 +110,6 @@ injected sidecars, setting this option to false can lead to unexpected behavior.
     Setting this flag to "true" will require that any Git SSH Secret offered to Tekton must have known_hosts included.
 
     See more info [here](https://github.com/tektoncd/pipeline/issues/2981).
-
-
-- `enable-tekton-oci-bundles` (Default: `false`)
-
-    Setting this flag to "true" enables the use of Tekton OCI bundle. This is an experimental feature and thus should
-still be considered an alpha feature.
 
 
 - `enable-custom-tasks` (Default: `false`)

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -69,8 +69,7 @@ func Test_SetDefaults_Pipeline_Properties(t *testing.T) {
 	}
 
 	tc.SetDefaults(context.TODO())
-	if *tc.Spec.Pipeline.SendCloudEventsForRuns != true ||
-		*tc.Spec.Pipeline.EnableTektonOciBundles != false {
+	if *tc.Spec.Pipeline.SendCloudEventsForRuns != true {
 		t.Error("Setting default failed for TektonConfig (spec.pipeline.pipelineProperties)")
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -48,9 +48,12 @@ func (p *Pipeline) setDefaults() {
 	if p.RequireGitSshSecretKnownHosts == nil {
 		p.RequireGitSshSecretKnownHosts = ptr.Bool(config.DefaultRequireGitSSHSecretKnownHosts)
 	}
-	if p.EnableTektonOciBundles == nil {
-		p.EnableTektonOciBundles = ptr.Bool(config.DefaultEnableTektonOciBundles)
-	}
+
+	// not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+	// this field is removed from pipeline component
+	// keeping here to maintain the API compatibility
+	p.EnableTektonOciBundles = nil
+
 	if p.EnableCustomTasks == nil {
 		// EnableCustomTask is always enable
 		p.EnableCustomTasks = ptr.Bool(true)

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -93,7 +93,6 @@ type PipelineProperties struct {
 	AwaitSidecarReadiness                    *bool  `json:"await-sidecar-readiness,omitempty"`
 	RunningInEnvironmentWithInjectedSidecars *bool  `json:"running-in-environment-with-injected-sidecars,omitempty"`
 	RequireGitSshSecretKnownHosts            *bool  `json:"require-git-ssh-secret-known-hosts,omitempty"`
-	EnableTektonOciBundles                   *bool  `json:"enable-tekton-oci-bundles,omitempty"`
 	EnableCustomTasks                        *bool  `json:"enable-custom-tasks,omitempty"`
 	EnableApiFields                          string `json:"enable-api-fields,omitempty"`
 	EmbeddedStatus                           string `json:"embedded-status,omitempty"`
@@ -102,6 +101,12 @@ type PipelineProperties struct {
 	// This field will be removed, see https://github.com/tektoncd/operator/issues/1497
 	// originally this field was removed in https://github.com/tektoncd/operator/pull/1481
 	// there is no use with this field, just adding back to unblock the upgrade
+
+	// not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+	// this field is removed from pipeline component
+	// keeping here to maintain the API compatibility
+	EnableTektonOciBundles *bool `json:"enable-tekton-oci-bundles,omitempty"`
+
 	VerificationMode          string `json:"verification-mode,omitempty"`
 	VerificationNoMatchPolicy string `json:"trusted-resources-verification-no-match-policy,omitempty"`
 	EnableProvenanceInStatus  *bool  `json:"enable-provenance-in-status,omitempty"`

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -943,11 +943,6 @@ func (in *PipelineProperties) DeepCopyInto(out *PipelineProperties) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnableTektonOciBundles != nil {
-		in, out := &in.EnableTektonOciBundles, &out.EnableTektonOciBundles
-		*out = new(bool)
-		**out = **in
-	}
 	if in.EnableCustomTasks != nil {
 		in, out := &in.EnableCustomTasks, &out.EnableCustomTasks
 		*out = new(bool)
@@ -955,6 +950,11 @@ func (in *PipelineProperties) DeepCopyInto(out *PipelineProperties) {
 	}
 	if in.SendCloudEventsForRuns != nil {
 		in, out := &in.SendCloudEventsForRuns, &out.SendCloudEventsForRuns
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableTektonOciBundles != nil {
+		in, out := &in.EnableTektonOciBundles, &out.EnableTektonOciBundles
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -515,8 +515,7 @@ func TestAddConfigMapValues_PipelineProperties(t *testing.T) {
 	assertNoEror(t, err)
 
 	prop := v1alpha1.PipelineProperties{
-		EnableTektonOciBundles: ptr.Bool(true),
-		EnableApiFields:        "stable",
+		EnableApiFields: "stable",
 	}
 
 	manifest, err = manifest.Transform(AddConfigMapValues("test1", prop))
@@ -527,7 +526,6 @@ func TestAddConfigMapValues_PipelineProperties(t *testing.T) {
 	assertNoEror(t, err)
 
 	assert.Equal(t, cm.Data["foo"], "bar")
-	assert.Equal(t, cm.Data["enable-tekton-oci-bundles"], "true")
 	assert.Equal(t, cm.Data["enable-api-fields"], "stable")
 }
 

--- a/pkg/reconciler/kubernetes/tektonpipeline/testdata/tektonpipeline-feature-flags-base.yaml
+++ b/pkg/reconciler/kubernetes/tektonpipeline/testdata/tektonpipeline-feature-flags-base.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  disable-affinity-assistant: "false"
+  coschedule: "workspaces"
+  disable-creds-init: "false"
+  await-sidecar-readiness: "true"
+  running-in-environment-with-injected-sidecars: "true"
+  require-git-ssh-secret-known-hosts: "false"
+  enable-tekton-oci-bundles: "false"
+  enable-api-fields: "beta"
+  send-cloudevents-for-runs: "false"
+  trusted-resources-verification-no-match-policy: "ignore"
+  enable-provenance-in-status: "true"
+  enforce-nonfalsifiability: "none"
+  results-from: "termination-message"
+  set-security-context: "false"
+  keep-pod-on-cancel: "false"
+  enable-cel-in-whenexpression: "false"
+  enable-step-actions: "false"
+  enable-artifacts: "false"
+  enable-param-enum: "false"
+  disable-inline-spec: ""
+  enable-concise-resolver-syntax: "false"
+  enable-kubernetes-sidecar: "false"

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -56,6 +56,11 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
 		pipeline := comp.(*v1alpha1.TektonPipeline)
 
+		// not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+		// this field is removed from pipeline component
+		// still keeping types to maintain the API compatibility
+		pipeline.Spec.Pipeline.EnableTektonOciBundles = nil
+
 		images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.PipelinesImagePrefix))
 		instance := comp.(*v1alpha1.TektonPipeline)
 		// adding extension's transformers first to run them before `extra` transformers

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tektonpipeline
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/pipeline/test/diff"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -362,6 +364,58 @@ func TestUpdateResolverConfigEnvironmentsInDeployment(t *testing.T) {
 			if d := cmp.Diff(depOut, depExpected); d != "" {
 				t.Errorf("Diff %s", diff.PrintWantGot(d))
 			}
+		})
+	}
+}
+
+// not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+// this field is removed from pipeline component
+// keeping in types to maintain the API compatibility
+// this test verifies that, "EnableTektonOciBundles" always not present in the feature flags config map
+func TestEnableTektonOciBundlesFeatureFlag(t *testing.T) {
+	tp := &v1alpha1.TektonPipeline{
+		Spec: v1alpha1.TektonPipelineSpec{
+			Pipeline: v1alpha1.Pipeline{
+				PipelineProperties: v1alpha1.PipelineProperties{
+					EnableTektonOciBundles: ptr.Bool(true),
+				},
+			},
+		},
+	}
+	ctx := context.TODO()
+
+	tests := []struct {
+		name                   string
+		enableTektonOciBundles *bool
+		expectedValue          string
+	}{
+		{name: "with-true", enableTektonOciBundles: ptr.Bool(true), expectedValue: "false"},
+		{name: "with-false", enableTektonOciBundles: ptr.Bool(false), expectedValue: "false"},
+		{name: "with-nil", enableTektonOciBundles: nil, expectedValue: "false"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tp.Spec.Pipeline.EnableTektonOciBundles = test.enableTektonOciBundles
+
+			// get manifests
+			manifest, err := common.Fetch("./testdata/tektonpipeline-feature-flags-base.yaml")
+			assert.NilError(t, err, "error on fetching testdata")
+
+			transformers := filterAndTransform(common.NoExtension(ctx))
+			_, err = transformers(ctx, &manifest, tp)
+			assert.NilError(t, err)
+
+			resources := manifest.Resources()
+			assert.Assert(t, len(resources) > 0)
+
+			featureFlagsMap := corev1.ConfigMap{}
+			err = apimachineryRuntime.DefaultUnstructuredConverter.FromUnstructured(resources[0].Object, &featureFlagsMap)
+			assert.NilError(t, err)
+
+			flagValue, found := featureFlagsMap.Data["enable-tekton-oci-bundles"]
+			assert.Assert(t, found == true, "'enable-tekton-oci-bundles' not found")
+			assert.Assert(t, flagValue == test.expectedValue, "'enable-tekton-oci-bundles' is not '%s'", test.expectedValue)
 		})
 	}
 }


### PR DESCRIPTION
# Changes

* feature flag `enable-tekton-oci-bundles` support removed and added into main stream. Supplying `enable-tekton-oci-bundles=true` can lead issue with pipeline controller. Hence ignore `enable-tekton-oci-bundles` values from TektonConfig CR and/or TektonPipelines CR.
* keeping `enable-tekton-oci-bundles` in operator to maintain the API compatibility
* originally removed from pipeline controller on https://github.com/tektoncd/pipeline/pull/7789

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
pipeline feature flag `enable-tekton-oci-bundles` will be ignored.
```
