### PR TITLE
Added Clusterrole for results API and Loki RBAC

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/logs-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/logs-rbac/rbac.yaml
@@ -17,6 +17,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: tekton-logging-view
+rules:
+- apiGroups:
+  - loki.grafana.com
+  resourceNames:
+  - logs
+  resources:
+  - application
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: tekton-results-viewlogs
 rules:
 - verbs:
@@ -58,7 +75,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-logging-application-view
+  name: tekton-logging-view
 subjects:
 - kind: ServiceAccount
   name: tekton-results-api


### PR DESCRIPTION
We have added the clusterrole for Loki and change the bindings to that role.
This reduces dependency upon other operator not creating that role in certain scenarios.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
NONE
```

