### PR TITLE
Remove TLS Secret Check for Results API

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -146,6 +146,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 	}
 
 	// check if the secrets are created
+	// TODO: Create secret automatically if they don't exist
+	// TODO: And remove this check in future release.
 	if err := r.validateSecretsAreCreated(ctx, tr); err != nil {
 		return err
 	}
@@ -319,16 +321,6 @@ func (r *Reconciler) validateSecretsAreCreated(ctx context.Context, tr *v1alpha1
 		if apierrors.IsNotFound(err) {
 			logger.Error(err)
 			tr.Status.MarkDependencyMissing(fmt.Sprintf("%s secret is missing", DbSecretName))
-			return err
-		}
-		logger.Error(err)
-		return err
-	}
-	_, err = r.kubeClientSet.CoreV1().Secrets(tr.Spec.TargetNamespace).Get(ctx, TlsSecretName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Error(err)
-			tr.Status.MarkDependencyMissing(fmt.Sprintf("%s secret is missing", TlsSecretName))
 			return err
 		}
 		logger.Error(err)

--- a/pkg/reconciler/openshift/tektonresult/testdata/api-service.yaml
+++ b/pkg/reconciler/openshift/tektonresult/testdata/api-service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-results-api
+    app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/version: devel
+  name: tekton-results-api-service
+  namespace: tekton-pipelines
+spec:
+  ports:
+    - name: server
+      nodePort: 30080
+      port: 8080
+    - name: prometheus
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+    - name: profiling
+      port: 6060
+      protocol: TCP
+      targetPort: 6060
+  selector:
+    app.kubernetes.io/name: tekton-results-api
+  type: NodePort


### PR DESCRIPTION
TLS check is a nuisance because TLS can come from the environment variables or via injection by some controller or vault or cert manager.
Shifted OpenShift's extension to serving ca to autogenerate certs.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release
```release-note
Remove Results API TLS Cert check and Shifted OpenShift's extension to utilize serving ca to autogenerate certs
```
