### PR TITLE
Add QueryLimit & QueryParams Fields for ResultsAPI

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -228,19 +228,11 @@ LOGGING_PLUGIN_NAMESPACE_KEY
 LOGGING_PLUGIN_STATIC_LABELS
 LOGGING_PLUGIN_TLS_VERIFICATION_DISABLE
 LOGGING_PLUGIN_FORWARDER_DELAY_DURATION
+LOGGING_PLUGIN_QUERY_PARAMS
+LOGGING_PLUGIN_QUERY_LIMIT
 ```
 
-- `LOGGING_PLUGIN_PROXY_PATH`: The path to the proxy used for logging. These reverse proxyies like NGinx is used for authentication.
-
-- `LOGGING_PLUGIN_API_URL`: The Base URL for quering Loki.
-
-- `LOGGING_PLUGIN_TOKEN_PATH`: The path to the token used for authentication with the logging service. `/var/run/secrets/kubernetes.io/serviceaccount/token` can be used if results api service account token can be used as Authorization jwt token for quering Loki.
-
-- `LOGGING_PLUGIN_NAMESPACE_KEY`: The key used to identify the namespace in log queries.
-
-- `LOGGING_PLUGIN_STATIC_LABELS`: Any static labels to be added to all log queries. It's necessary to have some fields to filter out tekton logs.
-
-- `LOGGING_PLUGIN_TLS_VERIFICATION_DISABLE`: A boolean flag to disable TLS verification. This should be set to "false" in production environments to ensure secure connections.
+Please consult the docs [here](https://github.com/tektoncd/results/blob/main/docs/logging-support.md) for information on these fields.
 
 These fields allow you to configure how Tekton Results interacts with your Loki backend.
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -97,6 +97,8 @@ type ResultsAPIProperties struct {
 	LoggingPluginStaticLabels           string `json:"logging_plugin_static_labels,omitempty"`
 	LoggingPluginCACert                 string `json:"logging_plugin_ca_cert,omitempty"`
 	LoggingPluginForwarderDelayDuration *uint  `json:"logging_plugin_forwarder_delay_duration,omitempty"`
+	LoggingPluginQueryLimit             *uint  `json:"logging_plugin_query_limit,omitempty"`
+	LoggingPluginQueryParams            string `json:"logging_plugin_query_params,omitempty"`
 	// Options holds additions fields and these fields will be updated on the manifests
 	Options AdditionalOptions `json:"options"`
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1219,6 +1219,11 @@ func (in *ResultsAPIProperties) DeepCopyInto(out *ResultsAPIProperties) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.LoggingPluginQueryLimit != nil {
+		in, out := &in.LoggingPluginQueryLimit, &out.LoggingPluginQueryLimit
+		*out = new(uint)
+		**out = **in
+	}
 	in.Options.DeepCopyInto(&out.Options)
 	return
 }

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
@@ -24,6 +24,8 @@ data:
     LOGS_TYPE=File
     LOGS_BUFFER_SIZE=32768
     LOGS_PATH=/logs
+    LOGGING_PLUGIN_QUERY_LIMIT=7777
+    LOGGING_PLUGIN_QUERY_PARAMS=direction=desc&skip=100
     STORAGE_EMULATOR_HOST=
 kind: ConfigMap
 metadata:

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -65,6 +65,7 @@ func Test_updateApiConfig(t *testing.T) {
 
 	boolVal := true
 	intVal := int64(12345)
+	limit := uint(100)
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
 	assert.NilError(t, err)
@@ -90,6 +91,8 @@ func Test_updateApiConfig(t *testing.T) {
 			LogsBufferSize:                      &intVal,
 			StorageEmulatorHost:                 "http://localhost:9004",
 			LoggingPluginForwarderDelayDuration: &bufferDuration,
+			LoggingPluginQueryLimit:             &limit,
+			LoggingPluginQueryParams:            "direction=asc&skip=0",
 		},
 	}
 
@@ -122,6 +125,8 @@ LOGS_API=true
 LOGS_TYPE=s3
 LOGS_BUFFER_SIZE=12345
 LOGS_PATH=/logs/test
+LOGGING_PLUGIN_QUERY_LIMIT=100
+LOGGING_PLUGIN_QUERY_PARAMS=direction=asc&skip=0
 STORAGE_EMULATOR_HOST=http://localhost:9004`)
 }
 


### PR DESCRIPTION
Added LOGGING_PLUGIN_QUERY_LIMIT and LOGGING_PLUGIN_QUERY_PARAMS fields for setting configmap of Results API.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes



```release-note
NONE
```

