### PR TITLE
Add Tekton Results DB_SSLROOTCERT config option

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -91,7 +91,8 @@ spec:
   targetNamespace: tekton-pipelines
   db_host: localhost
   db_port: 5342
-  db_sslmode: false
+  db_sslmode: verify-full
+  db_sslrootcert: /etc/tls/db/ca.crt
   db_enable_auto_migration: true
   log_level: debug
   logs_api: true
@@ -205,6 +206,27 @@ spec:
   is_external_db: true
 ...
 ```
+
+### Securing the DB connection
+
+To secure the DB connection using self-segned certificate or using certificate signed by 3rd party CA (e.g AWS RDS), one can provide path to the DB SSL root certificate, mounted and available on the Results API pod. The configuration will look like:
+
+
+```yaml
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonResult
+metadata:
+  name: result
+spec:
+  targetNamespace: tekton-pipelines
+  db_host: tekton-results-postgres-service.openshift-pipelines.svc.cluster.local
+  db_port: 5342
+  db_sslmode: verify-full
+  db_sslrootcert: /etc/tls/db/ca.crt
+  ...
+```
+
+The valid options for `db_sslmode` are explained here https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION. To use any of the `require`, `verify-ca` and `verify-full` modes with self signed certificate, the path to the CA certificate which signed the DB certificate must be provided as `db_sslrootcert`.
 
 ## LokiStack + TektonResult
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -68,6 +68,7 @@ type ResultsAPIProperties struct {
 	DBPort                *int64 `json:"db_port,omitempty"`
 	DBName                string `json:"db_name,omitempty"`
 	DBSSLMode             string `json:"db_sslmode,omitempty"`
+	DBSSLRootCert         string `json:"db_sslrootcert,omitempty"`
 	DBEnableAutoMigration *bool  `json:"db_enable_auto_migration,omitempty"`
 	ServerPort            *int64 `json:"server_port,omitempty"`
 	PrometheusPort        *int64 `json:"prometheus_port,omitempty"`

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
@@ -7,6 +7,7 @@ data:
     PROMETHEUS_PORT=9090
     DB_NAME=
     DB_SSLMODE=disable
+    DB_SSLROOTCERT=/etc/tls/db/ca.crt
     DB_ENABLE_AUTO_MIGRATION=true
     TLS_HOSTNAME_OVERRIDE=tekton-results-api-service.tekton-pipelines.svc.cluster.local
     TLS_PATH=/etc/tls

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -80,6 +80,7 @@ func Test_updateApiConfig(t *testing.T) {
 			DBName:                              "test",
 			ServerPort:                          &intVal,
 			DBSSLMode:                           "enable",
+			DBSSLRootCert:                       "/etc/tls/db/ca.crt",
 			DBEnableAutoMigration:               &boolVal,
 			TLSHostnameOverride:                 "localhostTest",
 			AuthDisable:                         &boolVal,
@@ -108,6 +109,7 @@ SERVER_PORT=12345
 PROMETHEUS_PORT=9090
 DB_NAME=test
 DB_SSLMODE=enable
+DB_SSLROOTCERT=/etc/tls/db/ca.crt
 DB_ENABLE_AUTO_MIGRATION=true
 TLS_HOSTNAME_OVERRIDE=localhostTest
 TLS_PATH=/etc/tls


### PR DESCRIPTION
Tekton Results provides an option allowing the users to configure DB SSL Root Certificate.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Tekton Results provides an option allowing the users to configure DB SSL Root Certificate. The option was missing the the operator making the deployment fail when the option is specified.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
