### PR TITLE
restore community tasks as openshift addons

### DIFF
--- a/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
+++ b/config/crs/openshift/config/all/operator_v1alpha1_config_cr.yaml
@@ -27,6 +27,8 @@ spec:
       value: "true"
     - name: resolverStepActions
       value: "true"
+    - name: communityResolverTasks
+      value: "true"
   params:
   - name: createRbacResource
     value: "true"

--- a/docs/TektonAddon.md
+++ b/docs/TektonAddon.md
@@ -6,7 +6,7 @@ weight: 6
 -->
 # Tekton Addon
 
-TektonAddon custom resource allows user to install resource like resolverTasks, resolverStepActions and pipelineTemplate along with Pipelines.
+TektonAddon custom resource allows user to install resource like resolverTasks, resolverStepActions, communityResolverTasks and pipelineTemplate along with Pipelines.
 It also allows user to install various Tasks in openshift-pipelines namespace.
 
 **NOTE:** TektonAddon is currently available only for OpenShift Platform. This is roadmap to enable it for Kubernetes platform.
@@ -28,6 +28,8 @@ spec:
     value: "true"
   - name: resolverStepActions
     value: "true"
+  - name: communityResolverTasks
+    value: "true"
 ```
 You can install this component using [TektonConfig](./TektonConfig.md) by choosing appropriate `profile`.
 
@@ -38,7 +40,8 @@ Available params are
 - `pipelineTemplates` (Default: `true`)
 - `resolverTasks` (Default: `true`)
 - `resolverStepActions` (Default: `true`)
+- `communityResolverTasks` (Default: `true`)
 
 User can disable the installation of resources by changing the value to `false`.
 
-- Pipelines templates uses tasks from `openshift-pipelines` in them so to install pipelineTemplates, resolverTasks must be `true`
+- Pipelines templates uses tasks from `openshift-pipelines`. Therefore, to install pipelineTemplates, resolverTasks must be set to `true`

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -329,7 +329,7 @@ By default pruner job will be created from the global pruner config (`spec.prune
 > `keep: 100` <br>
 ### Addon
 
-TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few PipelineTemplates, ResolverTasks and ResolverStepActions.
+TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few PipelineTemplates, ResolverTasks, ResolverStepActions and CommunityResolverTasks.
 
 This section allows to customize installation of those resources through params. You can read more about the supported params [here](./TektonAddon.md).
 
@@ -342,6 +342,8 @@ addon:
     - name: "resolverTasks"
       value: "true"
     - name: "resolverStepActions"
+      value: "true"
+    - name: "communityResolverTasks"
       value: "true"
 ```
 

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
       \     {\n            \"name\": \"clusterTasks\",\n            \"value\": \"\
       true\"\n          },\n          {\n            \"name\": \"pipelineTemplates\"\
       ,\n            \"value\": \"true\"\n          },\n          {\n            \"\
-      name\": \"communityClusterTasks\",\n            \"value\": \"true\"\n      \
+      name\": \"communityResolverTasks\",\n            \"value\": \"true\"\n      \
       \    }\n        ]\n      },\n      \"params\": [\n        {\n          \"name\"\
       : \"createRbacResource\",\n          \"value\": \"true\"\n        }\n      ],\n\
       \      \"profile\": \"all\",\n      \"pruner\": {\n        \"keep\": 100,\n\

--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -33,6 +33,7 @@ const (
 	ProfileLite  = "lite"
 
 	// Addon Params
+	CommunityResolverTasks = "communityResolverTasks"
 	PipelineTemplatesParam = "pipelineTemplates"
 	ResolverTasks          = "resolverTasks"
 	ResolverStepActions    = "resolverStepActions"
@@ -109,6 +110,7 @@ var (
 	}
 
 	AddonParams = map[string]ParamValue{
+		CommunityResolverTasks: defaultParamValue,
 		PipelineTemplatesParam: defaultParamValue,
 		ResolverTasks:          defaultParamValue,
 		ResolverStepActions:    defaultParamValue,

--- a/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
@@ -24,87 +24,85 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_AddonSetDefaults_DefaultParamsWithValues(t *testing.T) {
-
-	ta := &TektonAddon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
-			Namespace: "namespace",
+func Test_AddonSetDefaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialParams  []Param
+		expectedParams map[string]string
+	}{
+		{
+			name: "Default Params with Values",
+			initialParams: []Param{
+				{Name: PipelineTemplatesParam, Value: "true"},
+			},
+			expectedParams: map[string]string{
+				PipelineTemplatesParam: "true",
+			},
 		},
-		Spec: TektonAddonSpec{
-			CommonSpec: CommonSpec{
-				TargetNamespace: "namespace",
+		{
+			name: "Resolver Task is False",
+			initialParams: []Param{
+				{Name: ResolverTasks, Value: "false"},
+			},
+			expectedParams: map[string]string{
+				ResolverTasks: "false",
+			},
+		},
+		{
+			name: "Resolver Step Actions",
+			initialParams: []Param{
+				{Name: ResolverStepActions, Value: "false"},
+			},
+			expectedParams: map[string]string{
+				ResolverStepActions: "false",
+			},
+		},
+		{
+			name: "Community Resolver Tasks",
+			initialParams: []Param{
+				{Name: CommunityResolverTasks, Value: "false"},
+			},
+			expectedParams: map[string]string{
+				CommunityResolverTasks: "false",
 			},
 		},
 	}
 
-	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 3, len(ta.Spec.Params))
-
-	params := ParseParams(ta.Spec.Params)
-	value, ok := params[PipelineTemplatesParam]
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "true", value)
-}
-
-func Test_AddonSetDefaults_ResolverTaskIsFalse(t *testing.T) {
-
-	ta := &TektonAddon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
-			Namespace: "namespace",
-		},
-		Spec: TektonAddonSpec{
-			CommonSpec: CommonSpec{
-				TargetNamespace: "namespace",
-			},
-			Addon: Addon{
-				Params: []Param{
-					{
-						Name:  "resolverTasks",
-						Value: "false",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta := &TektonAddon{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				Spec: TektonAddonSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "namespace",
+					},
+					Addon: Addon{
+						Params: tt.initialParams,
 					},
 				},
-			},
-		},
+			}
+
+			ta.SetDefaults(context.TODO())
+			checkAddonParams(t, ta.Spec.Addon.Params, tt.expectedParams)
+		})
 	}
-
-	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 3, len(ta.Spec.Params))
-
-	params := ParseParams(ta.Spec.Params)
-	value, ok := params[ResolverTasks]
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "false", value)
 }
 
-func Test_AddonSetDefaults_ResolverStepActions(t *testing.T) {
+func checkAddonParams(t *testing.T, actualParams []Param, expectedParams map[string]string) {
+	t.Helper()
 
-	ta := &TektonAddon{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "name",
-			Namespace: "namespace",
-		},
-		Spec: TektonAddonSpec{
-			CommonSpec: CommonSpec{
-				TargetNamespace: "namespace",
-			},
-			Addon: Addon{
-				Params: []Param{
-					{
-						Name:  "resolverStepActions",
-						Value: "false",
-					},
-				},
-			},
-		},
+	if len(actualParams) != len(AddonParams) {
+		t.Fatalf("Expected %d addon params, got %d", len(AddonParams), len(actualParams))
 	}
 
-	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 3, len(ta.Spec.Params))
+	paramsMap := ParseParams(actualParams)
 
-	params := ParseParams(ta.Spec.Params)
-	value, ok := params[ResolverStepActions]
-	assert.Equal(t, true, ok)
-	assert.Equal(t, "false", value)
+	for key, expectedValue := range expectedParams {
+		value, exists := paramsMap[key]
+		assert.Equal(t, true, exists, "Param %q is missing in Spec.Addon.Params", key)
+		assert.Equal(t, expectedValue, value, "Param %q has incorrect value", key)
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -89,8 +89,16 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	tc.SetDefaults(context.TODO())
-	if len(tc.Spec.Addon.Params) != 3 {
-		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
+
+	if len(tc.Spec.Addon.Params) != len(AddonParams) {
+		t.Fatalf("Expected %d addon params, got %d", len(AddonParams), len(tc.Spec.Addon.Params))
+	}
+	paramsMap := ParseParams(tc.Spec.Addon.Params)
+
+	for key, expectedValue := range AddonParams {
+		value, exists := paramsMap[key]
+		assert.Equal(t, true, exists, "Param %q is missing in Spec.Addon.Params", key)
+		assert.Equal(t, expectedValue.Default, value, "Param %q has incorrect value", key)
 	}
 }
 

--- a/pkg/reconciler/openshift/tektonaddon/community_tasks.go
+++ b/pkg/reconciler/openshift/tektonaddon/community_tasks.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonaddon
+
+import (
+	"context"
+	"strings"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+)
+
+var communityResourceURLs = []string{
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.5/jib-maven.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.3/helm-upgrade-from-source.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/pull-request/0.1/pull-request.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml",
+	"https://raw.githubusercontent.com/tektoncd/catalog/main/task/argocd-task-sync-and-wait/0.2/argocd-task-sync-and-wait.yaml",
+}
+
+func (r *Reconciler) EnsureCommunityResolverTask(ctx context.Context, enable string, ta *v1alpha1.TektonAddon) error {
+	if len(r.communityResolverTaskManifest.Resources()) == 0 {
+		return nil
+	}
+	manifest := *r.communityResolverTaskManifest
+	if enable == "true" {
+		if err := r.installerSetClient.CustomSet(ctx, ta, CommunityResolverTaskInstallerSet, &manifest, filterAndTransformCommunityResolverTask(), nil); err != nil {
+			return err
+		}
+	} else {
+		if err := r.installerSetClient.CleanupCustomSet(ctx, CommunityResolverTaskInstallerSet); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func filterAndTransformCommunityResolverTask() client.FilterAndTransform {
+	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
+		instance := comp.(*v1alpha1.TektonAddon)
+		addonImages := common.ToLowerCaseKeys(common.ImagesFromEnv(common.AddonsImagePrefix))
+
+		extra := []mf.Transformer{
+			injectLabel(labelProviderType, providerTypeCommunity, overwrite, "Task"),
+			common.TaskImages(ctx, addonImages),
+		}
+		if err := common.Transform(ctx, manifest, instance, extra...); err != nil {
+			return nil, err
+		}
+		return manifest, nil
+	}
+}
+
+func appendCommunityResolverTasks(manifest *mf.Manifest) error {
+	urls := strings.Join(communityResourceURLs, ",")
+	m, err := mf.ManifestFrom(mf.Path(urls))
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}
+
+func fetchCommunityResolverTasks(manifest *mf.Manifest) error {
+	if err := appendCommunityResolverTasks(manifest); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/reconciler/openshift/tektonaddon/const.go
+++ b/pkg/reconciler/openshift/tektonaddon/const.go
@@ -22,6 +22,7 @@ const (
 	OpenShiftConsoleInstallerSet            = "OpenShiftConsole"
 	VersionedResolverTaskInstallerSet       = "VersionedResolverTask"
 	VersionedResolverStepActionInstallerSet = "VersionedResolverStepAction"
+	CommunityResolverTaskInstallerSet       = "CommunityResolverTask"
 	versionedClusterTaskPatchChar           = "0"
 	PipelinesTemplateInstallerSet           = "PipelinesTemplate"
 	TriggersResourcesInstallerSet           = "TriggersResources"

--- a/pkg/reconciler/openshift/tektonaddon/controller.go
+++ b/pkg/reconciler/openshift/tektonaddon/controller.go
@@ -114,21 +114,28 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatalf("failed to read console cli from kodata: %v", err)
 		}
 
+		communityResolverTaskManifest := &mf.Manifest{}
+		if err := fetchCommunityResolverTasks(communityResolverTaskManifest); err != nil {
+			// if unable to fetch community task, don't fail
+			logger.Errorf("failed to read community resolver task: %v", err)
+		}
+
 		c := &Reconciler{
-			crdClientSet:               crdClient,
-			installerSetClient:         client.NewInstallerSetClient(tisClient, version, "addon", v1alpha1.KindTektonAddon, metrics),
-			operatorClientSet:          operatorclient.Get(ctx),
-			extension:                  generator(ctx),
-			pipelineInformer:           tektonPipelineinformer.Get(ctx),
-			triggerInformer:            tektonTriggerinformer.Get(ctx),
-			manifest:                   manifest,
-			operatorVersion:            version,
-			resolverTaskManifest:       resolverTaskManifest,
-			resolverStepActionManifest: resolverStepActionManifest,
-			triggersResourcesManifest:  triggersResourcesManifest,
-			pipelineTemplateManifest:   pipelineTemplateManifest,
-			openShiftConsoleManifest:   openShiftConsoleManifest,
-			consoleCLIManifest:         consoleCLIManifest,
+			crdClientSet:                  crdClient,
+			installerSetClient:            client.NewInstallerSetClient(tisClient, version, "addon", v1alpha1.KindTektonAddon, metrics),
+			operatorClientSet:             operatorclient.Get(ctx),
+			extension:                     generator(ctx),
+			pipelineInformer:              tektonPipelineinformer.Get(ctx),
+			triggerInformer:               tektonTriggerinformer.Get(ctx),
+			manifest:                      manifest,
+			operatorVersion:               version,
+			resolverTaskManifest:          resolverTaskManifest,
+			resolverStepActionManifest:    resolverStepActionManifest,
+			triggersResourcesManifest:     triggersResourcesManifest,
+			pipelineTemplateManifest:      pipelineTemplateManifest,
+			openShiftConsoleManifest:      openShiftConsoleManifest,
+			consoleCLIManifest:            consoleCLIManifest,
+			communityResolverTaskManifest: communityResolverTaskManifest,
 		}
 		impl := tektonAddonreconciler.NewImpl(ctx, c)
 

--- a/test/e2e/common/00_tektonconfigdeployment_test.go
+++ b/test/e2e/common/00_tektonconfigdeployment_test.go
@@ -349,6 +349,7 @@ func (s *TektonConfigTestSuite) Test05_DisableAndEnableAddons() {
 	// disable addons and update
 	tc := s.getCurrentConfig(timeout)
 	tc.Spec.Addon.Params = []v1alpha1.Param{
+		{Name: v1alpha1.CommunityResolverTasks, Value: "false"},
 		{Name: v1alpha1.PipelineTemplatesParam, Value: "false"},
 	}
 	_, err := s.clients.TektonConfig().Update(context.TODO(), tc, metav1.UpdateOptions{})

--- a/test/resources/tektonaddons.go
+++ b/test/resources/tektonaddons.go
@@ -102,6 +102,7 @@ func AssertTektonInstallerSets(t *testing.T, clients *utils.Clients) {
 	assertInstallerSets(t, clients, tektonaddon.TriggersResourcesInstallerSet)
 	assertInstallerSets(t, clients, tektonaddon.ConsoleCLIInstallerSet)
 	assertInstallerSets(t, clients, tektonaddon.MiscellaneousResourcesInstallerSet)
+	assertInstallerSets(t, clients, tektonaddon.CommunityResolverTaskInstallerSet)
 }
 
 func assertInstallerSets(t *testing.T, clients *utils.Clients, component string) {

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -79,7 +79,7 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients opera
 							Value: "true",
 						},
 						{
-							Name:  "communityClusterTasks",
+							Name:  "communityResolverTasks",
 							Value: "true",
 						},
 					},


### PR DESCRIPTION
# Changes
In 1.17 after removing clusterTasks all the community clusterTasks also removed
here we put back community tasks as tasks under openshift-pipelines namespace

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
