### PR TITLE
Remove older versions of task and stepactions resolver installersets

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -38,8 +38,10 @@ var (
 
 	// post upgrade functions
 	postUpgradeFunctions = []upgradeFunc{
-		upgradeStorageVersion,          // upgrade #1: performs storage version migration
-		removeClusterTaskInstallerSets, // upgrade #2: removes the clusterTask installerset
+		upgradeStorageVersion,                   // upgrade #1: performs storage version migration
+		removeClusterTaskInstallerSets,          // upgrade #2: removes the clusterTask installerset
+		removeVersionedTaskInstallerSets,        // upgrade #3: remove the older versioned resolver task installersets
+		removeVersionedStepActionsInstallerSets, // upgrade #4: remove the older versioned step action resolver installersets
 	}
 )
 


### PR DESCRIPTION
This will remove the older versions of task and stepactions resolver installersets 
and keep only latest two versions during operator upgrade as we will support only latest 
two versions of tasks and stepactions 

Jira link: https://issues.redhat.com/browse/SRVKP-3802


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Remove the older versions of task and stepactions resolver installersets  except latest 2 versions
```

