### PR TITLE
Update TektonConfig CR's addon params to remove cluster tasks params

### DIFF
--- a/pkg/apis/operator/v1alpha1/const.go
+++ b/pkg/apis/operator/v1alpha1/const.go
@@ -33,10 +33,6 @@ const (
 	ProfileLite  = "lite"
 
 	// Addon Params
-	// Keeping ClusterTasksParams and CommunityClusterTasks params for backward compatibility
-	// will be removed from next operator api release
-	ClusterTasksParam      = "clusterTasks"
-	CommunityClusterTasks  = "communityClusterTasks"
 	PipelineTemplatesParam = "pipelineTemplates"
 	ResolverTasks          = "resolverTasks"
 	ResolverStepActions    = "resolverStepActions"
@@ -113,10 +109,6 @@ var (
 	}
 
 	AddonParams = map[string]ParamValue{
-		// Keeping ClusterTasks and CommunityClusterTasks params
-		// for backward compatibility and will be removed in next operator api release
-		ClusterTasksParam:      defaultParamValue,
-		CommunityClusterTasks:  defaultParamValue,
 		PipelineTemplatesParam: defaultParamValue,
 		ResolverTasks:          defaultParamValue,
 		ResolverStepActions:    defaultParamValue,

--- a/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_default_test.go
@@ -39,7 +39,7 @@ func Test_AddonSetDefaults_DefaultParamsWithValues(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 5, len(ta.Spec.Params))
+	assert.Equal(t, 3, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[PipelineTemplatesParam]
@@ -70,7 +70,7 @@ func Test_AddonSetDefaults_ResolverTaskIsFalse(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 5, len(ta.Spec.Params))
+	assert.Equal(t, 3, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[ResolverTasks]
@@ -101,7 +101,7 @@ func Test_AddonSetDefaults_ResolverStepActions(t *testing.T) {
 	}
 
 	ta.SetDefaults(context.TODO())
-	assert.Equal(t, 5, len(ta.Spec.Params))
+	assert.Equal(t, 3, len(ta.Spec.Params))
 
 	params := ParseParams(ta.Spec.Params)
 	value, ok := params[ResolverStepActions]

--- a/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_validation.go
@@ -48,6 +48,10 @@ func validateAddonParams(params []Param, pathToParams string) *apis.FieldError {
 	var errs *apis.FieldError
 
 	for i, p := range params {
+		// Todo: Remove this in next operator release
+		if p.Name == "clusterTasks" || p.Name == "communityClusterTasks" {
+			continue
+		}
 		paramValue, ok := AddonParams[p.Name]
 		if !ok {
 			errs = errs.Also(apis.ErrInvalidKeyName(p.Name, pathToParams))

--- a/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_default_test.go
@@ -89,7 +89,7 @@ func Test_SetDefaults_Addon_Params(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	tc.SetDefaults(context.TODO())
-	if len(tc.Spec.Addon.Params) != 5 {
+	if len(tc.Spec.Addon.Params) != 3 {
 		t.Error("Setting default failed for TektonConfig (spec.addon.params)")
 	}
 }

--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -33,7 +33,9 @@ var (
 	// pre upgrade functions
 	preUpgradeFunctions = []upgradeFunc{
 		resetTektonConfigConditions, // upgrade #1: removes conditions from TektonConfig CR, clears outdated conditions
-		upgradePipelineProperties,   // update default value of enable-step-actions from false to true
+		upgradePipelineProperties,   // upgrade #2: update default value of enable-step-actions from false to true
+		// Todo: Remove the removeDeprecatedAddonParams upgrade function in next operator release
+		removeDeprecatedAddonParams, // upgrade #3: remove the deprecated cluster task params from TektonConfig CR's addon params
 	}
 
 	// post upgrade functions

--- a/test/e2e/common/00_tektonconfigdeployment_test.go
+++ b/test/e2e/common/00_tektonconfigdeployment_test.go
@@ -349,8 +349,6 @@ func (s *TektonConfigTestSuite) Test05_DisableAndEnableAddons() {
 	// disable addons and update
 	tc := s.getCurrentConfig(timeout)
 	tc.Spec.Addon.Params = []v1alpha1.Param{
-		{Name: v1alpha1.ClusterTasksParam, Value: "false"},
-		{Name: v1alpha1.CommunityClusterTasks, Value: "false"},
 		{Name: v1alpha1.PipelineTemplatesParam, Value: "false"},
 	}
 	_, err := s.clients.TektonConfig().Update(context.TODO(), tc, metav1.UpdateOptions{})


### PR DESCRIPTION
Cluster tasks have been deprecated and removed, previous version of TektonConfig CR's addon params have the clusterTasks and communityClusterTasks params and need to remove it from the TektonConfig's addon params this removes the cluster tasks params from TektonConfig's addon params and updates it



# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Update TektonConfig CR's addon params to remove cluster tasks params
```