### PR TITLE
Fix env keys for git-clone and git-cli task

### DIFF
--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -62,8 +62,7 @@ image-substitutions:
       envKeys:
       - IMAGE_PIPELINES_ARG__GIT_IMAGE
       - IMAGE_ADDONS_PARAM_GITINITIMAGE
-      - IMAGE_ADDONS_GIT_RUN
-      - IMAGE_ADDONS_REPORT
+      - IMAGE_ADDONS_PREPARE_AND_RUN
       - IMAGE_ADDONS_GIT_CLONE
 - image: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel8@
   replaceLocations:
@@ -129,7 +128,6 @@ image-substitutions:
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_SKOPEO_COPY
-      - IMAGE_ADDONS_SKOPEO_RESULTS
 - image: registry.redhat.io/rhel8/buildah@sha256:6d2dcb651ba680cf4ec74331f8349dec43d071d420625a1703370acc8d984e9e
   replaceLocations:
     envTargets:


### PR DESCRIPTION
In git-clone and git-cli task we have reduced the number of steps in spec and while doing that there was a change in name but forgot to update same in config.yaml of opertorHub and which is leading a replacement issue

Signed-off-by: savitaashture <sashture@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
