### PR TITLE
refactor namespace reconciliation to ensure openshift rbac requisites

### DIFF
--- a/pkg/reconciler/common/utils.go
+++ b/pkg/reconciler/common/utils.go
@@ -63,3 +63,12 @@ func StructToMap(in, out interface{}) error {
 	}
 	return json.Unmarshal(data, out)
 }
+
+// Helper function to serialize labels map to JSON string
+func SerializeLabelsToJSON(labels map[string]string) (string, error) {
+	bytes, err := json.Marshal(labels)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize labels to JSON: %v", err)
+	}
+	return string(bytes), nil
+}

--- a/pkg/reconciler/common/utils_test.go
+++ b/pkg/reconciler/common/utils_test.go
@@ -113,3 +113,65 @@ func TestStructMapError(t *testing.T) {
 	err := StructToMap(&in, actualOut)
 	assert.Error(t, err, "json: Unmarshal(non-pointer map[string]interface {})")
 }
+
+func TestSerializeLabelsToJSON(t *testing.T) {
+	// Test cases with different inputs
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		expectedOutput string
+		expectError    bool
+	}{
+		{
+			name: "Valid input with multiple labels",
+			labels: map[string]string{
+				"app":   "my-app",
+				"env":   "production",
+				"owner": "dev-team",
+			},
+			expectedOutput: `{"app":"my-app","env":"production","owner":"dev-team"}`,
+			expectError:    false,
+		},
+		{
+			name:           "Empty input",
+			labels:         map[string]string{},
+			expectedOutput: `{}`,
+			expectError:    false,
+		},
+		{
+			name: "Single label",
+			labels: map[string]string{
+				"key": "value",
+			},
+			expectedOutput: `{"key":"value"}`,
+			expectError:    false,
+		},
+		{
+			name: "Special characters in keys and values",
+			labels: map[string]string{
+				"foo@bar":   "bazqux",
+				"key#1":     "value$%",
+				"space key": "with space",
+			},
+			expectedOutput: `{"foo@bar":"bazqux","key#1":"value$%","space key":"with space"}`,
+			expectError:    false,
+		},
+	}
+
+	// Loop over each test case
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function with the test labels
+			actual, err := SerializeLabelsToJSON(tt.labels)
+
+			// Check if we expect an error
+			if tt.expectError {
+				// Assert that an error was returned
+				assert.Error(t, err, "Expected error, but got none")
+			} else {
+				// Check if the output matches the expected result
+				assert.Equal(t, tt.expectedOutput, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

During upgrade of pipelines in OpenShift cluster there are additional rbac related reconciliation to be done across all namespaces in the cluster. Right now the namespace reconciliation happens one at a time in a for loop. This results in longer upgrade time. This PR improvises this by 

- Utilising `Patch` in place of `Update`
- Refactor to improve code modularity
- Bulk update of ClusterInterceptor ClusterRoleBinding(CRB)  with namespaces that are processed succesfully instead of updating the CRB everytime for each namespace
**[Note: The original scope included concurrency which was later dropped since there was no significant impact in time taken to process the namespaces]**

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
