### PR TITLE
Switch to golangci-lint GH action

### DIFF
--- a/.github/workflows/bump-payload-on-main.yaml
+++ b/.github/workflows/bump-payload-on-main.yaml
@@ -10,7 +10,7 @@ jobs:
   bump-payloads:
     name: "Bump payloads"
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build-release-matrix:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
     - id: set-matrix
       run: |

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:  # yamllint disable-line rule:empty-values
+
+permissions:
+  contents: read
+  checks: write  # Used to annotate code in the PR
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8  # v6.1.1
+        with:
+          version: v1.60
+          args: --timeout=10m

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -18,7 +18,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -39,7 +39,7 @@ func PipelineReady(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPi
 	ppln, err := getPipelineRes(informer)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf(PipelineNotFound)
+			return nil, errors.New(PipelineNotFound)
 		}
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func PipelineReady(informer informer.TektonPipelineInformer) (*v1alpha1.TektonPi
 		return nil, v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR
 	}
 	if !ppln.Status.IsReady() {
-		return nil, fmt.Errorf(PipelineNotReady)
+		return nil, errors.New(PipelineNotReady)
 	}
 	return ppln, nil
 }
@@ -72,7 +72,7 @@ func TriggerReady(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrig
 	trigger, err := getTriggerRes(informer)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf(TriggerNotFound)
+			return nil, errors.New(TriggerNotFound)
 		}
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func TriggerReady(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrig
 		return nil, v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR
 	}
 	if !trigger.Status.IsReady() {
-		return nil, fmt.Errorf(TriggerNotReady)
+		return nil, errors.New(TriggerNotReady)
 	}
 	return trigger, nil
 }

--- a/pkg/reconciler/common/deadlockbreaker.go
+++ b/pkg/reconciler/common/deadlockbreaker.go
@@ -69,7 +69,7 @@ func isWebhookEndpointsActive(m *manifestival.Manifest, kc kubernetes.Interface,
 		}
 		return false, err
 	}
-	if endPoint.Subsets == nil || len(endPoint.Subsets) == 0 {
+	if len(endPoint.Subsets) == 0 {
 		return false, nil
 	}
 	return true, nil

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mf "github.com/manifestival/manifestival"
@@ -113,7 +114,7 @@ func (i *InstallerSetClient) statusCheck(logger *zap.SugaredLogger, setType stri
 		if !ready.IsTrue() {
 			msg := fmt.Sprintf("%v/%v: installer set not ready, will retry: %v", i.resourceKind, setType, ready.Message)
 			logger.Debugf(msg)
-			return fmt.Errorf(msg)
+			return errors.New(msg)
 		}
 	}
 	return nil

--- a/pkg/reconciler/platform/config.go
+++ b/pkg/reconciler/platform/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package platform
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -132,7 +133,7 @@ func validateConfig(pc *PlatformConfig) error {
 	if len(violations) == 0 {
 		return nil
 	}
-	return fmt.Errorf(strings.Join(violations, ","))
+	return errors.New(strings.Join(violations, ","))
 }
 
 // stringToControllerNamesSlice returns a []ControllerName

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -37,7 +37,7 @@ function check_go_lint() {
 function check_yaml_lint() {
     header "Testing if yamllint has been done"
 
-    local YAML_FILES=$(find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print)
+    local YAML_FILES=$(find . \( -path ./vendor -prune \) -o \( -type d -name testdata -prune \) -o -type f -regex ".*y[a]ml" -print)
     yamllint -c .yamllint ${YAML_FILES}
 
     if [[ $? != 0 ]]; then
@@ -49,7 +49,8 @@ function check_yaml_lint() {
 }
 
 function post_build_tests() {
-  check_go_lint
+  # golangci-lint is executed now via GitHub actions
+  # check_go_lint
   check_yaml_lint
 }
 


### PR DESCRIPTION
# Changes

Start using the golangci-lint github action and stop using the check as part of the build jobs.

This way the version of the actions can be maintained by dependabot, the version of golangci-lint can be updated in the YAML and code in PRs can be annotated with issues. It also reduces the load in the prow job slighlty, saving a little infra cost.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```