### PR TITLE
fix: resolve panic issue in script when label is specified during bundle build

### DIFF
--- a/operatorhub/tools/bundle.py
+++ b/operatorhub/tools/bundle.py
@@ -232,6 +232,8 @@ def newCSVmods(config):
                 if "addn-annotations" in config.keys():
                     csv['metadata']['annotations'].update(config["addn-annotations"])
                 if "addn-labels" in config.keys():
+                    if "labels" not in csv['metadata']:
+                        csv['metadata']['labels'] = {}
                     csv['metadata']['labels'].update(config["addn-labels"])
 
                 csv_stream.seek(0)


### PR DESCRIPTION
reproduction steps

```sh
cd operatorhub/

wget https://storage.googleapis.com/tekton-releases/operator/previous/v0.74.0/release.yaml

export BUNDLE_ARGS="--workspace kubernetes --operator-release-version 1.2.3 --channels alpha --default-channel alpha --fetch-strategy-release-manifest --release-manifest $(pwd)/release.yaml --upgrade-strategy-semver --addn-labels key1=val1,key2=val2"

make operator-bundle

-------------------------
Results:
-------------------------

:::::::::::::::::::::::::
::::: update csv
:::::::::::::::::::::::::
Traceback (most recent call last):
  File "/Users/liuqing/code/alauda/katanomi/tekton-operator/operatorhub/./tools/bundle.py", line 328, in <module>
    newCSVmods(config)
  File "/Users/liuqing/code/alauda/katanomi/tekton-operator/operatorhub/./tools/bundle.py", line 235, in newCSVmods
    csv['metadata']['labels'].update(config["addn-labels"])
    ~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'labels'
make: *** [operator-bundle] Error 1
```

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```