### PR TITLE
fix: get tektonconfig version from label

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -85,7 +85,7 @@ function current_tektonconfig_version() {
 
 function tektonconfig_version_from_label() {
   label_key='operator.tekton.dev/release-version'
-  kubectl get tektonconfig config  -o yaml | grep ${label_key} | tr -d ' ' | cut -d ':' -f 2
+  kubectl get tektonconfig config  -o yaml | grep ${label_key} | head -n 1 | tr -d ' ' | cut -d ':' -f 2
 }
 
 tektonconfig_version_from_status() {


### PR DESCRIPTION
When the `managedFields` field is present in the TektonConfig CR, the `kubectl get tektonconfig config -o yaml` command returns multiple `operator.tekton.dev/release-version` labels. This causes the `tektonconfig_version_from_label` function to return an incorrect version. This commit fixes the issue by adding a `head -n 1` command to the `grep` command in the `tektonconfig_version_from_label` function.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
