### PR TITLE
Ensure the configured `TargetNamespace` overrides the default namespace in the Dashboard's container args

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -51,7 +51,7 @@ const (
 	HubImagePrefix                = "IMAGE_HUB_"
 	DashboardImagePrefix          = "IMAGE_DASHBOARD_"
 
-	DefaultPipelinesNamespace = "tekton-pipelines"
+	DefaultTargetNamespace = "tekton-pipelines"
 
 	ArgPrefix   = "arg_"
 	ParamPrefix = "param_"
@@ -471,7 +471,7 @@ func injectNamespaceClusterRole(targetNamespace string) mf.Transformer {
 			if containsNamespaceResource && ok {
 				nm := []interface{}{}
 				for _, rn := range resourceNames.([]interface{}) {
-					if rn.(string) == DefaultPipelinesNamespace {
+					if rn.(string) == DefaultTargetNamespace {
 						nm = append(nm, targetNamespace)
 					} else {
 						nm = append(nm, rn)
@@ -515,7 +515,7 @@ func replaceNamespaceInDBAddress(envs []corev1.EnvVar, targetNamespace string) [
 
 	for i, e := range envs {
 		if slices.Contains(req, e.Name) {
-			envs[i].Value = strings.ReplaceAll(e.Value, DefaultPipelinesNamespace, targetNamespace)
+			envs[i].Value = strings.ReplaceAll(e.Value, DefaultTargetNamespace, targetNamespace)
 		}
 	}
 	return envs
@@ -549,8 +549,8 @@ func ReplaceNamespaceInDeploymentArgs(deploymentNames []string, targetNamespace 
 
 func replaceNamespaceInContainerArg(container *corev1.Container, targetNamespace string) {
 	for i, a := range container.Args {
-		if strings.Contains(a, DefaultPipelinesNamespace) {
-			container.Args[i] = strings.ReplaceAll(a, DefaultPipelinesNamespace, targetNamespace)
+		if strings.Contains(a, DefaultTargetNamespace) {
+			container.Args[i] = strings.ReplaceAll(a, DefaultTargetNamespace, targetNamespace)
 		}
 	}
 }

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -432,7 +432,7 @@ func TestReplaceNamespaceInDeploymentEnv(t *testing.T) {
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assertNoEror(t, err)
 
-	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentEnv("openshift-pipelines"))
+	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentEnv([]string{"tekton-results-watcher", "tekton-results-api"}, "openshift-pipelines"))
 	assertNoEror(t, err)
 
 	d := &appsv1.Deployment{}
@@ -456,7 +456,7 @@ func TestReplaceNamespaceInDeploymentArgs(t *testing.T) {
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assertNoEror(t, err)
 
-	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentArgs("openshift-pipelines"))
+	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentArgs([]string{"tekton-results-watcher"}, "openshift-pipelines"))
 	assertNoEror(t, err)
 
 	d := &appsv1.Deployment{}

--- a/pkg/reconciler/kubernetes/tektondashboard/testdata/test-dashboard-transformer-updated.yaml
+++ b/pkg/reconciler/kubernetes/tektondashboard/testdata/test-dashboard-transformer-updated.yaml
@@ -404,15 +404,15 @@ spec:
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/part-of: tekton-dashboard
         app.kubernetes.io/version: v0.48.0
-        operator.tekton.dev/deployment-spec-applied-hash: 0d7e625dccc2efab4493c409bdc71e88
+        operator.tekton.dev/deployment-spec-applied-hash: e521024acd6c6a280dc53fb4de0a6725
       name: tekton-dashboard
     spec:
       containers:
         - args:
             - --port=9097
             - --logout-url=
-            - --pipelines-namespace=tekton-pipelines
-            - --triggers-namespace=tekton-pipelines
+            - --pipelines-namespace=foo-ns
+            - --triggers-namespace=foo-ns
             - --read-only=false
             - --log-level=info
             - --log-format=json

--- a/pkg/reconciler/kubernetes/tektondashboard/transform.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/transform.go
@@ -33,6 +33,7 @@ const (
 func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
 		dashboard := comp.(*v1alpha1.TektonDashboard)
+		targetNamespace := dashboard.Spec.GetTargetNamespace()
 
 		images := common.ToLowerCaseKeys(common.ImagesFromEnv(common.DashboardImagePrefix))
 
@@ -42,6 +43,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfiguration(dashboard.Spec.Config),
 			common.AddDeploymentRestrictedPSA(),
 			common.DeploymentImages(images),
+			common.ReplaceNamespaceInDeploymentArgs([]string{dashboardDeploymentName}, targetNamespace),
 		}
 		trns = append(trns, extra...)
 		if dashboard.Spec.ExternalLogs != "" {
@@ -54,7 +56,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 
 		// additional options transformer
 		// always execute as last transformer, so that the values in options will be final update values on the manifests
-		if err := common.ExecuteAdditionalOptionsTransformer(ctx, manifest, dashboard.Spec.GetTargetNamespace(), dashboard.Spec.Dashboard.Options); err != nil {
+		if err := common.ExecuteAdditionalOptionsTransformer(ctx, manifest, targetNamespace, dashboard.Spec.Dashboard.Options); err != nil {
 			return &mf.Manifest{}, err
 		}
 

--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -55,9 +55,13 @@ const (
 	loggingForwarderDelayDuration = "LOGGING_PLUGIN_FORWARDER_DELAY_DURATION"
 	logsAPIKey                    = "LOGS_API"
 	logsTypeKey                   = "LOGS_TYPE"
+
+	resultAPIDeployment     = "tekton-results-api"
+	resultWatcherDeployment = "tekton-results-watcher"
 )
 
 var (
+	resultDeployementNames = []string{resultAPIDeployment, resultWatcherDeployment}
 	// allowed property secret keys
 	allowedPropertySecretKeys = []string{
 		"S3_BUCKET_NAME",
@@ -81,8 +85,8 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	extra := []mf.Transformer{
 		common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdResults),
 		common.ApplyProxySettings,
-		common.ReplaceNamespaceInDeploymentArgs(targetNs),
-		common.ReplaceNamespaceInDeploymentEnv(targetNs),
+		common.ReplaceNamespaceInDeploymentArgs([]string{resultWatcherDeployment}, targetNs),
+		common.ReplaceNamespaceInDeploymentEnv(resultDeployementNames, targetNs),
 		updateApiConfig(instance.Spec),
 		enablePVCLogging(instance.Spec.ResultsAPIProperties),
 		updateEnvWithSecretName(instance.Spec.ResultsAPIProperties),


### PR DESCRIPTION
# Changes

Fixes #2438 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
- Remove `results` specific details from the common transformer code
- Ensure the configured `TargetNamespace`  overrides the default namespace in the Dashboard's container args

I've tested this locally and confirmed that the Operator created a deployment for the Dashboard with the correct namespace override per the workflow described in #2438 , however it would be good to have someone test and verify the effect on their end as well


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
When `defaultTargetNamespace` is specified in the Tekton Config, the value will now override the Dashboard's container args `--pipelines-namespace` and `--triggers-namespace`.
```
