### PR TITLE
Add proxy in the ConsolePlugin

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -135,5 +135,14 @@ spec:
       namespace: openshift-pipelines
       port: 8443
       basePath: "/"
+  proxy:
+    - type: Service
+      alias: tekton-results-api-service
+      endpoint:
+        type: Service
+        service:
+          name: tekton-results-api-service
+          namespace: openshift-pipeline
+          port: 8080
   i18n:
     loadType: Preload   # options: Preload, Lazy


### PR DESCRIPTION
This patch adds a proxy to result api server in pipelines-console-plugin 
in order to send Authorization headers to Results API

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
This adds a proxy to result api server in pipelines-console-plugin 
in order to send Authorization headers to Results API
```