### PR TITLE
Fix fetch-component-release task in nightly release

### DIFF
--- a/tekton/task-fetch-components.yaml
+++ b/tekton/task-fetch-components.yaml
@@ -14,7 +14,7 @@ spec:
     description: Target platform for for which the payload is going to be used
     default: "kubernetes openshift"
   steps:
-  - image: docker.io/library/golang:1.22@sha256:4594271250150c1a322ed749abfd218e1a8c6eb1ade90872e325a664412e2037
+  - image: docker.io/library/golang:1.23@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4
     name: fetch-components
     workingDir: /go/src/github.com/tektoncd/operator
     script: |


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update image to golang 1.23 to match version specified in go.mod

```
Fetching Tekton components for kubernetes build
go: go.mod requires go >= 1.23 (running go 1.22.7; GOTOOLCHAIN=local)
make: *** [Makefile:111: get-releases] Error 1
```

See recent nightly runs: https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-nightly/pipelineruns?labelSelector=tekton.dev%2Fpipeline%3Doperator-operator-release

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
