### PR TITLE
Only modify chains properties on upgrade

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
@@ -55,9 +55,7 @@ func upgradeChainProperties(ctx context.Context, logger *zap.SugaredLogger, k8sC
 		}
 	}
 
-	tc.Spec.Chain = v1alpha1.Chain{
-		ChainProperties: chain,
-	}
+	tc.Spec.Chain.ChainProperties = chain
 
 	_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Update(ctx, tc, metav1.UpdateOptions{})
 	return err


### PR DESCRIPTION
During upgrade when modifying tektonConfig for chains it also reset the `Disabled` flag, modifying only Chain Properties can fix the issue

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Chains Disabled status in TektonConfig no longer resets on Operator upgrade.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
