### PR TITLE
add trigger creation as prerequisite to dashboard e2e to ensure tekto…

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -3,13 +3,13 @@ chains:
   version: v0.23.1
 dashboard:
   github: tektoncd/dashboard
-  version: v0.53.0
+  version: v0.54.0
 hub:
   github: tektoncd/hub
-  version: v1.19.2
+  version: v1.20.0
 manual-approval-gate:
   github: openshift-pipelines/manual-approval-gate
-  version: v0.4.1
+  version: v0.5.0
 pipeline:
   github: tektoncd/pipeline
   version: v0.68.0
@@ -21,4 +21,4 @@ results:
   version: v0.13.3
 triggers:
   github: tektoncd/triggers
-  version: v0.30.1
+  version: v0.31.0

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -310,12 +310,12 @@ spec:
     ### Components
 
     - Tekton Pipelines: v0.68.0
-    - Tekton Triggers: v0.30.1
+    - Tekton Triggers: v0.31.0
     - Pipelines as Code: v0.32.0
     - Tekton Chains: v0.23.1
-    - Tekton Hub (tech-preview): v1.19.2
+    - Tekton Hub (tech-preview): v1.20.0
     - Tekton Results (tech-preview): v0.13.3
-    - Manual Approval Gate (tech-preview): v0.4.1
+    - Manual Approval Gate (tech-preview): v0.5.0
 
     ## Getting Started
 

--- a/test/e2e/kubernetes/tektondashboarddeployment_test.go
+++ b/test/e2e/kubernetes/tektondashboarddeployment_test.go
@@ -34,6 +34,7 @@ func TestTektonDashboardsDeployment(t *testing.T) {
 	crNames := utils.ResourceNames{
 		TektonConfig:    "config",
 		TektonPipeline:  "pipeline",
+		TektonTrigger:   "trigger",
 		TektonDashboard: "dashboard",
 		TargetNamespace: "tekton-pipelines",
 	}
@@ -41,10 +42,12 @@ func TestTektonDashboardsDeployment(t *testing.T) {
 	clients := client.Setup(t, crNames.TargetNamespace)
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownDashboard(clients, crNames.TektonTrigger) })
 	utils.CleanupOnInterrupt(func() { utils.TearDownDashboard(clients, crNames.TektonDashboard) })
 	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
 	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
 	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+	defer utils.TearDownTrigger(clients, crNames.TektonTrigger)
 	defer utils.TearDownDashboard(clients, crNames.TektonDashboard)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
@@ -57,6 +60,16 @@ func TestTektonDashboardsDeployment(t *testing.T) {
 	// Test if TektonPipeline can reach the READY status
 	t.Run("create-pipeline", func(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+	})
+
+	// Create a TektonTrigger
+	if _, err := resources.EnsureTektonTriggerExists(clients.TektonTrigger(), crNames); err != nil {
+		t.Fatalf("TektonTrigger %q failed to create: %v", crNames.TektonTrigger, err)
+	}
+
+	// Test if TektonTrigger can reach the READY status
+	t.Run("create-trigger", func(t *testing.T) {
+		resources.AssertTektonTriggerCRReadyStatus(t, clients, crNames)
 	})
 
 	// Create a TektonDashboard


### PR DESCRIPTION
…n-triggers-aggregate-view cluster role

# Changes
This fixes e2e test failing on this PR https://github.com/tektoncd/operator/pull/2548
it adds trigger cr creation as prerequisite to dashboard e2e to ensure tekton-triggers-aggregate-view cluster role
The error is described on the PR https://github.com/tektoncd/operator/pull/2548
e2e on dashboard are failing with this
```
dashboard   v0.54.0   False   Installer set not ready: Main Reconcilation failed: TektonDashboard/main: installer set not ready, will retry: Install failed with message: clusterroles.rbac.authorization.k8s.io "tekton-triggers-aggregate-view" not found

```
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
