### PR TITLE
Support addition of new containers provided as options

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -606,12 +606,12 @@ The following fields are supported in `deployment`
       * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
       * `runtimeClassName` - adds and updates runtimeClassName
       * `volumes` - adds and updates volumes
-      * `initContainers` - updates init-containers
+      * `initContainers` - adds and updates init-containers
         * `resources` - replaces the resources requirements with this, if not empty
         * `envs` - adds and updates environments
         * `volumeMounts` - adds and updates VolumeMounts
         * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
-      * `containers` - updates containers
+      * `containers` - adds and updates containers
         * `resources` - replaces the resources requirements with this, if not empty
         * `envs` - adds and updates environments
         * `volumeMounts` - adds and updates VolumeMounts
@@ -641,12 +641,12 @@ The following fields are supported in `StatefulSet`
       * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
       * `runtimeClassName` - adds and updates runtimeClassName
       * `volumes` - adds and updates volumes
-      * `initContainers` - updates init-containers
+      * `initContainers` - adds and updates init-containers
         * `resources` - replaces the resources requirements with this, if not empty
         * `envs` - adds and updates environments
         * `volumeMounts` - adds and updates VolumeMounts
         * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
-      * `containers` - updates containers
+      * `containers` - adds and updates containers
         * `resources` - replaces the resources requirements with this, if not empty
         * `envs` - adds and updates environments
         * `volumeMounts` - adds and updates VolumeMounts

--- a/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-deployment-add-container.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-deployment-add-container.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-pipelines
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  test: "123"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-events
+  namespace: tekton-pipelines
+  creationTimestamp: null
+data:
+  event1: no-data
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: tekton-pipelines-resolvers
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  buckets: "2"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: controller
+    controlled-by-options: "true"
+  annotations:
+    hpa-enabled: "false"
+status: {}
+spec:
+  strategy: {}
+  replicas: 4
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        annotation-foo: annotation-bar
+      labels:
+        app.kubernetes.io/name: controller
+        label-foo: label-bar
+        operator.tekton.dev/deployment-spec-applied-hash: 431f8b0948750a2b5e232680c9655a1f
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+                      - nvme
+                      - ramdisk
+      priorityClassName: test
+      runtimeClassName: foo
+      serviceAccountName: tekton-pipelines-controller
+      nodeSelector:
+        zone: east
+      tolerations:
+        - key: zone
+          operator: Equal
+          value: west
+          effect: NoSchedule
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: foo
+          matchLabelKeys:
+            - pod-template-hash
+      containers:
+        - name: container-xyz
+          resources: {}
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1@sha256:9025991c337374dadce6d49e29fbcf86b233ab8f5f96748c67293b2285c3e0b6
+          args:
+            - "-entrypoint-image"
+            - "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.50.1@sha256:0c66040a16142a598d5aa9f310b1cbf66e843aa7114188f5d0ab5d36b463a09b"
+            - "--disable-ha=false"
+          volumeMounts:
+            - name: config-logging
+              mountPath: /etc/config-logging-tmp
+            - name: config-registry-cert
+              mountPath: /etc/config-registry-cert
+            - name: custom-mount
+              mountPath: /etc/custom-mount
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_DEFAULTS_NAME
+              value: config-defaults
+            - name: CONFIG_LOGGING_NAME
+              value: pipeline-config-logging
+            - name: ENV_FOO
+              value: bar
+            - name: ENV_FROM_CONFIG_MAP
+              valueFrom:
+                configMapKeyRef:
+                  name: config-map-foo
+                  key: foo
+                  optional: true
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: probes
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=http://127.0.0.1:9090/
+            - --logtostderr=true
+            - --v=6
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          name: kube-rbac-proxy
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+      volumes:
+        - name: config-logging
+          hostPath:
+            path: /etc/config-logging
+        - name: config-registry-cert
+          configMap:
+            name: config-registry-cert
+        - name: my-custom-logs
+          hostPath:
+            path: /var/custom/logs

--- a/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-deployment-add-initcontainer.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-deployment-add-initcontainer.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-pipelines
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  test: "123"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-events
+  namespace: tekton-pipelines
+  creationTimestamp: null
+data:
+  event1: no-data
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: tekton-pipelines-resolvers
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  buckets: "2"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: controller
+    controlled-by-options: "true"
+  annotations:
+    hpa-enabled: "false"
+status: {}
+spec:
+  strategy: {}
+  replicas: 4
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        annotation-foo: annotation-bar
+      labels:
+        app.kubernetes.io/name: controller
+        label-foo: label-bar
+        operator.tekton.dev/deployment-spec-applied-hash: 6586234cd0d01964baea5323902c39eb
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+                      - nvme
+                      - ramdisk
+      priorityClassName: test
+      runtimeClassName: foo
+      serviceAccountName: tekton-pipelines-controller
+      nodeSelector:
+        zone: east
+      tolerations:
+        - key: zone
+          operator: Equal
+          value: west
+          effect: NoSchedule
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: foo
+          matchLabelKeys:
+            - pod-template-hash
+      containers:
+        - name: container-xyz
+          resources: {}
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1@sha256:9025991c337374dadce6d49e29fbcf86b233ab8f5f96748c67293b2285c3e0b6
+          args:
+            - "-entrypoint-image"
+            - "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.50.1@sha256:0c66040a16142a598d5aa9f310b1cbf66e843aa7114188f5d0ab5d36b463a09b"
+            - "--disable-ha=false"
+          volumeMounts:
+            - name: config-logging
+              mountPath: /etc/config-logging-tmp
+            - name: config-registry-cert
+              mountPath: /etc/config-registry-cert
+            - name: custom-mount
+              mountPath: /etc/custom-mount
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_DEFAULTS_NAME
+              value: config-defaults
+            - name: CONFIG_LOGGING_NAME
+              value: pipeline-config-logging
+            - name: ENV_FOO
+              value: bar
+            - name: ENV_FROM_CONFIG_MAP
+              valueFrom:
+                configMapKeyRef:
+                  name: config-map-foo
+                  key: foo
+                  optional: true
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: probes
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      initContainers:
+        - args:
+            - -c
+            - echo foo
+          command:
+            - /bin/bash
+          image: busybox:latest
+          name: test-init-container
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: config-logging
+          hostPath:
+            path: /etc/config-logging
+        - name: config-registry-cert
+          configMap:
+            name: config-registry-cert
+        - name: my-custom-logs
+          hostPath:
+            path: /var/custom/logs

--- a/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-statefulset-add-container.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-statefulset-add-container.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - image: registry.k8s.io/nginx-slim:0.8
+          name: nginx
+          ports:
+            - containerPort: 80
+              name: web
+          resources: {}
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html
+              name: www
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=http://127.0.0.1:9090/
+            - --logtostderr=true
+            - --v=6
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          name: kube-rbac-proxy
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+      runtimeClassName: foo
+  updateStrategy: {}
+  volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        name: www
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-statefulset-add-initcontainer.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-runtimeclassname-statefulset-add-initcontainer.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - image: registry.k8s.io/nginx-slim:0.8
+          name: nginx
+          ports:
+            - containerPort: 80
+              name: web
+          resources: {}
+          volumeMounts:
+            - mountPath: /usr/share/nginx/html
+              name: www
+      initContainers:
+        - args:
+            - -c
+            - echo foo
+          command:
+            - /bin/bash
+          image: busybox:latest
+          name: test-init-container
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      runtimeClassName: foo
+  updateStrategy: {}
+  volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        name: www
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/pkg/reconciler/common/transformer_additional_options.go
+++ b/pkg/reconciler/common/transformer_additional_options.go
@@ -353,12 +353,16 @@ func (ot *OptionsTransformer) updateVolumes(sourceVolumes, additionalVolumes []c
 }
 
 func (ot *OptionsTransformer) updateContainers(targetContainers, containersOptions []corev1.Container) []corev1.Container {
+	containersToAdd := []corev1.Container{}
 	for _, containerOptions := range containersOptions {
+		containerFound := false
 		for containerIndex := range targetContainers {
 			targetContainer := targetContainers[containerIndex]
 			if containerOptions.Name != targetContainer.Name {
 				continue
 			}
+
+			containerFound = true
 
 			// update resource requirements
 			if containerOptions.Resources.Size() != 0 {
@@ -409,7 +413,14 @@ func (ot *OptionsTransformer) updateContainers(targetContainers, containersOptio
 			targetContainers[containerIndex].Args = append(targetContainers[containerIndex].Args, containerOptions.Args...)
 
 		}
+
+		// add the new container from the options list
+		if !containerFound {
+			containersToAdd = append(containersToAdd, containerOptions)
+		}
 	}
+
+	targetContainers = append(targetContainers, containersToAdd...)
 
 	return targetContainers
 }

--- a/pkg/reconciler/common/transformer_additional_options_test.go
+++ b/pkg/reconciler/common/transformer_additional_options_test.go
@@ -594,6 +594,81 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-deployment.yaml",
 		},
 		{
+			name: "test-runtimeclassname-for-deployments-add-container",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RuntimeClassName: ptr.String("foo"),
+									Containers: []corev1.Container{
+										{
+											Name:  "kube-rbac-proxy",
+											Image: "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12",
+											Resources: corev1.ResourceRequirements{
+												Limits: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.MustParse("500m"),
+													corev1.ResourceMemory: resource.MustParse("128Mi"),
+												},
+											},
+											Args: []string{
+												"--secure-listen-address=0.0.0.0:9443",
+												"--upstream=http://127.0.0.1:9090/",
+												"--logtostderr=true",
+												"--v=6",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-runtimeclassname-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-deployment-add-container.yaml",
+		},
+		{
+			name: "test-runtimeclassname-for-deployments-add-init-container",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RuntimeClassName: ptr.String("foo"),
+									InitContainers: []corev1.Container{
+										{
+											Name:  "test-init-container",
+											Image: "busybox:latest",
+											Resources: corev1.ResourceRequirements{
+												Limits: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.MustParse("100m"),
+													corev1.ResourceMemory: resource.MustParse("128Mi"),
+												},
+											},
+											Args: []string{
+												"-c",
+												"echo foo",
+											},
+											Command: []string{
+												"/bin/bash",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-runtimeclassname-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-deployment-add-initcontainer.yaml",
+		},
+		{
 			name: "test-runtimeclassname-for-statefulsets",
 			additionalOptions: v1alpha1.AdditionalOptions{
 				Disabled: ptr.Bool(false),
@@ -603,11 +678,6 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RuntimeClassName: ptr.String("foo"),
-									Containers: []corev1.Container{
-										{
-											Resources: corev1.ResourceRequirements{},
-										},
-									},
 								},
 							},
 						},
@@ -627,6 +697,81 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 			},
 			inputFilename:          "./testdata/test-additional-options-base-runtimeclassname-statefulset.yaml",
 			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-statefulset.yaml",
+		},
+		{
+			name: "test-runtimeclassname-for-statefulsets-add-container",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				StatefulSets: map[string]appsv1.StatefulSet{
+					"web": {
+						Spec: appsv1.StatefulSetSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RuntimeClassName: ptr.String("foo"),
+									Containers: []corev1.Container{
+										{
+											Name:  "kube-rbac-proxy",
+											Image: "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12",
+											Resources: corev1.ResourceRequirements{
+												Limits: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.MustParse("500m"),
+													corev1.ResourceMemory: resource.MustParse("128Mi"),
+												},
+											},
+											Args: []string{
+												"--secure-listen-address=0.0.0.0:9443",
+												"--upstream=http://127.0.0.1:9090/",
+												"--logtostderr=true",
+												"--v=6",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-runtimeclassname-statefulset.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-statefulset-add-container.yaml",
+		},
+		{
+			name: "test-runtimeclassname-for-statefulsets-add-initContainers",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				StatefulSets: map[string]appsv1.StatefulSet{
+					"web": {
+						Spec: appsv1.StatefulSetSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RuntimeClassName: ptr.String("foo"),
+									InitContainers: []corev1.Container{
+										{
+											Name:  "test-init-container",
+											Image: "busybox:latest",
+											Resources: corev1.ResourceRequirements{
+												Limits: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.MustParse("100m"),
+													corev1.ResourceMemory: resource.MustParse("128Mi"),
+												},
+											},
+											Args: []string{
+												"-c",
+												"echo foo",
+											},
+											Command: []string{
+												"/bin/bash",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-runtimeclassname-statefulset.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-runtimeclassname-statefulset-add-initcontainer.yaml",
 		},
 	}
 


### PR DESCRIPTION
If a container or initContainer is provided in options of deployment or statefulset, if a container or initContainer with that name exists, the properties for of that container will be updated with the values provided in options.
With that change, if there is no match, the container or initContainer from options will be added to the deployments and statefulsets.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Existing TektonConfig manifests, with additional options for deployments and statefulSets
and including new containers and initContainers, those containers and initContainers will
now be added to the deployments and statefulSets. Previously new containers and 
initContainers were ignored and only existing containers and initContainers were updated
with the configuration added as additional options.
```