### PR TITLE
Fix image pull error due to missing sha256

### DIFF
--- a/charts/tekton-operator/templates/_helpers.tpl
+++ b/charts/tekton-operator/templates/_helpers.tpl
@@ -112,9 +112,11 @@ tekton-operator
 {{- end -}}
 
 {{- define "tekton-operator.pruner-image" -}}
-{{- $tag := .Values.pruner.image.tag -}}
-{{- $image := .Values.pruner.image.repository -}}
-{{- printf "%s:%s" $image $tag -}}
+{{- if contains "sha256:" .Values.pruner.image.tag -}}
+{{- printf "%s@%s" .Values.pruner.image.repository .Values.pruner.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.pruner.image.repository .Values.pruner.image.tag -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "tekton-operator.webhook-image" -}}

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -56,7 +56,7 @@ pruner:
   image:
     # Container image for Tekton pruner. Defaults to gcr.
     repository: "ghcr.io/tektoncd/plumbing/tkn"
-    tag: "233de6c8b8583a34c2379fa98d42dba739146c9336e8d41b66030484357481ed"
+    tag: "sha256:233de6c8b8583a34c2379fa98d42dba739146c9336e8d41b66030484357481ed"
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

The cronjob for tekton pruner fails as it cannot pull the image 

failed to pull and unpack image "gcr.io/tekton-releases/dogfooding/tkn:8d4383ff675cdf

The image for example should have been "gcr.io/tekton-releases/dogfooding/tkn@sha256:8d4383ff675cdf (missing @sha256). This small change fixes it.

Fixes #2495 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
