### PR TITLE
update tasks images from 0.3.3 to 0.3.4

### DIFF
--- a/hack/openshift/fetch-tektoncd-catalog-tasks.sh
+++ b/hack/openshift/fetch-tektoncd-catalog-tasks.sh
@@ -55,22 +55,22 @@ declare -A TEKTON_CATALOG_TASKS=(
 )
 declare -r TEKTON_ECOSYSTEM="https://raw.githubusercontent.com/openshift-pipelines/tektoncd-catalog"
 declare -A TEKTON_ECOSYSTEM_TASKS=(
-  ['task-buildah']="0.3.3"
+  ['task-buildah']="0.3.4"
   ['task-git-cli']="0.3.1"
   ['task-git-clone']='0.3.1'
   ['task-kn-apply']='0.1.1'
   ['task-kn']='0.1.1'
   ['task-maven']="0.2.1"
   ['task-openshift-client']="0.1.1"
-  ['task-s2i-dotnet']='0.3.3'
-  ['task-s2i-go']='0.3.3'
-  ['task-s2i-java']='0.3.3'
-  ['task-s2i-nodejs']='0.3.3'
-  ['task-s2i-perl']='0.3.3'
-  ['task-s2i-php']='0.3.3'
-  ['task-s2i-python']='0.3.3'
-  ['task-s2i-ruby']='0.3.3'
-  ['task-skopeo-copy']='0.3.3'
+  ['task-s2i-dotnet']='0.3.4'
+  ['task-s2i-go']='0.3.4'
+  ['task-s2i-java']='0.3.4'
+  ['task-s2i-nodejs']='0.3.4'
+  ['task-s2i-perl']='0.3.4'
+  ['task-s2i-php']='0.3.4'
+  ['task-s2i-python']='0.3.4'
+  ['task-s2i-ruby']='0.3.4'
+  ['task-skopeo-copy']='0.3.4'
   ['task-tkn']='0.1.1'
 )
 


### PR DESCRIPTION
issue: SRVKP-7078
fixes buildah permission issue by adding readonly mount option to entitlement volume to avoid defaut remounting readwrite permissions This change was added in 74.x but there are some users who are still on 71.x so backported the task versions

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
