### PR TITLE
docs: correct hyperlink error in results component documentation

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -112,7 +112,7 @@ spec:
   prometheus_histogram: false
 ```
 
-These properties are analogous to the one in configmap of tekton results api `tekton-results-api-config` documented at [api.md]:https://github.com/tektoncd/results/blob/4472848a0fb7c1473cfca8b647553170efac78a1/cmd/api/README.md
+These properties are analogous to the one in configmap of tekton results api `tekton-results-api-config` documented at [api.md](https://github.com/tektoncd/results/blob/4472848a0fb7c1473cfca8b647553170efac78a1/cmd/api/README.md)
 
 
 [result]:https://github.com/tektoncd/results


### PR DESCRIPTION
# Changes

Currently:
https://tekton.dev/docs/operator/tektonresult/

![Shot 2025 02 18 at 12 03 25](https://github.com/user-attachments/assets/bf1f9cb2-9338-4822-8ed4-096d3890cb32)


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```