### PR TITLE
fix(docs): correct configuration error in TektonResult

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -97,7 +97,7 @@ spec:
   log_level: debug
   logs_api: true
   logs_type: File
-  logs_buffer_size: 90kb
+  logs_buffer_size: 32768
   logs_path: /logs
   auth_disable: true
   logging_pvc_name: tekton-logs


### PR DESCRIPTION
# Changes

Corrected the configuration error in the TektonResults example.

1. The type definition of `logs_buffer_size` is `*int64`.

https://github.com/tektoncd/operator/blob/713b96bff3fa1e01a395b61281a1807d8d29a4f9/pkg/apis/operator/v1alpha1/tektonresult_types.go#L88

2. Samples from other places also store numbers.

https://github.com/tektoncd/operator/blob/713b96bff3fa1e01a395b61281a1807d8d29a4f9/config/crs/kubernetes/result/operator_v1alpha1_result_cr.yaml#L18-L28

3. If created according to the current example, an error will occur:

```
admission webhook "webhook.operator.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: cannot unmarshal string into Go struct field TektonResultSpec.spec.logs_buffer_size of type int64
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
docs: corrected the configuration error in the example of `TektonResult`
```

/kind bug