### PR TITLE
Preserve the existing TektonResult CR configuration

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -35,7 +35,8 @@ var (
 		resetTektonConfigConditions, // upgrade #1: removes conditions from TektonConfig CR, clears outdated conditions
 		upgradePipelineProperties,   // upgrade #2: update default value of enable-step-actions from false to true
 		// Todo: Remove the removeDeprecatedAddonParams upgrade function in next operator release
-		removeDeprecatedAddonParams, // upgrade #3: remove the deprecated cluster task params from TektonConfig CR's addon params
+		removeDeprecatedAddonParams,    // upgrade #3: remove the deprecated cluster task params from TektonConfig CR's addon params
+		copyResultConfigToTektonConfig, // upgrade #4: copy existing TektonResult configuration to the TektonConfig CR
 	}
 
 	// post upgrade functions


### PR DESCRIPTION
Now TektonResult is installed by the TektonConfig, TektonConfig config was creating TektonResult CR with default configuration and also not preserving the exsiting TektonResult configuration, now this patch fixes to preserve the TektonResult configuration

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Preserve the existing TektonResult CR configuration
```

