### PR TITLE
Convert result watcher deployment to statefulset ordinals

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -121,7 +121,11 @@ spec:
     disabled: false
     is_external_db: false
     options: {}
-  platforms:
+    performance:
+      disable-ha: false
+      buckets: 1
+      replicas: 1
+platforms:
     openshift:
       pipelinesAsCode:
         additionalPACControllers:

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -73,6 +73,8 @@ type Result struct {
 	LokiStackProperties `json:",inline"`
 	// Options holds additions fields and these fields will be updated on the manifests
 	Options AdditionalOptions `json:"options"`
+	// +optional
+	Performance PerformanceProperties `json:"performance,omitempty"`
 }
 
 // ResultsAPIProperties defines the fields which are configurable for

--- a/pkg/apis/operator/v1alpha1/tektonresult_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_validation.go
@@ -53,5 +53,9 @@ func (trs *TektonResultSpec) validate(path string) (errs *apis.FieldError) {
 			errs = errs.Also(apis.ErrInvalidValue(trs.LokiStackNamespace, fmt.Sprintf("%s.loki_stack_namespace", path), errMsg))
 		}
 	}
+
+	// validate performance properties
+	errs = errs.Also(trs.Performance.Validate(fmt.Sprintf("%s.performance", path)))
+
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_validation_test.go
@@ -36,3 +36,80 @@ func TestTektonResult_Validate(t *testing.T) {
 	err := tc.Validate(context.TODO())
 	assert.Equal(t, "invalid value: wrong-name: metadata.name, Only one instance of TektonResult is allowed by name, result", err.Error())
 }
+
+func TestTektonResultWatcherPerformancePropertiesValidate(t *testing.T) {
+	tr := &TektonResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "result",
+			Namespace: "bar",
+		},
+		Spec: TektonResultSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "foo",
+			},
+		},
+	}
+
+	// Helper to return a pointer to a uint
+	getBuckets := func(value uint) *uint {
+		return &value
+	}
+
+	// Helper to return a pointer to an int32
+	getReplicas := func(value int32) *int32 {
+		return &value
+	}
+
+	statefulsetOrdinals := true
+
+	// --- Validate buckets below the minimum range (0) ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	tr.Spec.Performance.Buckets = getBuckets(0)
+	errs := tr.Validate(context.TODO())
+	assert.Equal(t, "expected 1 <= 0 <= 10: spec.performance.buckets", errs.Error())
+
+	// --- Validate buckets above the maximum range (11) ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	tr.Spec.Performance.Buckets = getBuckets(11)
+	errs = tr.Validate(context.TODO())
+	assert.Equal(t, "expected 1 <= 11 <= 10: spec.performance.buckets", errs.Error())
+
+	// --- Validate valid buckets (minimum valid value: 1) ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	tr.Spec.Performance.Buckets = getBuckets(1)
+	errs = tr.Validate(context.TODO())
+	assert.Equal(t, "", errs.Error())
+
+	// --- Validate valid buckets (maximum valid value: 10) ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	tr.Spec.Performance.Buckets = getBuckets(10)
+	errs = tr.Validate(context.TODO())
+	assert.Equal(t, "", errs.Error())
+
+	// --- Validate valid configuration when StatefulsetOrdinals is true and buckets equal replicas ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	bucketValue := uint(5)
+	tr.Spec.Performance.Buckets = getBuckets(bucketValue)
+	replicaValue := int32(5)
+	tr.Spec.Performance.Replicas = getReplicas(replicaValue)
+	tr.Spec.Performance.StatefulsetOrdinals = &statefulsetOrdinals
+	errs = tr.Validate(context.TODO())
+	assert.Equal(t, "", errs.Error())
+
+	// --- Validate error when buckets do not equal replicas while StatefulsetOrdinals is true ---
+	tr.Spec.Performance = PerformanceProperties{}
+	tr.Spec.Performance.DisableHA = false
+	tr.Spec.Performance.StatefulsetOrdinals = &statefulsetOrdinals
+	bucketValue = uint(5)
+	tr.Spec.Performance.Buckets = getBuckets(bucketValue)
+	tr.Spec.Performance.Replicas = getReplicas(3)
+	errs = tr.Validate(context.TODO())
+	expectedErrorMessage := "invalid value: 3: spec.performance.replicas\n" +
+		"spec.performance.replicas must equal spec.performance.buckets for statefulset ordinals"
+	assert.Equal(t, expectedErrorMessage, errs.Error())
+}

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1217,6 +1217,7 @@ func (in *Result) DeepCopyInto(out *Result) {
 	in.ResultsAPIProperties.DeepCopyInto(&out.ResultsAPIProperties)
 	out.LokiStackProperties = in.LokiStackProperties
 	in.Options.DeepCopyInto(&out.Options)
+	in.Performance.DeepCopyInto(&out.Performance)
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektonresult/installerset.go
+++ b/pkg/reconciler/kubernetes/tektonresult/installerset.go
@@ -54,13 +54,20 @@ func (r *Reconciler) createInstallerSet(ctx context.Context, tr *v1alpha1.Tekton
 
 func (r *Reconciler) makeInstallerSet(tr *v1alpha1.TektonResult, manifest mf.Manifest, trSpecHash string) *v1alpha1.TektonInstallerSet {
 	ownerRef := *metav1.NewControllerRef(tr, tr.GetGroupVersionKind())
+	// Determine the subtype based on statefulset mode.
+	mode := "deployment"
+	if tr.Spec.Performance.StatefulsetOrdinals != nil && *tr.Spec.Performance.StatefulsetOrdinals {
+		mode = "statefulset"
+	}
+
 	return &v1alpha1.TektonInstallerSet{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", v1alpha1.ResultResourceName),
 			Labels: map[string]string{
-				v1alpha1.CreatedByKey:      createdByValue,
-				v1alpha1.InstallerSetType:  v1alpha1.ResultResourceName,
-				v1alpha1.ReleaseVersionKey: r.operatorVersion,
+				v1alpha1.CreatedByKey:            createdByValue,
+				v1alpha1.InstallerSetType:        v1alpha1.ResultResourceName,
+				v1alpha1.ReleaseVersionKey:       r.operatorVersion,
+				v1alpha1.InstallerSetInstallType: mode,
 			},
 			Annotations: map[string]string{
 				v1alpha1.TargetNamespaceKey: tr.Spec.TargetNamespace,

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -17,19 +17,19 @@ limitations under the License.
 package tektonresult
 
 import (
-	"fmt"
 	"path"
-	"testing"
 
 	mf "github.com/manifestival/manifestival"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-
-	"gotest.tools/v3/assert"
-
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"fmt"
+	"testing"
+
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_enablePVCLogging(t *testing.T) {

--- a/pkg/reconciler/shared/tektonconfig/result/result.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result.go
@@ -132,6 +132,11 @@ func UpdateResult(ctx context.Context, old *v1alpha1.TektonResult, new *v1alpha1
 		updated = true
 	}
 
+	if !reflect.DeepEqual(old.Spec.Performance, new.Spec.Performance) {
+		old.Spec.Performance = new.Spec.Performance
+		updated = true
+	}
+
 	if old.ObjectMeta.OwnerReferences == nil {
 		old.ObjectMeta.OwnerReferences = new.ObjectMeta.OwnerReferences
 		updated = true

--- a/test/e2e/kubernetes/tektonresultstatefulset_test.go
+++ b/test/e2e/kubernetes/tektonresultstatefulset_test.go
@@ -1,0 +1,98 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+)
+
+// TestTektonResultDeployment verifies the TektonResult creation, deployment recreation, and TektonResult deletion.
+func TestTektonResultsWatcherStatefulset(t *testing.T) {
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("Tekton Result is not available for %q", platform)
+	}
+
+	crNames := utils.ResourceNames{
+		TektonConfig:    "config",
+		TektonPipeline:  "pipeline",
+		TektonResult:    "result",
+		TargetNamespace: "tekton-pipelines",
+	}
+
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownResult(clients, crNames.TektonResult) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+	defer utils.TearDownResult(clients, crNames.TektonResult)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	// Create a TektonPipeline
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+
+	// Test if TektonPipeline can reach the READY status
+	t.Run("create-pipeline", func(t *testing.T) {
+		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+	})
+
+	// Before Installing Results, create the required secrets
+	t.Run("create-secrets", func(t *testing.T) {
+		createSecret(t, clients, crNames.TargetNamespace)
+	})
+
+	// Create a TektonResult
+	if _, err := resources.EnsureTektonResultWithStatefulsetExists(clients.TektonResult(), crNames); err != nil {
+		t.Fatalf("TektonResult %q failed to create: %v", crNames.TektonResult, err)
+	}
+
+	// Test if TektonResult can reach the READY status
+	t.Run("create-result", func(t *testing.T) {
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+	})
+
+	t.Run("restore-result-watcher-statefulset", func(t *testing.T) {
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+		resources.DeleteAndVerifyStatefulSet(t, clients, crNames.TargetNamespace, utils.TektonResultsDeploymentLabel)
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+	})
+
+	// Delete the TektonResult CR instance to see if all resources will be removed
+	t.Run("delete-result", func(t *testing.T) {
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+		resources.TektonResultCRDDelete(t, clients, crNames)
+	})
+
+	// Delete the TektonPipeline CR instance to see if all resources will be removed
+	t.Run("delete-pipeline", func(t *testing.T) {
+		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+		resources.TektonPipelineCRDelete(t, clients, crNames)
+	})
+}

--- a/test/resources/tektonresults.go
+++ b/test/resources/tektonresults.go
@@ -61,6 +61,38 @@ func EnsureTektonResultExists(clients resultv1alpha1.TektonResultInterface, name
 	return trCR, err
 }
 
+// Creates a TektonResult with the name names.TektonResult and statefulset for result watcher, if it does not exist.
+func EnsureTektonResultWithStatefulsetExists(clients resultv1alpha1.TektonResultInterface, names utils.ResourceNames) (*v1alpha1.TektonResult, error) {
+	trCR, err := clients.Get(context.TODO(), names.TektonResult, metav1.GetOptions{})
+	if err == nil {
+		return trCR, err
+	}
+	if apierrs.IsNotFound(err) {
+		statefulsetOrdinals := true
+
+		// Create a new TektonResult with the updated Performance config.
+		trCR = &v1alpha1.TektonResult{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: names.TektonResult,
+			},
+			Spec: v1alpha1.TektonResultSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					TargetNamespace: names.TargetNamespace,
+				},
+				Result: v1alpha1.Result{
+					Performance: v1alpha1.PerformanceProperties{
+						PerformanceStatefulsetOrdinalsConfig: v1alpha1.PerformanceStatefulsetOrdinalsConfig{
+							StatefulsetOrdinals: &statefulsetOrdinals,
+						},
+					},
+				},
+			},
+		}
+		return clients.Create(context.TODO(), trCR, metav1.CreateOptions{})
+	}
+	return trCR, err
+}
+
 // WaitForTektonResultState polls the status of the TektonResult called name
 // from client every `interval` until `inState` returns `true` indicating it
 // is done, returns an error or timeout.


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Transforms the results watcher from a deployment to a statefulset, offering a horizontal scaling option, instead of using leader election.
Limitation: This PR is specific to results watcher. However for results api, making the deployment to a statefulset ordinal does not increase performance due to sticky grpc sessions from the client, we would need to figure out another way to load balance incoming requests.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
Tekton Results Watcher now supports StatefulSet ordinals for improved horizontal scalability and deterministic workload distribution. When enabled, replicas use their ordinal identities to claim responsibility for specific resources, replacing leader election with a more balanced coordination model. This new mode is configurable via the performance section in the custom resource, with statefulset-ordinals controlling the behavior. By default, the system remains backward compatible with HA enabled using leader election. Note: this change applies only to the Results Watcher; Results API is still using leader election mode due to gRPC session stickiness.
```
