### PR TITLE
Set kubernetes min version

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -48,6 +48,8 @@ spec:
             drop:
               - ALL
         env:
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.0"
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pkg/reconciler/common/testdata/test-inject-envvar.yaml
+++ b/pkg/reconciler/common/testdata/test-inject-envvar.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: test
+  template:
+    metadata:
+      labels:
+        run: test
+    spec:
+      containers:
+      - image: busybox
+        name: controller-deployment
+        args: [
+          "-bash-image", "busybox",
+          "-nop=nop"
+        ]
+      - image: busybox
+        name: sidecar
+        args: [
+          "-git", "git"
+        ]

--- a/pkg/reconciler/common/testdata/test-replace-envvar.yaml
+++ b/pkg/reconciler/common/testdata/test-replace-envvar.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: test
+  template:
+    metadata:
+      labels:
+        run: test
+    spec:
+      containers:
+      - image: busybox
+        name: controller-deployment
+        args: [
+          "-bash-image", "busybox",
+          "-nop=nop"
+        ]
+        env:
+        - name: EXISTING_VAR
+          value: "original-value"
+        - name: OTHER_VAR
+          value: "some-value"
+      - image: busybox
+        name: sidecar
+        args: [
+          "-git", "git"
+        ]
+        env:
+        - name: SIDECAR_VAR
+          value: "sidecar-value"

--- a/pkg/reconciler/common/transformer_inject_envar_test.go
+++ b/pkg/reconciler/common/transformer_inject_envar_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"path"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestDeploymentEnvVars(t *testing.T) {
+	t.Run("inject environment variables into deployments", func(t *testing.T) {
+		envVars := []corev1.EnvVar{
+			{
+				Name:  "KUBERNETES_MIN_VERSION",
+				Value: "v1.0",
+			},
+			{
+				Name: "SECRET_VAR",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+						Key: "secret-key",
+					},
+				},
+			},
+		}
+
+		testData := path.Join("testdata", "test-inject-envvar.yaml")
+		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+		assertNoError(t, err)
+
+		newManifest, err := manifest.Transform(deploymentEnvVars(envVars))
+		assertNoError(t, err)
+
+		assertDeploymentHasEnvVar(t, newManifest.Resources(), "controller", "KUBERNETES_MIN_VERSION", "v1.0")
+		assertDeploymentHasSecretEnvVar(t, newManifest.Resources(), "controller", "SECRET_VAR", "test-secret", "secret-key")
+	})
+
+	t.Run("update existing environment variables", func(t *testing.T) {
+		envVars := []corev1.EnvVar{
+			{
+				Name:  "EXISTING_VAR",
+				Value: "value",
+			},
+		}
+
+		testData := path.Join("testdata", "test-replace-envvar.yaml")
+		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+		assertNoError(t, err)
+
+		newManifest, err := manifest.Transform(deploymentEnvVars(envVars))
+		assertNoError(t, err)
+
+		assertDeploymentHasEnvVar(t, newManifest.Resources(), "controller", "EXISTING_VAR", "value")
+	})
+}
+
+func assertDeploymentHasEnvVar(t *testing.T, resources []unstructured.Unstructured, deploymentName, envName, expectedValue string) {
+	t.Helper()
+	for _, resource := range resources {
+		if resource.GetKind() != "Deployment" {
+			continue
+		}
+
+		deployment := deploymentFor(t, resource)
+		containers := deployment.Spec.Template.Spec.Containers
+
+		for _, container := range containers {
+			for _, env := range container.Env {
+				if env.Name == envName {
+					if env.Value != expectedValue {
+						t.Errorf("assertion failed; unexpected env var value: expected %s and got %s for env var %s in container %s",
+							expectedValue, env.Value, envName, container.Name)
+					}
+					return
+				}
+			}
+		}
+
+		t.Errorf("Environment variable %s not found in any container of deployment %s", envName, deploymentName)
+	}
+}
+
+func assertDeploymentHasSecretEnvVar(t *testing.T, resources []unstructured.Unstructured, deploymentName, envName, secretName, secretKey string) {
+	t.Helper()
+	for _, resource := range resources {
+		if resource.GetKind() != "Deployment" {
+			continue
+		}
+
+		deployment := deploymentFor(t, resource)
+		containers := deployment.Spec.Template.Spec.Containers
+
+		for _, container := range containers {
+			for _, env := range container.Env {
+				if env.Name == envName {
+					if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+						t.Errorf("assertion failed; env var %s in container %s does not have SecretKeyRef", envName, container.Name)
+						return
+					}
+
+					if env.ValueFrom.SecretKeyRef.Name != secretName {
+						t.Errorf("assertion failed; unexpected secret name: expected %s and got %s for env var %s in container %s",
+							secretName, env.ValueFrom.SecretKeyRef.Name, envName, container.Name)
+					}
+
+					if env.ValueFrom.SecretKeyRef.Key != secretKey {
+						t.Errorf("assertion failed; unexpected secret key: expected %s and got %s for env var %s in container %s",
+							secretKey, env.ValueFrom.SecretKeyRef.Key, envName, container.Name)
+					}
+
+					return
+				}
+			}
+		}
+		t.Errorf("Environment variable %s not found in any container of deployment %s", envName, deploymentName)
+	}
+}

--- a/pkg/reconciler/common/transformer_inject_envvar.go
+++ b/pkg/reconciler/common/transformer_inject_envvar.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/version"
+)
+
+func DeploymentEnvVarKubernetesMinVersion() mf.Transformer {
+	var envVars []corev1.EnvVar
+	if minVersion, exists := os.LookupEnv(version.KubernetesMinVersionKey); exists {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  version.KubernetesMinVersionKey,
+			Value: minVersion,
+		})
+	}
+	return deploymentEnvVars(envVars)
+}
+
+func deploymentEnvVars(envVars []corev1.EnvVar) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Deployment" {
+			return nil
+		}
+
+		if len(envVars) == 0 {
+			return nil
+		}
+
+		d := &appsv1.Deployment{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, d)
+		if err != nil {
+			return err
+		}
+
+		containers := d.Spec.Template.Spec.Containers
+		for i := range containers {
+			for _, newEnv := range envVars {
+				envVarExists := false
+
+				for j := range containers[i].Env {
+					if containers[i].Env[j].Name == newEnv.Name {
+						containers[i].Env[j].Value = newEnv.Value
+						containers[i].Env[j].ValueFrom = newEnv.ValueFrom
+						envVarExists = true
+						break
+					}
+				}
+				if !envVarExists {
+					containers[i].Env = append(containers[i].Env, newEnv)
+				}
+			}
+		}
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+		if err != nil {
+			return err
+		}
+
+		u.SetUnstructuredContent(unstrObj)
+		return nil
+	}
+}

--- a/pkg/reconciler/common/transformer_injectlabel.go
+++ b/pkg/reconciler/common/transformer_injectlabel.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package common
 
 import (

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -116,9 +116,9 @@ func TestReplaceImages(t *testing.T) {
 		expected, _ := mf.ManifestFrom(mf.Recursive(testData))
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(DeploymentImages(map[string]string{}))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 
 		if d := cmp.Diff(expected.Resources(), newManifest.Resources()); d != "" {
 			t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
@@ -133,9 +133,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(DeploymentImages(images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertDeployContainersHasImage(t, newManifest.Resources(), "controller-deployment", image)
 		assertDeployContainersHasImage(t, newManifest.Resources(), "sidecar", "busybox")
 	})
@@ -149,9 +149,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(DeploymentImages(images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertDeployContainerArgsHasImage(t, newManifest.Resources(), "-bash", image)
 		assertDeployContainerArgsHasImage(t, newManifest.Resources(), "-git", "git")
 	})
@@ -165,9 +165,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(DeploymentImages(images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertDeployContainerArgsHasImage(t, newManifest.Resources(), "-nop", image)
 		assertDeployContainerArgsHasImage(t, newManifest.Resources(), "-git", "git")
 	})
@@ -181,9 +181,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-addon-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(TaskImages(context.TODO(), images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertTaskImage(t, newManifest.Resources(), "push", image)
 		assertTaskImage(t, newManifest.Resources(), "build", "$(inputs.params.BUILDER_IMAGE)")
 	})
@@ -197,9 +197,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-stepaction-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(StepActionImages(context.TODO(), images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertStepActionImage(t, newManifest.Resources(), "git-clone", image)
 	})
 
@@ -211,9 +211,9 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-statefulset-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(StatefulSetImages(images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertStatefulSetContainersHasImage(t, newManifest.Resources(), "controller-deployment", image)
 		assertStatefulSetContainersHasImage(t, newManifest.Resources(), "sidecar", "busybox")
 	})
@@ -227,15 +227,15 @@ func TestReplaceImages(t *testing.T) {
 		testData := path.Join("testdata", "test-replace-addon-image.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(TaskImages(context.TODO(), images))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		assertParamHasImage(t, newManifest.Resources(), "BUILDER_IMAGE", image)
 		assertTaskImage(t, newManifest.Resources(), "push", "buildah")
 	})
 }
 
-func assertNoEror(t *testing.T, err error) {
+func assertNoError(t *testing.T, err error) {
 	t.Helper()
 
 	if err != nil {
@@ -430,21 +430,21 @@ func statefulSetFor(t *testing.T, unstr unstructured.Unstructured) *appsv1.State
 func TestReplaceNamespaceInDeploymentEnv(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-env-in-result-deployment.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentEnv([]string{"tekton-results-watcher", "tekton-results-api"}, "openshift-pipelines"))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	d := &appsv1.Deployment{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	env := d.Spec.Template.Spec.Containers[0].Env
 	assert.Equal(t, env[0].Value, "tcp")
 	assert.Equal(t, env[1].Value, "tekton-results-mysql.openshift-pipelines.svc.cluster.local")
 
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[1].Object, d)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	env = d.Spec.Template.Spec.Containers[0].Env
 	assert.Equal(t, env[0].Value, "tcp")
@@ -454,14 +454,14 @@ func TestReplaceNamespaceInDeploymentEnv(t *testing.T) {
 func TestReplaceNamespaceInDeploymentArgs(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-arg-in-result-deployment.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	manifest, err = manifest.Transform(ReplaceNamespaceInDeploymentArgs([]string{"tekton-results-watcher"}, "openshift-pipelines"))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	d := &appsv1.Deployment{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	args := d.Spec.Template.Spec.Containers[0].Args
 	assert.Equal(t, args[0], "-api_addr")
@@ -471,29 +471,29 @@ func TestReplaceNamespaceInDeploymentArgs(t *testing.T) {
 func TestReplaceNamespaceInClusterInterceptor(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-namespace-in-cluster-interceptor.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	manifest, err = manifest.Transform(injectNamespaceCRClusterInterceptorClientConfig("foobar"))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	clusterInterceptor := manifest.Resources()[0].Object
 	service, _, err := unstructured.NestedFieldNoCopy(clusterInterceptor, "spec", "clientConfig", "service")
 	m := service.(map[string]interface{})
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	assert.Equal(t, "foobar", m["namespace"])
 }
 
 func TestReplaceNamespaceInClusterRole(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-namespace-in-cluster-role.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	manifest, err = manifest.Transform(injectNamespaceClusterRole("foobar"))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	clusterRole := manifest.Resources()[0].Object
 	rules, _, err := unstructured.NestedSlice(clusterRole, "rules")
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	namespaceRule := rules[0].(map[string]interface{})
 	for _, name := range namespaceRule["resourceNames"].([]interface{}) {
 		if name.(string) != "foobar" {
@@ -512,18 +512,18 @@ func TestAddConfigMapValues_PipelineProperties(t *testing.T) {
 
 	testData := path.Join("testdata", "test-replace-cm-values.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	prop := v1alpha1.PipelineProperties{
 		EnableApiFields: "stable",
 	}
 
 	manifest, err = manifest.Transform(AddConfigMapValues("test1", prop))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	assert.Equal(t, cm.Data["foo"], "bar")
 	assert.Equal(t, cm.Data["enable-api-fields"], "stable")
@@ -533,7 +533,7 @@ func TestAddConfigMapValues_OptionalPipelineProperties(t *testing.T) {
 
 	testData := path.Join("testdata", "test-replace-cm-values.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	min := uint(120)
 	prop := v1alpha1.OptionalPipelineProperties{
@@ -543,11 +543,11 @@ func TestAddConfigMapValues_OptionalPipelineProperties(t *testing.T) {
 	}
 
 	manifest, err = manifest.Transform(AddConfigMapValues("test2", prop))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[1].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	// ConfigMap will have only fields which are defined in `prop` OptionalPipelineProperties above
 	assert.Equal(t, cm.Data["default-cloud-events-sink"], "abc")
 	assert.Equal(t, cm.Data["default-timeout-minutes"], "120")
@@ -794,9 +794,9 @@ func TestInjectLabelOnNamespace(t *testing.T) {
 		testData := path.Join("testdata", "test-namespace-inject.yaml")
 
 		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		newManifest, err := manifest.Transform(InjectLabelOnNamespace("operator.tekton.dev/disable-proxy=true"))
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		for _, resource := range newManifest.Resources() {
 			labels := resource.GetLabels()
 			value, ok := labels["operator.tekton.dev/disable-proxy"]
@@ -815,7 +815,7 @@ func TestAddConfiguration(t *testing.T) {
 
 	testData := path.Join("testdata", "test-add-configurations.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	config := v1alpha1.Config{
 		NodeSelector: map[string]string{
@@ -833,11 +833,11 @@ func TestAddConfiguration(t *testing.T) {
 	}
 
 	manifest, err = manifest.Transform(AddConfiguration(config))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	d := &v1beta1.Deployment{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, d)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	assert.Equal(t, d.Spec.Template.Spec.NodeSelector["foo"], config.NodeSelector["foo"])
 	assert.Equal(t, d.Spec.Template.Spec.Tolerations[0].Key, config.Tolerations[0].Key)
 	assert.Equal(t, d.Spec.Template.Spec.PriorityClassName, config.PriorityClassName)
@@ -904,7 +904,7 @@ func TestAddStatefulSetPSA(t *testing.T) {
 func TestCopyConfigMapValues(t *testing.T) {
 	testData := path.Join("testdata", "test-resolver-config.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	expectedValues := map[string]string{
 		"default-tekton-hub-catalog":        "abc-catalog",
@@ -913,11 +913,11 @@ func TestCopyConfigMapValues(t *testing.T) {
 	}
 
 	manifest, err = manifest.Transform(CopyConfigMap("hubresolver-config", expectedValues))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	// ConfigMap will have values changed only for field which are defined
 	assert.Equal(t, cm.Data["default-tekton-hub-catalog"], "abc-catalog")
 	assert.Equal(t, cm.Data["default-artifact-hub-task-catalog"], "some-random-catalog")
@@ -934,7 +934,7 @@ func TestCopyConfigMapValues(t *testing.T) {
 func TestCopyEmptyConfigMapValues(t *testing.T) {
 	testData := path.Join("testdata", "test-empty-config.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	expectedValues := map[string]string{
 		"default-tekton-hub-catalog":        "abc-catalog",
@@ -943,11 +943,11 @@ func TestCopyEmptyConfigMapValues(t *testing.T) {
 	}
 
 	manifest, err = manifest.Transform(CopyConfigMap("empty-config", expectedValues))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	// ConfigMap will have all expected values
 	assert.Equal(t, cm.Data["default-tekton-hub-catalog"], "abc-catalog")
 	assert.Equal(t, cm.Data["default-artifact-hub-task-catalog"], "some-random-catalog")
@@ -957,31 +957,31 @@ func TestCopyEmptyConfigMapValues(t *testing.T) {
 func TestCopyConfigMapWithEmptyExpectedValues(t *testing.T) {
 	testData := path.Join("testdata", "test-empty-config.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	expectedValues := map[string]string{}
 
 	manifest, err = manifest.Transform(CopyConfigMap("empty-config", expectedValues))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 }
 
 func TestCopyConfigMapWithWrongKind(t *testing.T) {
 	testData := path.Join("testdata", "test-namespace-inject.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	expectedValues := map[string]string{}
 
 	manifest, err = manifest.Transform(CopyConfigMap("tekton-pipelines", expectedValues))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cm := &corev1.ConfigMap{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, cm)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 }
 
 func TestReplaceDeploymentArg(t *testing.T) {
@@ -1016,11 +1016,11 @@ func TestReplaceDeploymentArg(t *testing.T) {
 func TestReplaceNamespaceInServiceAccount(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-namespace-in-service-account.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	targetNamespace := "foobar"
 	manifest, err = manifest.Transform(ReplaceNamespaceInServiceAccount(targetNamespace))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	for _, resource := range manifest.Resources() {
 		if resource.GetNamespace() != targetNamespace {
@@ -1032,16 +1032,16 @@ func TestReplaceNamespaceInServiceAccount(t *testing.T) {
 func TestReplaceNamespaceInClusterRoleBinding(t *testing.T) {
 	testData := path.Join("testdata", "test-replace-namespace-in-cluster-role-binding.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	targetNamespace := "foobar"
 	manifest, err = manifest.Transform(ReplaceNamespaceInClusterRoleBinding(targetNamespace))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	for _, resource := range manifest.Resources() {
 		crb := &rbacv1.ClusterRoleBinding{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, crb)
-		assertNoEror(t, err)
+		assertNoError(t, err)
 
 		for _, subject := range crb.Subjects {
 			if subject.Namespace != targetNamespace {
@@ -1265,7 +1265,7 @@ func TestAddSecretData(t *testing.T) {
 			if test.expectError {
 				t.Errorf("Error %v", err)
 			} else {
-				assertNoEror(t, err)
+				assertNoError(t, err)
 				// Remove creationTimestamp from both expected and actual objects
 				if metadata, ok := test.expectedObj.Object["metadata"].(map[string]interface{}); ok {
 					delete(metadata, "creationTimestamp")

--- a/pkg/reconciler/common/utils_test.go
+++ b/pkg/reconciler/common/utils_test.go
@@ -30,7 +30,7 @@ func TestFetchVersionFromConfigMap(t *testing.T) {
 
 	testData := path.Join("testdata", "test-fetch-version-from-configmap.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	version, err := FetchVersionFromConfigMap(manifest, "pipelines-info")
 	if err != nil {
@@ -46,7 +46,7 @@ func TestFetchVersionFromConfigMap_ConfigMapNotFound(t *testing.T) {
 
 	testData := path.Join("testdata", "test-fetch-version-from-configmap.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	_, err = FetchVersionFromConfigMap(manifest, "triggers-info")
 	if err == nil {
@@ -60,7 +60,7 @@ func TestFetchVersionFromConfigMap_VersionKeyNotFound(t *testing.T) {
 
 	testData := path.Join("testdata", "test-fetch-version-from-configmap-invalid.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	_, err = FetchVersionFromConfigMap(manifest, "pipelines-info")
 	if err == nil {

--- a/pkg/reconciler/kubernetes/manualapprovalgate/transform.go
+++ b/pkg/reconciler/kubernetes/manualapprovalgate/transform.go
@@ -32,6 +32,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		extra := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.ManualApprovalGates),
 			common.DeploymentImages(magImages),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.AddDeploymentRestrictedPSA(),
 		}
 		extra = append(extra, extension.Transformers(magCR)...)

--- a/pkg/reconciler/kubernetes/tektonchain/transform.go
+++ b/pkg/reconciler/kubernetes/tektonchain/transform.go
@@ -32,6 +32,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		extra := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(v1alpha1.OperandTektoncdChains),
 			common.DeploymentImages(chainImages),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.AddConfiguration(chainCR.Spec.Config),
 			common.AddConfigMapValues(ChainsConfig, chainCR.Spec.Chain.ChainProperties),
 			common.AddDeploymentRestrictedPSA(),

--- a/pkg/reconciler/kubernetes/tektondashboard/transform.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/transform.go
@@ -43,6 +43,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfiguration(dashboard.Spec.Config),
 			common.AddDeploymentRestrictedPSA(),
 			common.DeploymentImages(images),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.ReplaceNamespaceInDeploymentArgs([]string{dashboardDeploymentName}, targetNamespace),
 		}
 		trns = append(trns, extra...)

--- a/pkg/reconciler/kubernetes/tektonhub/transform.go
+++ b/pkg/reconciler/kubernetes/tektonhub/transform.go
@@ -38,6 +38,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			mf.InjectOwner(hubCR),
 			mf.InjectNamespace(hubCR.Spec.GetTargetNamespace()),
 			common.DeploymentImages(images),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.JobImages(images),
 			updateApiConfigMap(hubCR, apiConfigMapName),
 			addConfigMapKeyValue(uiConfigMapName, "API_URL", hubCR.Status.ApiRouteUrl),

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -80,6 +80,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfigMapValues(ConfigMetrics, pipeline.Spec.PipelineMetricsProperties),
 			common.AddConfigMapValues(ResolverFeatureFlag, pipeline.Spec.Resolvers),
 			common.DeploymentImages(images),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.InjectLabelOnNamespace(proxyLabel),
 			common.AddConfiguration(pipeline.Spec.Config),
 			common.CopyConfigMap(bundleResolverConfig, pipeline.Spec.BundlesResolverConfig),

--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -95,6 +95,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		common.AddDeploymentRestrictedPSA(),
 		common.AddStatefulSetRestrictedPSA(),
 		common.DeploymentImages(resultImgs),
+		common.DeploymentEnvVarKubernetesMinVersion(),
 		common.StatefulSetImages(resultImgs),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)

--- a/pkg/reconciler/kubernetes/tektontrigger/transform.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/transform.go
@@ -43,6 +43,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfigMapValues(ConfigDefaults, trigger.Spec.OptionalTriggersProperties),
 			common.AddConfigMapValues(FeatureFlag, trigger.Spec.TriggersProperties),
 			common.DeploymentImages(triggerImages),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.AddConfiguration(trigger.Spec.Config),
 		}
 		trns = append(trns, extra...)

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -53,6 +53,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		tfs := []mf.Transformer{
 			common.InjectOperandNameLabelOverwriteExisting(openshift.OperandOpenShiftPipelineAsCode),
 			common.DeploymentImages(images),
+			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.AddConfiguration(pac.Spec.Config),
 			occommon.ApplyCABundles,
 			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),

--- a/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates_test.go
+++ b/pkg/reconciler/openshift/tektonaddon/pipelinetemplates/pipelinetemplates_test.go
@@ -16,15 +16,15 @@ func TestGeneratePipelineTemplates(t *testing.T) {
 	manifest := mf.Manifest{}
 
 	err := GeneratePipelineTemplates(addonLocation, &manifest)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 	for _, m := range manifest.Resources() {
 		jsonPipeline, err := m.MarshalJSON()
-		assertNoEror(t, err)
+		assertNoError(t, err)
 		golden.Assert(t, string(jsonPipeline), strings.ReplaceAll(fmt.Sprintf("%s.golden", m.GetName()), "/", "-"))
 	}
 }
 
-func assertNoEror(t *testing.T, err error) {
+func assertNoError(t *testing.T, err error) {
 	t.Helper()
 
 	if err != nil {

--- a/pkg/reconciler/openshift/tektonresult/extension_test.go
+++ b/pkg/reconciler/openshift/tektonresult/extension_test.go
@@ -40,15 +40,15 @@ func TestGetRouteManifest(t *testing.T) {
 
 	os.Setenv(common.KoEnvKey, "testdata")
 	mf, err := getRouteManifest()
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 	cr := &rbac.ClusterRole{}
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(mf.Resources()[0].Object, cr)
-	assertNoEror(t, err)
+	assertNoError(t, err)
 
 }
 
-func assertNoEror(t *testing.T, err error) {
+func assertNoError(t *testing.T, err error) {
 	t.Helper()
 
 	if err != nil {


### PR DESCRIPTION
# Changes
- Fixes typo: use assertNoError instead of assertNoEror.
- Propagates the KUBERNETES_MIN_VERSION environment variable to component deployments if set at the operator pod level, using a transformer function.

fixes https://github.com/tektoncd/pipeline/issues/8529

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
