### PR TITLE
fix kubernetes_min_version initial value on the operator openshift ba…

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -52,7 +52,7 @@ spec:
             type: RuntimeDefault
         env:
         - name: KUBERNETES_MIN_VERSION
-          value: "v1.0"
+          value: "v1.0.0"
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pkg/reconciler/common/transformer_inject_envar_test.go
+++ b/pkg/reconciler/common/transformer_inject_envar_test.go
@@ -29,7 +29,7 @@ func TestDeploymentEnvVars(t *testing.T) {
 		envVars := []corev1.EnvVar{
 			{
 				Name:  "KUBERNETES_MIN_VERSION",
-				Value: "v1.0",
+				Value: "v1.0.0",
 			},
 			{
 				Name: "SECRET_VAR",
@@ -51,7 +51,7 @@ func TestDeploymentEnvVars(t *testing.T) {
 		newManifest, err := manifest.Transform(deploymentEnvVars(envVars))
 		assertNoError(t, err)
 
-		assertDeploymentHasEnvVar(t, newManifest.Resources(), "controller", "KUBERNETES_MIN_VERSION", "v1.0")
+		assertDeploymentHasEnvVar(t, newManifest.Resources(), "controller", "KUBERNETES_MIN_VERSION", "v1.0.0")
 		assertDeploymentHasSecretEnvVar(t, newManifest.Resources(), "controller", "SECRET_VAR", "test-secret", "secret-key")
 	})
 


### PR DESCRIPTION
…sed manifests

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
