### PR TITLE
Update golangci-lint version to v2.0.1 for compatibility with action v7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,9 @@ jobs:
         fi
         echo "$gofmt_out"
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837  # v6.5.0
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd  # v7.0.0
       with:
-        version: v1.63.4
+        version: v2.0.1
         only-new-issues: true
         args: --timeout=10m
     - name: yamllint

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: "1.23.x"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837  # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd  # v7.0.0
         with:
-          version: v1.63.4
+          version: v2.0.1
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,83 +1,93 @@
-# Documentation: https://golangci-lint.run/usage/configuration/
-
-linters-settings:
-  gosec:
-    excludes:
-      - G601
-    exclude-generated: true
-  errcheck:
-    exclude-functions:
-      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-      - flag.Set
-      - os.Setenv
-      - logger.Sync
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - (io.Closer).Close
-      - updateConfigMap
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/ghodss/yaml:
-            recommendations:
-              - sigs.k8s.io/yaml
-  depguard:
-    rules:
-      prevent_unmaintained_packages:
-        list-mode: lax # allow unless explicitely denied
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-        deny:
-          - pkg: io/ioutil
-            desc: "replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil"
-          - pkg: github.com/ghodss/yaml
-            desc: "use sigs.k8s.io/yaml instead, to be consistent"
+version: "2"
+run:
+  build-tags:
+    - e2e
+  modules-download-mode: vendor
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
-  - unused
-  - errcheck
-  - gofmt
-  - goimports
-  - gomodguard
-  - unconvert
-issues:
-  uniq-by-line: false
-  # Note: path identifiers are regular expressions, hence the \.go suffixes.
-  exclude-rules:
-  - path: main\.go
-    linters:
-    - forbidigo
-  - path: _test\.go
-    linters:
-    - dogsled
     - errcheck
-    - goconst
-    - gosec
-    - ineffassign
-    - maintidx
-    - typecheck
+    - gomodguard
+    - unconvert
+    - unused
+  settings:
+    depguard:
+      rules:
+        prevent_unmaintained_packages:
+          list-mode: lax
+          files:
+            - $all
+            - '!$test'
+          allow:
+            - $gostd
+          deny:
+            - pkg: io/ioutil
+              desc: 'replaced by io and os packages since Go 1.16: https://tip.golang.org/doc/go1.16#ioutil'
+            - pkg: github.com/ghodss/yaml
+              desc: use sigs.k8s.io/yaml instead, to be consistent
+    errcheck:
+      exclude-functions:
+        - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+        - flag.Set
+        - os.Setenv
+        - logger.Sync
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (io.Closer).Close
+        - updateConfigMap
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/ghodss/yaml:
+              recommendations:
+                - sigs.k8s.io/yaml
+    gosec:
+      excludes:
+        - G601
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - forbidigo
+        path: main\.go
+      - linters:
+          - dogsled
+          - errcheck
+          - goconst
+          - gosec
+          - ineffassign
+          - maintidx
+        path: _test\.go
+    paths:
+      - .*/zz_generated.deepcopy.go
+      - pkg/apis/pipeline/v1beta1/openapi_generated.go
+      - vendor
+      - pkg/client
+      - pkg/spire/test
+      - third_party$
+      - builtin$
+      - examples$
+issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  include:
-  # Enable off-by-default rules for revive requiring that all exported elements have a properly formatted comment.
-  - EXC0012 # https://golangci-lint.run/usage/false-positives/#exc0012
-  - EXC0014 # https://golangci-lint.run/usage/false-positives/#exc0014
-  exclude-files:
-  - .*/zz_generated.deepcopy.go
-  - pkg/apis/pipeline/v1beta1/openapi_generated.go
-  exclude-dirs:
-  - vendor
-  - pkg/client
-  - pkg/spire/test
-run:
-  issues-exit-code: 1
-  build-tags:
-  - e2e
-  timeout: 20m
-  modules-download-mode: vendor
-
-
+  uniq-by-line: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*/zz_generated.deepcopy.go
+      - pkg/apis/pipeline/v1beta1/openapi_generated.go
+      - vendor
+      - pkg/client
+      - pkg/spire/test
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

The CI tests for the pr - https://github.com/tektoncd/operator/pull/2654 are failing with the below error
Error: Failed to run: Error: invalid version string 'v1.63.4', golangci-lint v1 is not supported by golangci-lint-action v7., Error: invalid version string 'v1.63.4', golangci-lint v1 is not supported by golangci-lint-action v7.
    at parseVersion (/home/runner/work/_actions/golangci/golangci-lint-action/1481404843c368bc19ca9406f87d6e0fc97bdcfd/dist/run/index.js:93[23](https://github.com/tektoncd/operator/actions/runs/14041880559/job/39313748757?pr=2654#step:4:25)6:15)
    at getRequestedVersion (/home/runner/work/_actions/golangci/golangci-lint-action/1481404843c368bc19ca9406f87d6e0fc97bdcfd/dist/run/index.js:93285:36)
    at getVersion (/home/runner/work/_actions/golangci/golangci-lint-action/1481404843c368bc19ca9406f87d6e0fc97bdcfd/dist/run/index.js:93318:[24](https://github.com/tektoncd/operator/actions/runs/14041880559/job/39313748757?pr=2654#step:4:26))
    at install (/home/runner/work/_actions/golangci/golangci-lint-action/1481404843c368bc19ca9406f87d6e0fc97bdcfd/dist/run/index.js:92540:56)
    at prepareEnv (/home/runner/work/_actions/golangci/golangci-lint-action/1481404843c368bc19ca9406f87d6e0fc97bdcfd/dist/run/index.js:92855:49)
Error: invalid version string 'v1.63.4', golangci-lint v1 is not supported by golangci-lint-action v7.

Looking at https://github.com/golangci/golangci-lint-action, I see that v7.0.0 supports golangci-lint v2 only. Hence speicifying the latest v2 version from https://github.com/golangci/golangci-lint/releases which is v2.0.1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
