### PR TITLE
 Improve operator logging by implementing proper log levels and context

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -128,17 +128,22 @@ func isClusterScoped(kind string) bool {
 
 func (i *installer) ensureResources(resources []unstructured.Unstructured) error {
 	for _, r := range resources {
+		ressourceLogger := i.logger.With(
+			"kind", r.GetKind(),
+			"namespace", r.GetNamespace(),
+			"name", r.GetName(),
+		)
 		expectedHash, err := hash.Compute(r.Object)
 		if err != nil {
+			ressourceLogger.Error("failed to compute resource hash", "error", err)
 			return err
 		}
-
-		i.logger.Infof("fetching resource %s: %s/%s", r.GetKind(), r.GetNamespace(), r.GetName())
+		ressourceLogger.Debug("fetching resource")
 
 		res, err := i.mfClient.Get(&r)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
-				i.logger.Infof("resource not found, creating %s: %s/%s", r.GetKind(), r.GetNamespace(), r.GetName())
+				ressourceLogger.Info("creating new resource")
 				// add hash on the resource of expected manifest and create
 				anno := r.GetAnnotations()
 				if anno == nil {
@@ -148,30 +153,35 @@ func (i *installer) ensureResources(resources []unstructured.Unstructured) error
 				r.SetAnnotations(anno)
 				err = i.mfClient.Create(&r)
 				if err != nil {
+					ressourceLogger.Error("failed to create resource", "error", err)
 					return err
 				}
+				ressourceLogger.Info("resource created successfully")
 				continue
 			}
+			ressourceLogger.Error("failed to get resource", "error", err)
 			return err
 		}
 
 		if res.GetDeletionTimestamp() != nil {
-			i.logger.Debugf("waiting for resource %s: %s/%s to be deleted",
-				r.GetKind(), r.GetNamespace(), r.GetName())
+			ressourceLogger.Debug("resource is being deleted, will reconcile again")
 			return v1alpha1.RECONCILE_AGAIN_ERR
 		}
 
-		i.logger.Infof("found resource %s: %s/%s, checking for update!", r.GetKind(), r.GetNamespace(), r.GetName())
+		ressourceLogger.Debug("resource exists, checking for updates")
 
 		// if resource exist then check if expected hash is different from the one
 		// on the resource
 		hashOnResource := res.GetAnnotations()[v1alpha1.LastAppliedHashKey]
 
 		if expectedHash == hashOnResource {
+			ressourceLogger.Debug("resource is up-to-date, no changes needed")
 			continue
 		}
 
-		i.logger.Infof("updating resource %s: %s/%s", r.GetKind(), r.GetNamespace(), r.GetName())
+		ressourceLogger.Info("resource needs update",
+			"currentHash", hashOnResource,
+			"expectedHash", expectedHash)
 
 		anno := r.GetAnnotations()
 		if anno == nil {
@@ -182,11 +192,14 @@ func (i *installer) ensureResources(resources []unstructured.Unstructured) error
 
 		installManifests, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{r}), mf.UseClient(i.mfClient))
 		if err != nil {
+			ressourceLogger.Error("failed to create manifest", "error", err)
 			return err
 		}
 		if err := installManifests.Apply(); err != nil {
+			ressourceLogger.Error("failed to apply manifest", "error", err)
 			return err
 		}
+		ressourceLogger.Info("resource updated successfully")
 	}
 	return nil
 }
@@ -247,11 +260,12 @@ func (i *installer) resourceReconcileFields(u *unstructured.Unstructured) []stri
 // currently tested with deployments and StatefulSet
 // TODO: (jkandasa) needs to be tested with other resources too
 func (i *installer) ensureResource(ctx context.Context, expected *unstructured.Unstructured) error {
-	i.logger.Debugw("verifying a resource",
+	loggerWithContext := i.logger.With(
 		"name", expected.GetName(),
 		"namespace", expected.GetNamespace(),
 		"kind", expected.GetKind(),
 	)
+	loggerWithContext.Debug("verifying a resource")
 
 	// update specific things to deployments and statefulSets
 	if expected.GetKind() == "Deployment" || expected.GetKind() == "StatefulSet" {
@@ -259,12 +273,7 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 		// update proxy settings
 		err := common.ApplyProxySettings(expected)
 		if err != nil {
-			i.logger.Errorw("error on applying proxy settings",
-				"name", expected.GetName(),
-				"namespace", expected.GetNamespace(),
-				"kind", expected.GetKind(),
-				err,
-			)
+			loggerWithContext.Errorw("failed to apply proxy settings", "error", err)
 			return err
 		}
 
@@ -274,7 +283,7 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 		// lists the available HPAs
 		hpaList, err := i.kubeClientSet.AutoscalingV2().HorizontalPodAutoscalers(expected.GetNamespace()).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			i.logger.Error("error on listing HPA", err)
+			loggerWithContext.Errorw("failed to list HPAs", "error", err)
 			return err
 		}
 
@@ -290,12 +299,11 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 
 		// if a hpa found to this resource, update replicas value from the hpa
 		if hpa != nil {
-			i.logger.Debugw("hpa found for this resource, verifying replicas value from hpa",
-				"resourceName", expected.GetName(),
-				"resourceKind", expected.GetKind(),
-				"namespace", hpa.GetNamespace(),
+			hpaLogger := loggerWithContext.With(
 				"hpaName", hpa.GetName(),
+				"hpaNamespace", hpa.GetNamespace(),
 			)
+			hpaLogger.Debug("HPA found for resource, verifying replicas")
 
 			hpaScalingDisabled := true
 			// verify HPA status from ScalingActive condition
@@ -329,49 +337,33 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 			}
 
 			if hpaScalingDisabled {
-				i.logger.Infow("hpa scaling is in disabled state, verifying manifest replicas value and adjusting it to hpa scaling range",
-					"resourceName", expected.GetName(),
-					"resourceKind", expected.GetKind(),
-					"namespace", hpa.GetNamespace(),
-					"hpaName", hpa.GetName(),
-				)
+				hpaLogger.Info("HPA scaling disabled, adjusting replicas to scaling range")
 
 				manifestReplicas, manifestReplicasFound, err := unstructured.NestedInt64(expected.Object, "spec", "replicas")
 				if err != nil {
-					i.logger.Errorw("error on getting manifest replicas",
-						"resourceName", expected.GetName(),
-						"resourceKind", expected.GetKind(),
-						"namespace", hpa.GetNamespace(),
-						err,
-					)
+					hpaLogger.Errorw("failed to get manifest replicas", "error", err)
 				} else if !manifestReplicasFound {
-					i.logger.Errorw("manifest replicas value is nil",
-						"resourceName", expected.GetName(),
-						"resourceKind", expected.GetKind(),
-						"namespace", hpa.GetNamespace(),
-					)
+					hpaLogger.Debug("manifest replicas not found, defaulting to 1")
 					// set default value as 1
 					manifestReplicas = 1
 				}
 
 				// adjust the manifest replicas value to hpa's scaling range
 				if manifestReplicas < int64(*minReplicas) {
+					originalReplicas := manifestReplicas
 					manifestReplicas = int64(*minReplicas)
-					i.logger.Infow("manifest replicas value is lower than the hpa minReplicas, updates with minReplicas",
-						"resourceName", expected.GetName(),
-						"resourceKind", expected.GetKind(),
-						"namespace", hpa.GetNamespace(),
-						"hpaName", hpa.GetName(),
-						"updatedManifestReplicas", manifestReplicas,
+					hpaLogger.Infow("adjusted replicas to minReplicas",
+						"originalReplicas", originalReplicas,
+						"newReplicas", manifestReplicas,
+						"minReplicas", *minReplicas,
 					)
 				} else if manifestReplicas > int64(maxReplicas) {
+					originalReplicas := manifestReplicas
 					manifestReplicas = int64(maxReplicas)
-					i.logger.Infow("manifest replicas value is higher than the hpa minReplicas, updates with maxReplicas",
-						"resourceName", expected.GetName(),
-						"resourceKind", expected.GetKind(),
-						"namespace", hpa.GetNamespace(),
-						"hpaName", hpa.GetName(),
-						"updatedManifestReplicas", manifestReplicas,
+					hpaLogger.Infow("adjusted replicas to maxReplicas",
+						"originalReplicas", originalReplicas,
+						"newReplicas", manifestReplicas,
+						"maxReplicas", maxReplicas,
 					)
 				}
 
@@ -379,49 +371,34 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 				desiredReplicas = int32(manifestReplicas)
 
 			} else { // hpa scaling is enabled
-				i.logger.Debugw("hpa scaling is enabled, verifying replicas value from hpa",
-					"hpaName", hpa.GetName(),
+				hpaLogger.Debugw("HPA scaling enabled",
 					"desiredReplicas", desiredReplicas,
-					"minReplicas", minReplicas,
+					"minReplicas", *minReplicas,
+					"maxReplicas", maxReplicas,
 					"scaleTargetKind", hpa.Spec.ScaleTargetRef.Kind,
 					"scaleTargetName", hpa.Spec.ScaleTargetRef.Name,
-					"namespace", hpa.GetNamespace(),
 				)
 
 				// if there is no metrics data available in the cluster the HPA desiredReplicas will be zero
 				// compare minReplicas and desiredReplicas and take the higher one
 				if desiredReplicas < *minReplicas {
-					i.logger.Debugw("hpa desiredReplicas is lesser than minReplicas, taking minReplicas as desiredReplicas",
-						"hpaName", hpa.GetName(),
+					hpaLogger.Debugw("HPA desiredReplicas less than minReplicas, adjusting desiredReplicas to minReplicas",
+						"OriginalDesiredReplicas", desiredReplicas,
 						"minReplicas", *minReplicas,
 						"scaleTargetKind", hpa.Spec.ScaleTargetRef.Kind,
 						"scaleTargetName", hpa.Spec.ScaleTargetRef.Name,
-						"namespace", hpa.GetNamespace(),
 					)
 					desiredReplicas = *minReplicas
 				}
 			}
 
-			i.logger.Infow("calculated desiredReplicas from hpa and manifest",
-				"resourceName", expected.GetName(),
-				"resourceKind", expected.GetKind(),
-				"namespace", hpa.GetNamespace(),
-				"hpaName", hpa.GetName(),
-				"desiredReplicas", desiredReplicas,
-			)
+			hpaLogger.Infow("calculated final desired replicas", "desiredReplicas", desiredReplicas, "hpaScalingEnabled", !hpaScalingDisabled)
 
 			// update the replicas value from HPA in expected object
 			// note: converting the replicas value to int64, "DeepCopyJSONValue" not accepts int32, it is available inside "SetNestedField"
 			err = unstructured.SetNestedField(expected.Object, int64(desiredReplicas), "spec", "replicas")
 			if err != nil {
-				i.logger.Errorw("error on setting replicas value",
-					"hpaName", hpa.GetName(),
-					"desiredReplicas", desiredReplicas,
-					"scaleTargetKind", hpa.Spec.ScaleTargetRef.Kind,
-					"scaleTargetName", hpa.Spec.ScaleTargetRef.Name,
-					"namespace", hpa.GetNamespace(),
-					err,
-				)
+				hpaLogger.Errorw("failed to set replicas value", "error", err)
 				return err
 			}
 
@@ -433,34 +410,22 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 	if err != nil {
 		// If the resource doesn't exist, then create new
 		if apierrs.IsNotFound(err) {
-			i.logger.Debugw("resource not found, creating",
-				"name", expected.GetName(),
-				"namespace", expected.GetNamespace(),
-				"kind", expected.GetKind(),
-			)
+			loggerWithContext.Info("resource not found, creating")
 			err = i.mfClient.Create(expected)
 			if err != nil {
-				i.logger.Debugw("error on creating a resource",
-					"name", expected.GetName(),
-					"namespace", expected.GetNamespace(),
-					"kind", expected.GetKind(),
-					err,
-				)
+				loggerWithContext.Errorw("failed to create resource", "error", err)
 				return err
 			}
+			loggerWithContext.Info("resource created successfully")
 		}
+		loggerWithContext.Errorw("failed to get resource", "error", err)
 		return err
 	}
 
-	i.logger.Debugw("resource found in cluster, checking for changes",
-		"name", existing.GetName(),
-		"namespace", existing.GetNamespace(),
-		"kind", existing.GetKind(),
-	)
+	loggerWithContext.Debug("resource found in cluster, checking for changes")
 
 	if existing.GetDeletionTimestamp() != nil {
-		i.logger.Debugf("waiting for resource %s: %s/%s to be deleted",
-			existing.GetKind(), existing.GetNamespace(), existing.GetName())
+		loggerWithContext.Debug("resource is being deleted, waiting for completion")
 		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
@@ -470,12 +435,8 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 	// compute hash value for the expected deployment or statefulset
 	expectedHashValue, err := i.computeResourceHash(expected, reconcileFields...)
 	if err != nil {
-		i.logger.Errorw("error on compute a hash value to a expected resource",
-			"name", expected.GetName(),
-			"namespace", expected.GetNamespace(),
-			"kind", expected.GetKind(),
-		)
-		return fmt.Errorf("failed to compute hash value to expected resource, name:%s, error: %v", expected.GetName(), err)
+		loggerWithContext.Errorw("failed to compute hash for expected resource", "error", err)
+		return fmt.Errorf("failed to compute hash value for expected resource, name:%s, error: %v", expected.GetName(), err)
 	}
 
 	// compute hash value for the existing resource
@@ -486,49 +447,35 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 	// compute hash
 	existingHashValue, err := i.computeResourceHash(existingCloned, reconcileFields...)
 	if err != nil {
-		i.logger.Errorw("error on computing hash value to an existing resource",
-			"name", existingCloned.GetName(),
-			"namespace", existingCloned.GetNamespace(),
-			"kind", existingCloned.GetKind(),
-		)
-		return fmt.Errorf("failed to compute hash value of a existing resource, name:%s, namespace:%s, kind:%s error: %v",
+		loggerWithContext.Errorw("failed to compute hash for existing resource", "error", err)
+		return fmt.Errorf("failed to compute hash value for existing resource, name:%s, namespace:%s, kind:%s error: %v",
 			existingCloned.GetName(), existingCloned.GetNamespace(), existingCloned.GetKind(), err,
 		)
 	}
 
 	// if change detected in hash value, update the resource with changes
 	if existingHashValue != expectedHashValue {
-		i.logger.Debugw("change detected in the resource, reconciling",
-			"name", existing.GetName(),
-			"namespace", existing.GetNamespace(),
-			"kind", existing.GetKind(),
-			"existingHashValue", existingHashValue,
-			"expectedHashValue", expectedHashValue,
+		loggerWithContext.Infow("change detected, updating resource",
+			"existingHash", existingHashValue,
+			"expectedHash", expectedHashValue,
 		)
+
 		err = i.copyResourceFields(expected, existing, reconcileFields...)
 		if err != nil {
+			loggerWithContext.Errorw("failed to copy resource fields", "error", err)
 			return err
 		}
 
 		err = i.mfClient.Update(existing)
 		if err != nil {
-			i.logger.Errorw("error on updating a resource",
-				"resourceName", existing.GetName(),
-				"namespace", existing.GetNamespace(),
-				"kind", existing.GetKind(),
-				err,
-			)
+			loggerWithContext.Errorw("failed to update resource", "error", err)
 			return v1alpha1.RECONCILE_AGAIN_ERR
 		}
 
-		i.logger.Debugw("reconciliation successful",
-			"name", existing.GetName(),
-			"namespace", existing.GetNamespace(),
-			"kind", existing.GetKind(),
-		)
+		loggerWithContext.Info("resource updated successfully")
 		return nil
 	}
-
+	loggerWithContext.Debug("no changes detected, resource is up-to-date")
 	return nil
 }
 


### PR DESCRIPTION
# Changes
Partially fixes https://github.com/tektoncd/operator/issues/2472 because it addresses only tekton-operator-cluster-operations
- Reduce noise by moving routine operations to DEBUG level
- Add consistent resource context to all log statements
- Provide more detailed information for state changes
- Add success confirmations for create/update operations
- Include error details and hash information for better troubleshooting

**Before 
tekton-operator-cluster-operations counts 3463 lines
After
tekton-operator-cluster-operations counts 1087 lines**

before
```
{"level":"info","timestamp":"2025-04-07T07:07:19.714Z","logger":"tekton-operator-cluster-operations","caller":"leaderelection/context.go:158","msg":"\"tekton-operator-5cdd868fc5-6fp28_c0c10f98-c711-48fa-a010-0c9dc82ea6a7\" has started leading \"tekton-operator-cluster-operations.github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.reconciler.00-of-01\"","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28"}
{"level":"info","timestamp":"2025-04-07T07:07:19.725Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:136","msg":"fetching resource ValidatingWebhookConfiguration: /validation.webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.726Z","logger":"tekton-operator-cluster-operations.event-broadcaster","caller":"record/event.go:364","msg":"Event(v1.ObjectReference{Kind:\"TektonInstallerSet\", Namespace:\"\", Name:\"validating-mutating-webhook-g2pfp\", UID:\"d2be1bec-a955-4198-a1fa-5a25af27b2c3\", APIVersion:\"operator.tekton.dev/v1alpha1\", ResourceVersion:\"769\", FieldPath:\"\"}): type: 'Normal' reason: 'FinalizerUpdate' Updated \"validating-mutating-webhook-g2pfp\" finalizers","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28"}
{"level":"info","timestamp":"2025-04-07T07:07:19.730Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:141","msg":"resource not found, creating ValidatingWebhookConfiguration: /validation.webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.734Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:136","msg":"fetching resource MutatingWebhookConfiguration: /webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.737Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:141","msg":"resource not found, creating MutatingWebhookConfiguration: /webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.742Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:136","msg":"fetching resource ValidatingWebhookConfiguration: /config.webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.745Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:141","msg":"resource not found, creating ValidatingWebhookConfiguration: /config.webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.773Z","logger":"tekton-operator-cluster-operations","caller":"controller/controller.go:550","msg":"Reconcile succeeded","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"3a8ec3fd-b4ed-4b35-96fd-f21d8af1ffaf","knative.dev/key":"validating-mutating-webhook-g2pfp","duration":0.057809463}
{"level":"info","timestamp":"2025-04-07T07:07:19.773Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:136","msg":"fetching resource ValidatingWebhookConfiguration: /validation.webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"7d3e7504-10d9-4011-95f6-16dffe660c03","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.775Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:164","msg":"found resource ValidatingWebhookConfiguration: /validation.webhook.operator.tekton.dev, checking for update!","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"7d3e7504-10d9-4011-95f6-16dffe660c03","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.775Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:136","msg":"fetching resource MutatingWebhookConfiguration: /webhook.operator.tekton.dev","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"7d3e7504-10d9-4011-95f6-16dffe660c03","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"level":"info","timestamp":"2025-04-07T07:07:19.777Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:164","msg":"found resource MutatingWebhookConfiguration: /webhook.operator.tekton.dev, checking for update!","commit":"a566ccb","knative.dev/pod":"tekton-operator-5cdd868fc5-6fp28","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"7d3e7504-10d9-4011-95f6-16dffe660c03","knative.dev/key":"validating-mutating-webhook-g2pfp","installerSet":"/validating-mutating-webhook-g2pfp"}
{"lev
```

Now

```
{"level":"info","timestamp":"2025-04-07T08:33:51.875Z","logger":"tekton-operator-cluster-operations","caller":"leaderelection/context.go:158","msg":"\"tekton-operator-564786fcc8-bl4tv_5e1ac36f-8213-44cf-a40a-28a8f596ba0b\" has started leading \"tekton-operator-cluster-operations.github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.reconciler.00-of-01\"","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv"}
{"level":"info","timestamp":"2025-04-07T08:33:51.880Z","logger":"tekton-operator-cluster-operations.event-broadcaster","caller":"record/event.go:364","msg":"Event(v1.ObjectReference{Kind:\"TektonInstallerSet\", Namespace:\"\", Name:\"validating-mutating-webhook-l88gk\", UID:\"011729c8-3a7e-49a4-a23b-2e109c9ff3d3\", APIVersion:\"operator.tekton.dev/v1alpha1\", ResourceVersion:\"640\", FieldPath:\"\"}): type: 'Normal' reason: 'FinalizerUpdate' Updated \"validating-mutating-webhook-l88gk\" finalizers","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv"}
{"level":"info","timestamp":"2025-04-07T08:33:51.885Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:146","msg":"creating new resource","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"e5daa751-8e57-4ae7-bce2-1363f67e955e","knative.dev/key":"validating-mutating-webhook-l88gk","installerSet":"/validating-mutating-webhook-l88gk","kind":"ValidatingWebhookConfiguration","namespace":"","name":"validation.webhook.operator.tekton.dev"}
{"level":"info","timestamp":"2025-04-07T08:33:51.889Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:159","msg":"resource created successfully","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"e5daa751-8e57-4ae7-bce2-1363f67e955e","knative.dev/key":"validating-mutating-webhook-l88gk","installerSet":"/validating-mutating-webhook-l88gk","kind":"ValidatingWebhookConfiguration","namespace":"","name":"validation.webhook.operator.tekton.dev"}
{"level":"info","timestamp":"2025-04-07T08:33:51.891Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:146","msg":"creating new resource","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"e5daa751-8e57-4ae7-bce2-1363f67e955e","knative.dev/key":"validating-mutating-webhook-l88gk","installerSet":"/validating-mutating-webhook-l88gk","kind":"MutatingWebhookConfiguration","namespace":"","name":"webhook.operator.tekton.dev"}
{"level":"info","timestamp":"2025-04-07T08:33:51.896Z","logger":"tekton-operator-cluster-operations","caller":"tektoninstallerset/install.go:159","msg":"resource created successfully","commit":"a566ccb-dirty","knative.dev/pod":"tekton-operator-564786fcc8-bl4tv","knative.dev/controller":"github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektoninstallerset.Reconciler","knative.dev/kind":"operator.tekton.dev.TektonInstallerSet","knative.dev/traceid":"e5daa751-8e57-4ae7-bce2-1363f67e955e","knative.dev/key":"validating-mutating-webhook-l88gk","installerSet":"/validating-mutating-webhook-l88gk","kind":"MutatingWebhookConfiguration","namespace":"","name":"webhook.operator.tekton.dev"}
{
```
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
