### PR TITLE
Improve operator logging by implementing proper log levels and context

### DIFF
--- a/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
+++ b/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
@@ -118,21 +118,24 @@ var (
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain) pkgreconciler.Event {
-
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With(
+		"name", tc.GetName(),
+		"generation", tc.Generation,
+		"namespace", tc.GetNamespace(),
+	)
 	defer r.recorder.LogMetricsWithSpec(r.chainVersion, tc.Spec, logger)
 
 	tc.Status.InitializeConditions()
 	tc.Status.ObservedGeneration = tc.Generation
 
-	logger.Infow("Reconciling TektonChain", "status", tc.Status)
+	logger.Debugw("Starting TektonChain reconciliation", "status", tc.Status.GetCondition(apis.ConditionReady))
 
 	if tc.GetName() != v1alpha1.ChainResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.ChainResourceName,
 			tc.GetName(),
 		)
-		logger.Error(msg)
+		logger.Errorw("Invalid resource name", "expectedName", v1alpha1.ConfigResourceName, "actualName", tc.GetName())
 		tc.Status.MarkNotReady(msg)
 		return nil
 	}
@@ -141,30 +144,36 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	if _, err := common.PipelineReady(r.pipelineInformer); err != nil {
 		if err.Error() == common.PipelineNotReady || err == v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR {
 			tc.Status.MarkDependencyInstalling("TektonPipeline is still installing")
-			// wait for TektonPipeline status to change
+			logger.Debug("Waiting for TektonPipeline installation")
 			return fmt.Errorf(common.PipelineNotReady)
 		}
-		// (tektonpipeline.operator.tekton.dev instance not available yet)
+		// tektonpipeline.operator.tekton.dev instance not available yet
 		tc.Status.MarkDependencyMissing("TektonPipeline does not exist")
+		logger.Errorw("TektonPipeline dependency check failed", "error", err)
 		return err
 	}
 	tc.Status.MarkDependenciesInstalled()
+	logger.Debug("TektonPipeline dependency check completed successfully")
 
 	// Pass the object through defaulting
 	tc.SetDefaults(ctx)
 
 	// Mark TektonChain Instance as Not Ready if an upgrade is needed
 	if err := r.markUpgrade(ctx, tc); err != nil {
+		logger.Errorw("Upgrade check failed", "error", err)
 		return err
 	}
 
 	if err := r.extension.PreReconcile(ctx, tc); err != nil {
-		tc.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
+		errMsg := fmt.Sprintf("PreReconciliation failed: %s", err.Error())
+		logger.Errorw("PreReconcile failed", "error", err)
+		tc.Status.MarkPreReconcilerFailed(errMsg)
 		return err
 	}
 
 	// Mark PreReconcile Complete
 	tc.Status.MarkPreReconcilerComplete()
+	logger.Debug("PreReconcile completed successfully")
 
 	// Fetching and deleting the chains tektoninstallerset to delete `chains-config` configMap
 	// to handle the scenario when user upgrades i.e. in previous version `chains-config` configMap
@@ -172,11 +181,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	// `chains-config` configMap
 	chainlabelSelector, err := common.LabelSelector(ls)
 	if err != nil {
+		logger.Errorw("Invalid chain label selector", "error", err)
 		return err
 	}
 
 	existingChainInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, chainlabelSelector)
 	if err != nil {
+		logger.Errorw("Failed to retrieve current chain installer set", "error", err)
 		return err
 	}
 
@@ -185,31 +196,28 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		installedTIS, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Get(ctx, existingChainInstallerSet, metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
+			logger.Errorw("Chain InstallerSet not found", "name", existingChainInstallerSet)
 			return err
 		}
 
-		installerSetReleaseVersion := installedTIS.Labels[v1alpha1.ReleaseVersionKey]
-
-		if installerSetReleaseVersion != r.operatorVersion {
-			// Delete the existing Tekton Chain InstallerSet
+		if rv := installedTIS.Labels[v1alpha1.ReleaseVersionKey]; rv != r.operatorVersion {
+			logger.Infow("Deleting outdated InstallerSet", "name", existingChainInstallerSet, "currentVersion", rv, "expectedVersion", r.operatorVersion)
 			err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 				Delete(ctx, existingChainInstallerSet, metav1.DeleteOptions{})
 			if err != nil {
-				logger.Errorf("failed to delete InstallerSet: %s", err.Error())
+				logger.Errorw("Failed to delete outdated InstallerSet", "error", err)
 				return err
 			}
 
-			// Make sure the Tekton Chain InstallerSet is deleted
-			_, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
-				Get(ctx, existingChainInstallerSet, metav1.GetOptions{})
-			if err == nil {
+			if _, err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().Get(ctx, existingChainInstallerSet, metav1.GetOptions{}); err == nil {
 				tc.Status.MarkNotReady("Waiting for previous installer set to get deleted")
+				logger.Debugw("InstallerSet deletion pending", "name", existingChainInstallerSet)
 				return v1alpha1.REQUEUE_EVENT_AFTER
-			}
-			if !apierrors.IsNotFound(err) {
-				logger.Errorf("failed to get InstallerSet: %s", err.Error())
+			} else if !apierrors.IsNotFound(err) {
+				logger.Errorw("Error confirming InstallerSet deletion", "error", err)
 				return err
 			}
+			logger.Infow("Outdated InstallerSet successfully deleted")
 			return nil
 		}
 	}
@@ -217,18 +225,22 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	// Check if a Tekton Chain Config InstallerSet already exists, if not then create one
 	configLabelSector, err := common.LabelSelector(configLs)
 	if err != nil {
+		logger.Errorw("Invalid chain config label selector", "error", err)
 		return err
 	}
 
 	existingConfigInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, configLabelSector)
 	if err != nil {
+		logger.Errorw("Failed to get config installer set name", "error", err, "selector", configLabelSector)
 		return err
 	}
 	if existingConfigInstallerSet == "" {
 		tc.Status.MarkInstallerSetNotAvailable("Chain Config InstallerSet not available")
+		logger.Infow("Creating new Chain Config InstallerSet", "targetNamespace", tc.Spec.TargetNamespace)
 
 		createdIs, err := r.createConfigInstallerSet(ctx, tc)
 		if err != nil {
+			logger.Errorw("Failed to create Config InstallerSet", "error", err)
 			return err
 		}
 
@@ -240,13 +252,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		Get(ctx, existingConfigInstallerSet, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Infow("Config InstallerSet not found, creating new one", "name", existingConfigInstallerSet)
 			createdIs, err := r.createConfigInstallerSet(ctx, tc)
 			if err != nil {
+				logger.Errorw("Failed to create Config InstallerSet", "error", err)
 				return err
 			}
+			logger.Infow("Chain Config InstallerSet created successfully", "name", createdIs.GetName())
 			return r.updateTektonChainStatus(tc, createdIs)
 		}
-		logger.Error("failed to get InstallerSet: %s", err)
+		logger.Errorw("Failed to get Config InstallerSet", "name", existingConfigInstallerSet, "error", err)
 		return err
 	}
 
@@ -259,11 +274,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	// and create a new with expected properties
 
 	if configInstallerSetTargetNamespace != tc.Spec.TargetNamespace || configInstallerSetReleaseVersion != r.operatorVersion {
+		logger.Infow("Config InstallerSet needs update",
+			"name", existingConfigInstallerSet,
+			"currentNamespace", configInstallerSetTargetNamespace,
+			"expectedNamespace", tc.Spec.TargetNamespace,
+			"currentVersion", configInstallerSetReleaseVersion,
+			"expectedVersion", r.operatorVersion)
 		// Delete the existing Tekton Chain InstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Delete(ctx, existingConfigInstallerSet, metav1.DeleteOptions{})
 		if err != nil {
-			logger.Errorf("failed to delete InstallerSet: %s", err.Error())
+			logger.Errorw("Failed to delete Chains Config InstallerSet", "name", existingConfigInstallerSet, "error", err)
 			return err
 		}
 
@@ -272,10 +293,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 			Get(ctx, existingConfigInstallerSet, metav1.GetOptions{})
 		if err == nil {
 			tc.Status.MarkNotReady("Waiting for previous installer set to get deleted")
+			logger.Debugw("Config InstallerSet deletion pending", "name", existingConfigInstallerSet)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		if !apierrors.IsNotFound(err) {
-			logger.Error("failed to get InstallerSet: %s", err)
+			logger.Errorw("Failed to confirm Config InstallerSet deletion", "name", existingConfigInstallerSet, "error", err)
 			return err
 		}
 		return nil
@@ -288,6 +310,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		// Hash of TektonChain Spec
 		expectedSpecHash, err := hash.Compute(tc.Spec)
 		if err != nil {
+			logger.Errorw("Failed to compute spec hash", "error", err)
 			return err
 		}
 
@@ -295,49 +318,62 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		lastAppliedHash := installedConfigTIS.GetAnnotations()[v1alpha1.LastAppliedHashKey]
 
 		if lastAppliedHash != expectedSpecHash {
-
+			logger.Infow("Config spec changed, updating InstallerSet",
+				"name", installedConfigTIS.Name,
+				"oldHash", lastAppliedHash,
+				"newHash", expectedSpecHash)
 			if err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 				Delete(ctx, installedConfigTIS.Name, metav1.DeleteOptions{}); err != nil {
+				logger.Errorw("Failed to delete outdated Config InstallerSet", "name", installedConfigTIS.Name, "error", err)
 				return err
 			}
 
 			// after updating installer set enqueue after a duration
 			// to allow changes to get deployed
+			logger.Infow("Config InstallerSet deleted to apply spec changes", "name", installedConfigTIS.Name)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Debugw("Config InstallerSet up to date", "name", installedConfigTIS.Name)
 	}
 
 	// Chain controller is deployed as statefulset, ensure deployment installerset is deleted
 	if tc.Spec.Performance.StatefulsetOrdinals != nil && *tc.Spec.Performance.StatefulsetOrdinals {
 		if err := r.installerSetClient.CleanupWithLabelInstallTypeDeployment(ctx, v1alpha1.ChainResourceName); err != nil {
-			logger.Error("failed to delete chain deployment installer set: %v", err)
+			logger.Errorw("Failed to delete chain deployment installer set", "error", err, "resource", v1alpha1.ChainResourceName)
 			return err
 		}
+		logger.Debugw("Using statefulset deployment type", "resource", v1alpha1.ChainResourceName)
 	} else {
 		// Chain controller is deployed as deployment, ensure statefulset installerset is deleted
 		if err := r.installerSetClient.CleanupWithLabelInstallTypeStatefulset(ctx, v1alpha1.ChainResourceName); err != nil {
-			logger.Error("failed to delete chain statefulset installer set: %v", err)
+			logger.Errorw("Failed to delete chain statefulset installer set", "error", err, "resource", v1alpha1.ChainResourceName)
 			return err
 		}
+		logger.Debugw("Using standard deployment type", "resource", v1alpha1.ChainResourceName)
 	}
 
 	// Check if a Tekton Chain InstallerSet already exists, if not then create one
 	labelSelector, err := common.LabelSelector(ls)
 	if err != nil {
+		logger.Errorw("Invalid label selector", "error", err, "selector", ls)
 		return err
 	}
 	existingInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, labelSelector)
 	if err != nil {
+		logger.Errorw("Failed to get current installer set name", "error", err, "selector", labelSelector)
 		return err
 	}
 
 	if existingInstallerSet == "" {
 		tc.Status.MarkInstallerSetNotAvailable("Chain InstallerSet not available")
+		logger.Infow("Creating new Chain InstallerSet", "targetNamespace", tc.Spec.TargetNamespace)
 
 		createdIs, err := r.createInstallerSet(ctx, tc)
 		if err != nil {
+			logger.Errorw("Failed to create InstallerSet", "error", err)
 			return err
 		}
+		logger.Infow("Chain InstallerSet created successfully", "name", createdIs.GetName())
 		return r.updateTektonChainStatus(tc, createdIs)
 	}
 
@@ -346,13 +382,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		Get(ctx, existingInstallerSet, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Infow("InstallerSet not found, creating new one", "name", existingInstallerSet)
 			createdIs, err := r.createInstallerSet(ctx, tc)
 			if err != nil {
+				logger.Errorw("Failed to create InstallerSet", "error", err)
 				return err
 			}
+			logger.Infow("Chain InstallerSet created successfully", "name", createdIs.GetName())
 			return r.updateTektonChainStatus(tc, createdIs)
 		}
-		logger.Error("failed to get InstallerSet: %s", err)
+		logger.Errorw("Failed to get InstallerSet", "name", existingInstallerSet, "error", err)
 		return err
 	}
 
@@ -365,11 +404,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	// and create a new with expected properties
 
 	if installerSetTargetNamespace != tc.Spec.TargetNamespace || installerSetReleaseVersion != r.operatorVersion {
+		logger.Infow("InstallerSet needs update",
+			"name", existingInstallerSet,
+			"currentNamespace", installerSetTargetNamespace,
+			"expectedNamespace", tc.Spec.TargetNamespace,
+			"currentVersion", installerSetReleaseVersion,
+			"expectedVersion", r.operatorVersion)
 		// Delete the existing Tekton Chain InstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Delete(ctx, existingInstallerSet, metav1.DeleteOptions{})
 		if err != nil {
-			logger.Errorf("failed to delete InstallerSet: %s", err.Error())
+			logger.Errorw("Failed to delete InstallerSet", "name", existingInstallerSet, "error", err)
 			return err
 		}
 
@@ -378,12 +423,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 			Get(ctx, existingInstallerSet, metav1.GetOptions{})
 		if err == nil {
 			tc.Status.MarkNotReady("Waiting for previous installer set to get deleted")
+			logger.Debugw("InstallerSet deletion pending", "name", existingInstallerSet)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		if !apierrors.IsNotFound(err) {
-			logger.Error("failed to get InstallerSet: %s", err)
+			logger.Errorw("Failed to confirm InstallerSet deletion", "name", existingInstallerSet, "error", err)
 			return err
 		}
+		logger.Infow("InstallerSet successfully deleted", "name", existingInstallerSet)
 		return nil
 
 	} else {
@@ -394,6 +441,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		// Hash of TektonChain Spec
 		expectedSpecHash, err := hash.Compute(tc.Spec)
 		if err != nil {
+			logger.Errorw("Failed to compute spec hash", "error", err)
 			return err
 		}
 
@@ -401,17 +449,22 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		lastAppliedHash := installedTIS.GetAnnotations()[v1alpha1.LastAppliedHashKey]
 
 		if lastAppliedHash != expectedSpecHash {
-
+			logger.Infow("Spec changed, updating InstallerSet",
+				"name", installedTIS.Name,
+				"oldHash", lastAppliedHash,
+				"newHash", expectedSpecHash)
 			manifest := r.manifest
 			// installerSet adds it's owner as namespace's owner
 			// so deleting tekton chain deletes target namespace too
 			// to skip it we filter out namespace if pipeline have same namespace
 			pipelineNamespace, err := common.PipelineTargetNamspace(r.pipelineInformer)
 			if err != nil {
-				logger.Error("unable to fetch pipeline namespace:  ", err)
+				logger.Errorw("Failed to fetch pipeline namespace", "error", err)
 				return err
 			}
 			if tc.Spec.GetTargetNamespace() == pipelineNamespace {
+				logger.Debugw("Filtering out namespace resource as it's shared with pipeline",
+					"namespace", pipelineNamespace)
 				manifest = manifest.Filter(mf.Not(mf.ByKind("Namespace")))
 			}
 			// remove secret and `chains-config` configMap from this installerset as this installerset will be deleted on upgrade
@@ -420,7 +473,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 
 			transformer := filterAndTransform(r.extension)
 			if _, err := transformer(ctx, &manifest, tc); err != nil {
-				logger.Error("manifest transformation failed: ", err.Error())
+				logger.Errorw("Manifest transformation failed", "error", err)
 				return err
 			}
 
@@ -434,30 +487,38 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 
 			if _, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 				Update(ctx, installedTIS, metav1.UpdateOptions{}); err != nil {
+				logger.Errorw("Failed to update InstallerSet", "name", installedTIS.Name, "error", err)
 				return err
 			}
 
 			// after updating installer set enqueue after a duration
 			// to allow changes to get deployed
+			logger.Infow("InstallerSet successfully updated", "name", installedTIS.Name)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Debugw("InstallerSet up to date", "name", installedTIS.Name)
 	}
 
 	// Check if a Tekton Chain Secret InstallerSet already exists, if not then create one
 	secretLabelSelector, err := common.LabelSelector(secretLs)
 	if err != nil {
+		logger.Errorw("Invalid secret label selector", "error", err, "selector", secretLs)
 		return err
 	}
 	existingSecretInstallerSet, err := tektoninstallerset.CurrentInstallerSetName(ctx, r.operatorClientSet, secretLabelSelector)
 	if err != nil {
+		logger.Errorw("Failed to get secret installer set name", "error", err, "selector", secretLabelSelector)
 		return err
 	}
 	if existingSecretInstallerSet == "" {
 		tc.Status.MarkInstallerSetNotAvailable("Chain Secret InstallerSet not available")
-		_, err := r.createSecretInstallerSet(ctx, tc)
+		logger.Infow("Creating new Chain Secret InstallerSet", "targetNamespace", tc.Spec.TargetNamespace)
+		createdIs, err := r.createSecretInstallerSet(ctx, tc)
 		if err != nil {
+			logger.Errorw("Failed to create Secret InstallerSet", "error", err)
 			return err
 		}
+		logger.Infow("Chain Secret InstallerSet created successfully", "name", createdIs.GetName())
 		return v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
@@ -466,24 +527,31 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		Get(ctx, existingSecretInstallerSet, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err := r.createSecretInstallerSet(ctx, tc)
+			logger.Infow("Secret InstallerSet not found, creating new one", "name", existingSecretInstallerSet)
+			createdIs, err := r.createSecretInstallerSet(ctx, tc)
 			if err != nil {
+				logger.Errorw("Failed to create Secret InstallerSet", "error", err)
 				return err
 			}
+			logger.Infow("Chain Secret InstallerSet created successfully", "name", createdIs.GetName())
 			return v1alpha1.RECONCILE_AGAIN_ERR
 		}
-		logger.Error("failed to get InstallerSet: %s", err)
+		logger.Errorw("Failed to get Secret InstallerSet", "name", existingSecretInstallerSet, "error", err)
 		return err
 	}
 
 	// if the namespace or generatedSigningSecret has been changed for chainsCR, then delete the Tekton Chain Secret Installerset
 	secretInstallerSetTargetNamespace := installedSecretTIS.Annotations[v1alpha1.TargetNamespaceKey]
 	if secretInstallerSetTargetNamespace != tc.Spec.TargetNamespace {
+		logger.Infow("Secret InstallerSet namespace changed, recreating",
+			"name", existingSecretInstallerSet,
+			"currentNamespace", secretInstallerSetTargetNamespace,
+			"expectedNamespace", tc.Spec.TargetNamespace)
 		// Delete the existing Tekton Chain Secret InstallerSet
 		err := r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Delete(ctx, existingSecretInstallerSet, metav1.DeleteOptions{})
 		if err != nil {
-			logger.Error("failed to delete TektonChainSecret InstallerSet: %s", err)
+			logger.Errorw("Failed to delete Secret InstallerSet", "name", existingSecretInstallerSet, "error", err)
 			return err
 		}
 
@@ -492,12 +560,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 			Get(ctx, existingSecretInstallerSet, metav1.GetOptions{})
 		if err == nil {
 			tc.Status.MarkNotReady("Waiting for previous installer set to get deleted")
+			logger.Debugw("Secret InstallerSet deletion pending", "name", existingSecretInstallerSet)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		if !apierrors.IsNotFound(err) {
-			logger.Error("failed to get InstallerSet: %s", err)
+			logger.Errorw("Failed to confirm Secret InstallerSet deletion", "name", existingSecretInstallerSet, "error", err)
 			return err
 		}
+		logger.Infow("Secret InstallerSet successfully deleted", "name", existingSecretInstallerSet)
 		return nil
 	}
 
@@ -505,12 +575,20 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	secretInstallerSetSigningKey, err := strconv.ParseBool(installedSecretTIS.Annotations[secretTISSigningAnnotation])
 	if err != nil {
 		secretInstallerSetSigningKey = false
+		logger.Debugw("Failed to parse signing key annotation, defaulting to false",
+			"annotation", secretTISSigningAnnotation,
+			"error", err)
 	}
 	if secretInstallerSetSigningKey != tc.Spec.GenerateSigningSecret {
+		logger.Infow("Signing key configuration changed, updating Secret InstallerSet",
+			"name", existingSecretInstallerSet,
+			"currentValue", secretInstallerSetSigningKey,
+			"newValue", tc.Spec.GenerateSigningSecret)
 		manifest := r.manifest.Filter(mf.ByKind("Secret"))
 		transformer := filterAndTransform(r.extension)
 		if _, err := transformer(ctx, &manifest, tc); err != nil {
 			tc.Status.MarkNotReady("transformation failed: " + err.Error())
+			logger.Errorw("Secret manifest transformation failed", "error", err)
 			return err
 		}
 		// update the installer set annotation
@@ -521,8 +599,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 
 		if _, err = r.operatorClientSet.OperatorV1alpha1().TektonInstallerSets().
 			Update(ctx, installedSecretTIS, metav1.UpdateOptions{}); err != nil {
+			logger.Errorw("Failed to update Secret InstallerSet", "name", installedSecretTIS.Name, "error", err)
 			return err
 		}
+		logger.Infow("Secret InstallerSet successfully updated", "name", installedSecretTIS.Name)
 	}
 
 	// Mark InstallerSetAvailable
@@ -531,6 +611,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 	ready := installedTIS.Status.GetCondition(apis.ConditionReady)
 	if ready == nil {
 		tc.Status.MarkInstallerSetNotReady("Waiting for installation")
+		logger.Debugw("InstallerSet status is Unknown", "name", installedTIS.Name)
 		return v1alpha1.REQUEUE_EVENT_AFTER
 	}
 
@@ -539,22 +620,28 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 		return v1alpha1.REQUEUE_EVENT_AFTER
 	} else if ready.Status == corev1.ConditionFalse {
 		tc.Status.MarkInstallerSetNotReady(ready.Message)
+		logger.Infow("InstallerSet not ready", "name", installedTIS.Name, "message", ready.Message)
 		return v1alpha1.REQUEUE_EVENT_AFTER
 	}
 
 	// Mark InstallerSet Ready
 	tc.Status.MarkInstallerSetReady()
+	logger.Infow("InstallerSet not ready", "name", installedTIS.Name, "message", ready.Message)
 
 	if err := r.extension.PostReconcile(ctx, tc); err != nil {
-		tc.Status.MarkPostReconcilerFailed(fmt.Sprintf("PostReconciliation failed: %s", err.Error()))
+		errMsg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
+		tc.Status.MarkPostReconcilerFailed(errMsg)
+		logger.Errorw("PostReconcile failed", "error", err, "component", "extension")
 		return err
 	}
 
 	// Mark PostReconcile Complete
 	tc.Status.MarkPostReconcilerComplete()
+	logger.Debug("PostReconcile completed successfully")
 
 	// Update the object for any spec changes
 	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonChains().Update(ctx, tc, metav1.UpdateOptions{}); err != nil {
+		logger.Errorw("Failed to update TektonChain status", "error", err)
 		return err
 	}
 

--- a/pkg/reconciler/kubernetes/tektondashboard/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektondashboard/reconcile.go
@@ -28,6 +28,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektondashboardreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektondashboard"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -58,81 +59,106 @@ var _ tektondashboardreconciler.Finalizer = (*Reconciler)(nil)
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, td *v1alpha1.TektonDashboard) pkgreconciler.Event {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("tektondashboard", td.GetName())
 	td.Status.InitializeConditions()
 	td.Status.ObservedGeneration = td.Generation
 	td.Status.SetVersion(r.dashboardVersion)
 
-	logger.Infow("Reconciling TektonDashboards", "status", td.Status)
+	logger.Debugw("Starting TektonDashboard reconciliation",
+		"version", r.dashboardVersion,
+		"generation", td.Generation,
+		"status", td.Status.GetCondition(apis.ConditionReady))
 
 	if td.GetName() != v1alpha1.DashboardResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.DashboardResourceName,
 			td.GetName(),
 		)
-		logger.Error(msg)
+		logger.Errorw("Invalid resource name", "expectedName", v1alpha1.DashboardResourceName, "actualName", td.GetName())
 		td.Status.MarkNotReady(msg)
 		return nil
 	}
 
 	// find the valid tekton-pipeline installation
+	logger.Debug("Checking Tekton Pipeline dependency")
 	if _, err := common.PipelineReady(r.pipelineInformer); err != nil {
 		if err.Error() == common.PipelineNotReady || err == v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR {
+			logger.Infow("Tekton Pipeline dependency not ready yet", "error", err)
 			td.Status.MarkDependencyInstalling("tekton-pipelines is still installing")
 			// wait for pipeline status to change
 			return v1alpha1.REQUEUE_EVENT_AFTER
 
 		}
 		// (tektonpipeline.opeator.tekton.dev instance not available yet)
+		logger.Errorw("Tekton Pipeline dependency missing", "error", err)
 		td.Status.MarkDependencyMissing("tekton-pipelines does not exist")
 		return err
 	}
+	logger.Info("All dependencies installed successfully")
 	td.Status.MarkDependenciesInstalled()
 
+	logger.Debug("Removing obsolete installer sets")
 	if err := r.installerSetClient.RemoveObsoleteSets(ctx); err != nil {
-		logger.Error("failed to remove obsolete installer sets: %v", err)
+		logger.Errorw("Failed to remove obsolete installer sets", "error", err)
 		return err
 	}
+	logger.Debug("Obsolete installer sets removed")
 
+	logger.Debug("Executing pre-reconciliation")
 	if err := r.extension.PreReconcile(ctx, td); err != nil {
+		logger.Errorw("Pre-reconciliation failed", "error", err)
 		td.Status.MarkPreReconcilerFailed(fmt.Sprintf("PreReconciliation failed: %s", err.Error()))
 		return err
 	}
 
 	// Mark PreReconcile Complete
+	logger.Info("Pre-reconciliation completed successfully")
 	td.Status.MarkPreReconcilerComplete()
 
 	var manifest mf.Manifest
 	if td.Spec.Readonly {
+		logger.Debugw("Using readonly manifest", "readonly", true)
 		manifest = r.readonlyManifest
 	} else {
+		logger.Debugw("Using full access manifest", "readonly", false)
 		manifest = r.fullaccessManifest
 	}
 
 	// When Tekton Dashboard is insalled targetNamespace is getting updated with the OwnerRef as TektonDashboard
 	// and hence deleting the component in the integration tests, targetNamespace was getting deleted. Hence
 	// filtering out the namespace here
+	logger.Debug("Filtering out namespace from manifest")
 	manifest = manifest.Filter(mf.Not(mf.ByKind("Namespace")))
+
+	logger.Debug("Applying main manifest")
 	if err := r.installerSetClient.MainSet(ctx, td, &manifest, filterAndTransform(r.extension)); err != nil {
 		msg := fmt.Sprintf("Main Reconcilation failed: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Failed to apply main installer set", "error", err)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("Main reconciliation requested requeue")
 			return err
 		}
 		td.Status.MarkInstallerSetNotReady(msg)
 		return nil
 	}
+	logger.Info("Main manifest applied successfully")
 
+	logger.Debug("Executing post-reconciliation")
 	if err := r.extension.PostReconcile(ctx, td); err != nil {
 		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Post-reconciliation failed", "error", err)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("Post-reconciliation requested requeue")
 			return err
 		}
+		logger.Infow("Post-reconciliation completed successfully")
 		td.Status.MarkPostReconcilerFailed(msg)
 		return nil
 	}
 
+	logger.Info("Post-reconciliation completed successfully")
 	td.Status.MarkPostReconcilerComplete()
+
+	logger.Info("TektonDashboard reconciliation completed successfully")
 	return nil
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -57,16 +58,22 @@ var _ tektonpipelinereconciler.Interface = (*Reconciler)(nil)
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipeline) pkgreconciler.Event {
-	logger := logging.FromContext(ctx).With("name", tp.GetName())
+	logger := logging.FromContext(ctx).With(
+		"name", tp.GetName(),
+		"namespace", tp.GetNamespace(),
+		"resourceVersion", tp.GetResourceVersion(),
+	)
+	logger.Debugw("Starting TektonPipeline reconciliation",
+		"version", r.pipelineVersion,
+		"status", tp.Status.GetCondition(apis.ConditionReady))
+
 	tp.Status.InitializeConditions()
 	tp.Status.SetVersion(r.pipelineVersion)
 
 	if tp.GetName() != v1alpha1.PipelineResourceName {
-		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
-			v1alpha1.PipelineResourceName,
-			tp.GetName(),
-		)
-		logger.Error(msg)
+		msg := fmt.Sprintf("Resource ignored: expected name '%s', got '%s'",
+			v1alpha1.PipelineResourceName, tp.GetName())
+		logger.Errorw("Invalid resource name", "expectedName", v1alpha1.PipelineResourceName, "actualName", tp.GetName())
 		tp.Status.MarkNotReady(msg)
 		return nil
 	}
@@ -75,33 +82,41 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	tp.SetDefaults(ctx)
 
 	// reconcile target namespace
+	logger.Debug("Reconciling target namespace")
 	if err := common.ReconcileTargetNamespace(ctx, nil, nil, tp, r.kubeClientSet); err != nil {
+		logger.Errorw("Failed to reconcile target namespace", "error", err)
 		return err
 	}
 
 	if err := r.installerSetClient.RemoveObsoleteSets(ctx); err != nil {
-		logger.Error("failed to remove obsolete installer sets: %v", err)
+		logger.Errorw("Failed to remove obsolete installer sets", "error", err)
 		return err
 	}
+	logger.Debug("Obsolete installer sets removed")
 
 	// Pipeline controller is deployed as statefulset, ensure deployment installerset is deleted
 	if tp.Spec.Performance.StatefulsetOrdinals != nil && *tp.Spec.Performance.StatefulsetOrdinals {
+		logger.Debugw("Cleaning up deployment installer set", "usingStatefulset", true)
 		if err := r.installerSetClient.CleanupSubTypeDeployment(ctx); err != nil {
-			logger.Error("failed to delete main deployment installer set: %v", err)
+			logger.Errorw("Failed to delete main deployment installer set", "error", err)
 			return err
 		}
+		logger.Debug("Deployment installer set deleted")
 	} else {
 		// Pipeline controller is deployed as deployment, ensure statefulset installerset is deleted
 		if err := r.installerSetClient.CleanupSubTypeStatefulset(ctx); err != nil {
-			logger.Error("failed to delete main statefulset installer set: %v", err)
+			logger.Debugw("Cleaning up statefulset installer set", "usingDeployment", true)
 			return err
 		}
+		logger.Debug("Statefulset installer set deleted")
 	}
 
+	logger.Debug("Executing pre-reconciliation")
 	if err := r.extension.PreReconcile(ctx, tp); err != nil {
 		msg := fmt.Sprintf("PreReconciliation failed: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Pre-reconciliation failed", "error", err)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("Pre-reconciliation requested requeue")
 			return err
 		}
 		tp.Status.MarkPreReconcilerFailed(msg)
@@ -109,6 +124,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	}
 
 	// Mark PreReconcile Complete
+	logger.Info("Pre-reconciliation completed successfully")
 	tp.Status.MarkPreReconcilerComplete()
 
 	// When TektonPipeline component is deleted targetNamespace was getting deleted,
@@ -116,30 +132,36 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	// in turn also updated the ownerRef of targetNamespace from TektonConfig to TektonPipeline.
 	// Since namespace is created in TektonConfig reconciler hence deleting TektonPipeline
 	// component should not delete the targetNamespace hence filtering out the namespace here
+	logger.Debug("Filtering out namespace from manifest")
 	manifest := r.manifest.Filter(mf.Not(mf.ByKind("Namespace")))
 
 	// Ensure webhook deadlock prevention before applying the manifest
+	logger.Debug("Preempting webhook deadlock")
 	if err := common.PreemptDeadlock(ctx, &manifest, r.kubeClientSet, v1alpha1.PipelineResourceName); err != nil {
-		msg := fmt.Sprintf("Failed to preempt webhook deadlock: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Failed to preempt webhook deadlock", "error", err)
 		return err
 	}
 
 	//Apply manifest
+	logger.Debug("Applying main manifest")
 	if err := r.installerSetClient.MainSet(ctx, tp, &manifest, filterAndTransform(r.extension)); err != nil {
 		msg := fmt.Sprintf("Main Reconcilation failed: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Failed to apply main installer set", "error", err)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("Main reconciliation requested requeue")
 			return err
 		}
 		tp.Status.MarkInstallerSetNotReady(msg)
 		return nil
 	}
+	logger.Info("Main manifest applied successfully")
 
+	logger.Debug("Executing post-reconciliation")
 	if err := r.extension.PostReconcile(ctx, tp); err != nil {
 		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
-		logger.Error(msg)
+		logger.Errorw("Post-reconciliation failed", "error", err)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Info("Post-reconciliation requested requeue")
 			return err
 		}
 		tp.Status.MarkPostReconcilerFailed(msg)
@@ -147,7 +169,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPipel
 	}
 
 	// Mark PostReconcile Complete
+	logger.Info("Post-reconciliation completed successfully")
 	tp.Status.MarkPostReconcilerComplete()
 
+	logger.Info("TektonPipeline reconciliation completed successfully")
 	return nil
 }

--- a/pkg/reconciler/kubernetes/tektontrigger/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/reconcile.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -58,88 +59,113 @@ var _ tektontriggerreconciler.Interface = (*Reconciler)(nil)
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tt *v1alpha1.TektonTrigger) pkgreconciler.Event {
-	logger := logging.FromContext(ctx).With("name", tt.GetName())
+	logger := logging.FromContext(ctx).With("tektonTrigger", tt.GetName())
 	tt.Status.InitializeConditions()
 	tt.Status.SetVersion(r.triggersVersion)
 
+	logger.Infow("Starting TektonTrigger reconciliation",
+		"version", r.triggersVersion,
+		"status", tt.Status.GetCondition(apis.ConditionReady))
+
 	if tt.GetName() != v1alpha1.TriggerResourceName {
+		logger.Errorw("Invalid resource name",
+			"expectedName", v1alpha1.TriggerResourceName,
+			"actualName", tt.GetName())
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.TriggerResourceName,
-			tt.GetName(),
-		)
-		logger.Error(msg)
+			tt.GetName())
 		tt.Status.MarkNotReady(msg)
 		return nil
 	}
 
 	if err := r.targetNamespaceCheck(ctx, tt); err != nil {
+		logger.Errorw("Target namespace check failed", "error", err)
 		return err
 	}
 
 	//Make sure TektonPipeline is installed before proceeding with
 	//TektonTrigger
+	logger.Debug("Checking TektonPipeline dependency")
 	if _, err := common.PipelineReady(r.pipelineInformer); err != nil {
 		if err.Error() == common.PipelineNotReady || err == v1alpha1.DEPENDENCY_UPGRADE_PENDING_ERR {
+			logger.Infow("Waiting for TektonPipeline installation to complete")
 			tt.Status.MarkDependencyInstalling("tekton-pipelines is still installing")
 			// wait for pipeline status to change
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		// (tektonpipeline.operator.tekton.dev instance not available yet)
+		logger.Errorw("TektonPipeline dependency not found", "error", err)
 		tt.Status.MarkDependencyMissing("tekton-pipelines does not exist")
 		return err
 	}
 	tt.Status.MarkDependenciesInstalled()
+	logger.Info("All dependencies installed successfully")
 
 	// Pass the object through defaulting
+	logger.Debug("Applying defaults to TektonTrigger")
 	tt.SetDefaults(ctx)
 
 	if err := r.installerSetClient.RemoveObsoleteSets(ctx); err != nil {
-		logger.Error("failed to remove obsolete installer sets: %v", err)
+		logger.Errorw("Failed to remove obsolete installer sets", "error", err)
 		return err
 	}
+	logger.Debug("Successfully removed obsolete installer sets")
 
+	logger.Debug("Running pre-reconciliation steps")
 	if err := r.extension.PreReconcile(ctx, tt); err != nil {
-		msg := fmt.Sprintf("PreReconciliation failed: %s", err.Error())
-		logger.Error(msg)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("PreReconciliation requested requeue")
 			return err
 		}
+		msg := fmt.Sprintf("PreReconciliation failed: %s", err.Error())
+		logger.Errorw("PreReconciliation failed", "error", err)
 		tt.Status.MarkPreReconcilerFailed(msg)
 		return nil
 	}
 
 	//Mark PreReconcile Complete
 	tt.Status.MarkPreReconcilerComplete()
+	logger.Info("PreReconciliation completed successfully")
 
 	// Ensure webhook deadlock prevention before applying the manifest
+	logger.Debugw("Preventing webhook deadlock")
 	if err := common.PreemptDeadlock(ctx, &r.manifest, r.kubeClientSet, v1alpha1.TriggerResourceName); err != nil {
-		msg := fmt.Sprintf("Failed to preempt webhook deadlock: %s", err.Error())
-		logger.Error(msg)
+		logger.Error("Webhook deadlock prevention failed", "error", err)
 		return err
 	}
+	logger.Debugw("Webhook deadlock prevention successful")
 
+	logger.Debugw("Running main reconciliation with installer set")
 	if err := r.installerSetClient.MainSet(ctx, tt, &r.manifest, filterAndTransform(r.extension)); err != nil {
-		msg := fmt.Sprintf("Main Reconcilation failed: %s", err.Error())
-		logger.Error(msg)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Info("Main reconciliation requested requeue")
 			return err
 		}
+		msg := fmt.Sprintf("Main Reconcilation failed: %s", err.Error())
+		logger.Errorw("Main reconciliation failed", "error", err)
 		tt.Status.MarkInstallerSetNotReady(msg)
 		return nil
 	}
+	logger.Info("Main reconciliation completed successfully")
 
+	logger.Debug("Running post-reconciliation steps")
 	if err := r.extension.PostReconcile(ctx, tt); err != nil {
-		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
-		logger.Error(msg)
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("PostReconciliation requested requeue")
 			return err
 		}
+		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
+		logger.Errorw("PostReconciliation failed", "error", err)
 		tt.Status.MarkPostReconcilerFailed(msg)
 		return nil
 	}
 
 	// Mark PostReconcile Complete
 	tt.Status.MarkPostReconcilerComplete()
+	logger.Infow("TektonTrigger reconciliation completed successfully",
+		"ready", tt.Status.GetCondition(apis.ConditionReady).IsTrue(),
+		"version", r.triggersVersion)
+
 	return nil
 }
 

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/upgrade"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -102,29 +103,35 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfig) pkgreconciler.Event {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("tektonconfig", tc.Name)
 	tc.Status.InitializeConditions()
 	tc.Status.SetVersion(r.operatorVersion)
 
-	logger.Infow("Reconciling TektonConfig", "status", tc.Status)
+	logger.Infow("Starting TektonConfig reconciliation",
+		"version", r.operatorVersion,
+		"profile", tc.Spec.Profile,
+		"status", tc.Status.GetCondition(apis.ConditionReady))
+
 	if tc.GetName() != v1alpha1.ConfigResourceName {
 		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.ConfigResourceName,
 			tc.GetName(),
 		)
-		logger.Error(msg)
+		logger.Errorw("Invalid resource name", "expectedName", v1alpha1.ConfigResourceName, "actualName", tc.GetName())
 		tc.Status.MarkNotReady(msg)
 		return nil
 	}
 
 	// run pre upgrade
-	err := r.upgrade.RunPreUpgrade(ctx)
-	if err != nil {
+	if err := r.upgrade.RunPreUpgrade(ctx); err != nil {
+		logger.Errorw("Pre-upgrade failed", "error", err)
 		return err
 	}
+	logger.Debug("Pre-upgrade completed successfully")
 
 	// Mark TektonConfig Instance as Not Ready if an upgrade is needed
 	if err := r.markUpgrade(ctx, tc); err != nil {
+		logger.Errorw("Failed to mark upgrade status", "error", err)
 		return err
 	}
 
@@ -135,105 +142,159 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 		nsMetaLabels = tc.Spec.TargetNamespaceMetadata.Labels
 		nsMetaAnnotations = tc.Spec.TargetNamespaceMetadata.Annotations
 	}
+	logger.Debugw("Reconciling target namespace",
+		"labelCount", len(nsMetaLabels),
+		"annotationCount", len(nsMetaAnnotations))
+
 	if err := common.ReconcileTargetNamespace(ctx, nsMetaLabels, nsMetaAnnotations, tc, r.kubeClientSet); err != nil {
+		logger.Errorw("Failed to reconcile target namespace", "error", err)
 		return err
 	}
+	logger.Debug("Target namespace reconciled successfully")
 
+	// Pre-reconcile extension hooks
 	if err := r.extension.PreReconcile(ctx, tc); err != nil {
 		if err == v1alpha1.RECONCILE_AGAIN_ERR {
+			logger.Infow("Extensions requested requeue")
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Errorw("Pre-install hook failed", "error", err)
 		tc.Status.MarkPreInstallFailed(err.Error())
 		return err
 	}
 
 	tc.Status.MarkPreInstallComplete()
+	logger.Debug("Pre-install completed successfully")
 
-	// Ensure if the pipeline CR already exists, if not create Pipeline CR
+	// Ensure Pipeline CR
 	tektonpipeline := pipeline.GetTektonPipelineCR(tc, r.operatorVersion)
-	// Ensure it exists
+	logger.Debug("Ensuring TektonPipeline CR exists")
 	if _, err := pipeline.EnsureTektonPipelineExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonPipelines(), tektonpipeline); err != nil {
-		tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonPipeline: %s", err.Error()))
+		errMsg := fmt.Sprintf("TektonPipeline: %s", err.Error())
+		logger.Errorw("Failed to ensure TektonPipeline exists", "error", err)
+		tc.Status.MarkComponentNotReady(errMsg)
 		if err == v1alpha1.RECONCILE_AGAIN_ERR {
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		return nil
 	}
+	logger.Info("TektonPipeline CR reconciled successfully")
 
-	// Create TektonTrigger CR if the profile is all or basic
+	// Ensure Pipeline Trigger
 	if tc.Spec.Profile == v1alpha1.ProfileAll || tc.Spec.Profile == v1alpha1.ProfileBasic {
 		tektontrigger := trigger.GetTektonTriggerCR(tc, r.operatorVersion)
+		logger.Debug("Ensuring TektonTrigger CR exists")
 		if _, err := trigger.EnsureTektonTriggerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), tektontrigger); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
+			errMsg := fmt.Sprintf("TektonTrigger: %s", err.Error())
+			logger.Errorw("Failed to ensure TektonTrigger exists", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
-
 		}
+		logger.Info("TektonTrigger CR reconciled successfully")
 	} else {
+		logger.Debugw("Ensuring TektonTrigger CR doesn't exist", "profile", tc.Spec.Profile)
 		if err := trigger.EnsureTektonTriggerCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers()); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonTrigger: %s", err.Error()))
+			errMsg := fmt.Sprintf("TektonTrigger: %s", err.Error())
+			logger.Errorw("Failed to ensure TektonTrigger has been deleted", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Info("TektonTrigger CR removal reconciled successfully")
 	}
 
+	// Ensure Chain CR
 	if !tc.Spec.Chain.Disabled {
 		tektonchain := chain.GetTektonChainCR(tc, r.operatorVersion)
+		logger.Debug("Ensuring TektonChain CR exists")
 		if _, err := chain.EnsureTektonChainExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonChains(), tektonchain); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonChain: %s", err.Error()))
+			errMsg := fmt.Sprintf("TektonChain: %s", err.Error())
+			logger.Errorw("Failed to ensure TektonChain exists", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Info("TektonChain CR reconciled successfully")
 	} else {
+		logger.Debugw("Ensuring TektonChain CR doesn't exist", "chainDisabled", tc.Spec.Chain.Disabled)
 		if err := chain.EnsureTektonChainCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonChains()); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonChain: %s", err.Error()))
+			errMsg := fmt.Sprintf("TektonChain: %s", err.Error())
+			logger.Errorw("Failed to ensure TektonChain has been deleted", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Info("TektonChain CR removal reconciled successfully")
 	}
 
-	// Create Results CR if it's enable
+	// Ensure Result CR
 	if !tc.Spec.Result.Disabled {
 		tektonresult := result.GetTektonResultCR(tc, r.operatorVersion)
-		if _, err = result.EnsureTektonResultExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonResults(), tektonresult); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonResult %s", err.Error()))
+		logger.Debug("Ensuring TektonResult CR exists")
+		if _, err := result.EnsureTektonResultExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonResults(), tektonresult); err != nil {
+			errMsg := fmt.Sprintf("TektonResult %s", err.Error())
+			logger.Errorw("Failed to ensure TektonResult exists", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Info("TektonResult CR reconciled successfully")
 	} else {
+		logger.Debugw("Ensuring TektonResult CR doesn't exist", "resultDisabled", tc.Spec.Result.Disabled)
 		if err := result.EnsureTektonResultCRNotExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonResults()); err != nil {
-			tc.Status.MarkComponentNotReady(fmt.Sprintf("TektonResult: %s", err.Error()))
+			errMsg := fmt.Sprintf("TektonResult: %s", err.Error())
+			logger.Errorw("Failed to ensure TektonResult has been deleted", "error", err)
+			tc.Status.MarkComponentNotReady(errMsg)
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
+		logger.Info("TektonResult CR removal reconciled successfully")
 	}
 
-	// reconcile pruner installerSet
+	// Ensure Pruner
 	if !tc.Spec.Pruner.Disabled {
+		logger.Debugw("Reconciling pruner installer set", "prunerDisabled", tc.Spec.Pruner.Disabled)
 		err := r.reconcilePrunerInstallerSet(ctx, tc)
 		if err != nil {
+			logger.Errorw("Failed to reconcile pruner installer set", "error", err)
 			return err
 		}
+		logger.Info("Pruner installer set reconciled successfully")
 	}
 
+	// Run resource pruning
 	if err := common.Prune(ctx, r.kubeClientSet, tc); err != nil {
-		tc.Status.MarkComponentNotReady(fmt.Sprintf("tekton-resource-pruner: %s", err.Error()))
-		logger.Error(err)
+		errMsg := fmt.Sprintf("tekton-resource-pruner: %s", err.Error())
+		logger.Errorw("Resource pruning failed", "error", err)
+		tc.Status.MarkComponentNotReady(errMsg)
+	} else {
+		logger.Debug("Resource pruning completed successfully")
 	}
 
 	tc.Status.MarkComponentsReady()
+	logger.Info("All components marked ready")
 
+	// Post-reconcile extension hooks
 	if err := r.extension.PostReconcile(ctx, tc); err != nil {
+		logger.Errorw("Post-reconcile hook failed", "error", err)
 		return err
 	}
 
 	tc.Status.MarkPostInstallComplete()
+	logger.Debug("Post-install completed successfully")
 
-	// Update the object status
+	// Update the object for any spec changes
+	logger.Debug("Updating TektonConfig status")
 	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonConfigs().UpdateStatus(ctx, tc, metav1.UpdateOptions{}); err != nil {
+		logger.Errorw("Failed to update TektonConfig status", "error", err)
 		return err
 	}
+	logger.Debug("TektonConfig status updated successfully")
 
 	// run post upgrade
-	err = r.upgrade.RunPostUpgrade(ctx)
-	if err != nil {
+	if err := r.upgrade.RunPostUpgrade(ctx); err != nil {
+		logger.Errorw("Post-upgrade failed", "error", err)
 		return err
 	}
+	logger.Debug("Post-upgrade completed successfully")
 
+	logger.Infow("TektonConfig reconciliation completed successfully",
+		"status", tc.Status.GetCondition(apis.ConditionReady))
 	return nil
 }
 


### PR DESCRIPTION
# Changes
Followup of https://github.com/tektoncd/operator/pull/2674
Partially fixes https://github.com/tektoncd/operator/issues/2472.  it addresses only tekton-operator-lifecycle

- Add consistent resource context to all log statements
- Provide more detailed information for state changes
- Add success confirmations for create/update operations
- Include error details and hash information for better troubleshooting

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
