### PR TITLE
Move TektonConfig Update to UpdateStatus to prevent spec changes

### DIFF
--- a/pkg/reconciler/common/common.go
+++ b/pkg/reconciler/common/common.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"context"
 	"errors"
 	"strings"
 
@@ -100,20 +99,4 @@ func TriggerReady(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrig
 func getTriggerRes(informer informer.TektonTriggerInformer) (*v1alpha1.TektonTrigger, error) {
 	res, err := informer.Lister().Get(v1alpha1.TriggerResourceName)
 	return res, err
-}
-
-func CheckUpgradePending(tc v1alpha1.TektonComponent) (bool, error) {
-	labels := tc.GetLabels()
-	ver, ok := labels[v1alpha1.ReleaseVersionKey]
-	if !ok {
-		return true, nil
-	}
-	operatorVersion, err := OperatorVersion(context.TODO())
-	if err != nil {
-		return false, err
-	}
-	if ver != operatorVersion {
-		return true, nil
-	}
-	return false, nil
 }

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -123,7 +123,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 		return err
 	}
 
-	tc.SetDefaults(ctx)
 	// Mark TektonConfig Instance as Not Ready if an upgrade is needed
 	if err := r.markUpgrade(ctx, tc); err != nil {
 		return err
@@ -224,8 +223,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 
 	tc.Status.MarkPostInstallComplete()
 
-	// Update the object for any spec changes
-	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonConfigs().Update(ctx, tc, metav1.UpdateOptions{}); err != nil {
+	// Update the object status
+	if _, err := r.operatorClientSet.OperatorV1alpha1().TektonConfigs().UpdateStatus(ctx, tc, metav1.UpdateOptions{}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Changes
- Removed the explicit call to setDefaults, as it is already handled by the DefaultingAdmissionController (webhook).
- Moved the TektonConfig update to UpdateStatus to prevent changes to the spec.
- Removed the unused method CheckUpgradePending.

this doesnt fix https://github.com/tektoncd/operator/issues/2675 but it is related

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
