### PR TITLE
Add LoggingPluginMultipartRegex for ResultsAPI

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -115,6 +115,7 @@ type ResultsAPIProperties struct {
 	LoggingPluginForwarderDelayDuration *uint  `json:"logging_plugin_forwarder_delay_duration,omitempty"`
 	LoggingPluginQueryLimit             *uint  `json:"logging_plugin_query_limit,omitempty"`
 	LoggingPluginQueryParams            string `json:"logging_plugin_query_params,omitempty"`
+	LoggingPluginMultipartRegex         string `json:"logging_plugin_multipart_regex,omitempty"`
 }
 
 // TektonResultStatus defines the observed state of TektonResult

--- a/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
+++ b/pkg/reconciler/kubernetes/tektonresult/testdata/api-config.yaml
@@ -28,6 +28,7 @@ data:
     LOGS_PATH=/logs
     LOGGING_PLUGIN_QUERY_LIMIT=7777
     LOGGING_PLUGIN_QUERY_PARAMS=direction=desc&skip=100
+    LOGGING_PLUGIN_MULTIPART_REGEX=""
     STORAGE_EMULATOR_HOST=
 kind: ConfigMap
 metadata:

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -98,6 +98,7 @@ func Test_updateApiConfig(t *testing.T) {
 				LoggingPluginForwarderDelayDuration: &bufferDuration,
 				LoggingPluginQueryLimit:             &limit,
 				LoggingPluginQueryParams:            "direction=asc&skip=0",
+				LoggingPluginMultipartRegex:         `-%s`,
 			},
 		},
 	}
@@ -135,6 +136,7 @@ LOGS_BUFFER_SIZE=12345
 LOGS_PATH=/logs/test
 LOGGING_PLUGIN_QUERY_LIMIT=100
 LOGGING_PLUGIN_QUERY_PARAMS=direction=asc&skip=0
+LOGGING_PLUGIN_MULTIPART_REGEX=-%s
 STORAGE_EMULATOR_HOST=http://localhost:9004`)
 }
 


### PR DESCRIPTION
Added LOGGING_PLUGIN_MULTIPART_REGEX field for setting configmap of Results API.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
-->

```release-note
NONE
```

