### PR TITLE
Add html_url to github-push CTB to fix clone issue

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/01-clustertriggerbindings/github.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/01-clustertriggerbindings/github.yaml
@@ -39,6 +39,8 @@ spec:
     value: $(body.head_commit.message)
   - name: git-repo-url
     value: $(body.repository.url)
+  - name: git-repo-clone-url
+    value: $(body.repository.html_url)
   - name: git-repo-name
     value: $(body.repository.name)
   - name: content-type


### PR DESCRIPTION
Git clone was failing with a 403 error when using `git-repo-url` because `$(body.repository.url)` points to the GitHub API URL. 
To resolve this, a new parameter `git-repo-clone-url` has been introduced, which uses `$(body.repository.html_url)` — the correct URL for cloning the repository.
sample payload example: 
```
{
  "ref": "refs/heads/main",
  "before": "a5b65c051f6cf14c99d54861151cb8069d3d3dfa",
  "after": "9edc40be966be2f218e414b166c57096a0cbd4d6",
  "repository": {
    ...
    "owner": {
       ....
    },
    "html_url": "https://github.com/org/repo",
    "url": "https://api.github.com/repos/org/repo",
    "forks_url": "https://api.github.com/repos/org/repo/forks",
    ...
    ...
    ...
    "git_url": "git://github.com/org/repo.git",
    "ssh_url": "git@github.com:org/repo.git",
    "clone_url": "https://github.com/org/repo.git
```
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Updated github-push CTB with new name git-repo-clone-url which helps to clone the code
```
