### PR TITLE
Corrected comment for StartMainWithSelectedControllers and moved copyright header

### DIFF
--- a/pkg/reconciler/platform/platform.go
+++ b/pkg/reconciler/platform/platform.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package platform
 
 import (
@@ -69,22 +85,6 @@ func activeControllers(p Platform) ControllerMap {
 // the result of disabledControllers is the set of controllers excluded by activeControllers function
 // in other words, disabledControllers returns a map which has controllers "not" specified in the controlelrNames input to a platform
 // the returned map is a subset of the platform specific map which stores all-supported-controllers
-/*
-Copyright 2022 The Tekton Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 func disabledControllers(p Platform) ControllerMap {
 	pParams := p.PlatformParams()
 	result := p.AllSupportedControllers()
@@ -122,8 +122,8 @@ func StartMainWithAllControllers(p Platform) {
 	startMain(p, p.AllSupportedControllers())
 }
 
-// StartMainWithAllControllers calls startMain with a subset of controllers
-// specified in the platformConfig of a platform
+// StartMainWithSelectedControllers starts the main control loop with only the controllers
+// that are explicitly specified in the platform configuration.
 func StartMainWithSelectedControllers(p Platform) {
 	validateControllerNamesOrDie(p)
 	selectedCtrls := activeControllers(p)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Improved code readability in `platform.go` by updating the function comment for `StartMainWithSelectedControllers` to reflect its behavior and moving the copyright header to the top of the file.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```release-note
NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
