### PR TITLE
Support custom DB secret in Results

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -1,9 +1,12 @@
-<!--
----
+## <!--
+
 linkTitle: "TektonConfig"
 weight: 1
+
 ---
+
 -->
+
 # Tekton Config
 
 TektonConfig custom resource is the top most component of the operator which allows user to install and customize all other
@@ -14,144 +17,146 @@ Operator provides support for installing and managing following operator compone
 - [TektonPipeline](./TektonPipeline.md)
 - [TektonTrigger](./TektonTrigger.md)
 
-
 Other than the above components depending on the platform operator also provides support for
+
 - On both Kubernetes and OpenShift
-    - [TektonChain](./TektonChain.md)
-    - [TektonResult](./TektonResult.md)
+  - [TektonChain](./TektonChain.md)
+  - [TektonResult](./TektonResult.md)
 - On Kubernetes
-    - [TektonDashboard](./TektonDashboard.md)
+  - [TektonDashboard](./TektonDashboard.md)
 - On OpenShift
-    - [TektonAddon](./TektonAddon.md)
-    - [OpenShiftPipelinesAsCode](./OpenShiftPipelinesAsCode.md)
+  - [TektonAddon](./TektonAddon.md)
+  - [OpenShiftPipelinesAsCode](./OpenShiftPipelinesAsCode.md)
 
 The TektonConfig CR provides the following features
 
 ```yaml
-  apiVersion: operator.tekton.dev/v1alpha1
-  kind: TektonConfig
-  metadata:
-    name: config
-  spec:
-    targetNamespace: tekton-pipelines
-    targetNamespaceMetadata:
-      labels: {}
-      annotations: {}
-    profile: all
-    config:
-      nodeSelector: <>
-      tolerations: []
-      priorityClassName: system-cluster-critical
-    chain:
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  targetNamespace: tekton-pipelines
+  targetNamespaceMetadata:
+    labels: {}
+    annotations: {}
+  profile: all
+  config:
+    nodeSelector: <>
+    tolerations: []
+    priorityClassName: system-cluster-critical
+  chain:
+    disabled: false
+  pipeline:
+    await-sidecar-readiness: true
+    coschedule: workspaces
+    disable-affinity-assistant: false
+    disable-creds-init: false
+    disable-home-env-overwrite: true
+    disable-working-directory-overwrite: true
+    disable-inline-spec: "pipeline,pipelinerun,taskrun"
+    enable-api-fields: beta
+    enable-bundles-resolver: true
+    enable-cel-in-whenexpression: false
+    enable-cluster-resolver: true
+    enable-custom-tasks: true
+    enable-git-resolver: true
+    enable-hub-resolver: true
+    enable-param-enum: false
+    enable-provenance-in-status: true
+    enable-step-actions: false
+    enforce-nonfalsifiability: none
+    keep-pod-on-cancel: false
+    max-result-size: 4096
+    metrics.count.enable-reason: false
+    metrics.pipelinerun.duration-type: histogram
+    metrics.pipelinerun.level: pipeline
+    metrics.taskrun.duration-type: histogram
+    metrics.taskrun.level: task
+    require-git-ssh-secret-known-hosts: false
+    results-from: termination-message
+    running-in-environment-with-injected-sidecars: true
+    send-cloudevents-for-runs: false
+    set-security-context: false
+    trusted-resources-verification-no-match-policy: ignore
+    performance:
+      disable-ha: false
+      buckets: 1
+      replicas: 1
+      threads-per-controller: 2
+      kube-api-qps: 5.0
+      kube-api-burst: 10
+    options:
       disabled: false
-    pipeline:
-      await-sidecar-readiness: true
-      coschedule: workspaces
-      disable-affinity-assistant: false
-      disable-creds-init: false
-      disable-home-env-overwrite: true
-      disable-working-directory-overwrite: true
-      disable-inline-spec: "pipeline,pipelinerun,taskrun"
-      enable-api-fields: beta
-      enable-bundles-resolver: true
-      enable-cel-in-whenexpression: false
-      enable-cluster-resolver: true
-      enable-custom-tasks: true
-      enable-git-resolver: true
-      enable-hub-resolver: true
-      enable-param-enum: false
-      enable-provenance-in-status: true
-      enable-step-actions: false
-      enforce-nonfalsifiability: none
-      keep-pod-on-cancel: false
-      max-result-size: 4096
-      metrics.count.enable-reason: false
-      metrics.pipelinerun.duration-type: histogram
-      metrics.pipelinerun.level: pipeline
-      metrics.taskrun.duration-type: histogram
-      metrics.taskrun.level: task
-      require-git-ssh-secret-known-hosts: false
-      results-from: termination-message
-      running-in-environment-with-injected-sidecars: true
-      send-cloudevents-for-runs: false
-      set-security-context: false
-      trusted-resources-verification-no-match-policy: ignore
-      performance:
-        disable-ha: false
-        buckets: 1
-        replicas: 1
-        threads-per-controller: 2
-        kube-api-qps: 5.0
-        kube-api-burst: 10
+      configMaps: {}
+      deployments: {}
+      webhookConfigurationOptions: {}
+  pruner:
+    disabled: false
+    schedule: "0 8 * * *"
+    resources:
+      - taskrun
+      - pipelinerun
+    keep: 3
+    # keep-since: 1440
+    # NOTE: you can use either "keep" or "keep-since", not both
+    prune-per-resource: true
+  hub:
+    params:
+      - name: enable-devconsole-integration
+        value: "true"
+    options:
+      disabled: false
+      configMaps: {}
+      deployments: {}
+      webhookConfigurationOptions: {}
+  dashboard:
+    readonly: true
+    options:
+      disabled: false
+      configMaps: {}
+      deployments: {}
+      webhookConfigurationOptions: {}
+  result:
+    disabled: false
+    is_external_db: false
+    options: {}
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        additionalPACControllers:
+          <controllerName>:
+            enable: true
+            configMapName:
+            secretName:
+            settings:
+        enable: true
+        settings:
+          application-name: Pipelines as Code CI
+          auto-configure-new-github-repo: "false"
+          bitbucket-cloud-check-source-ip: "true"
+          custom-console-name: ""
+          custom-console-url: ""
+          custom-console-url-pr-details: ""
+          custom-console-url-pr-tasklog: ""
+          error-detection-from-container-logs: "false"
+          error-detection-max-number-of-lines: "50"
+          error-detection-simple-regexp:
+            ^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([
+            ]*)?(?P<error>.*)
+          error-log-snippet: "true"
+          hub-catalog-name: tekton
+          hub-url: https://api.hub.tekton.dev/v1
+          remote-tasks: "true"
+          secret-auto-create: "true"
+          secret-github-app-token-scoped: "true"
       options:
         disabled: false
         configMaps: {}
         deployments: {}
         webhookConfigurationOptions: {}
-    pruner:
-      disabled: false
-      schedule: "0 8 * * *"
-      resources:
-        - taskrun
-        - pipelinerun
-      keep: 3
-      # keep-since: 1440
-      # NOTE: you can use either "keep" or "keep-since", not both
-      prune-per-resource: true
-    hub:
-      params:
-        - name: enable-devconsole-integration
-          value: "true"
-      options:
-        disabled: false
-        configMaps: {}
-        deployments: {}
-        webhookConfigurationOptions: {}
-    dashboard:
-      readonly: true
-      options:
-        disabled: false
-        configMaps: {}
-        deployments: {}
-        webhookConfigurationOptions: {}
-    result:
-      disabled: false
-      is_external_db: false
-      options: {}
-    platforms:
-      openshift:
-        pipelinesAsCode:
-          additionalPACControllers:
-            <controllerName>:
-              enable: true
-              configMapName:
-              secretName:
-              settings:
-          enable: true
-          settings:
-            application-name: Pipelines as Code CI
-            auto-configure-new-github-repo: "false"
-            bitbucket-cloud-check-source-ip: "true"
-            custom-console-name: ""
-            custom-console-url: ""
-            custom-console-url-pr-details: ""
-            custom-console-url-pr-tasklog: ""
-            error-detection-from-container-logs: "false"
-            error-detection-max-number-of-lines: "50"
-            error-detection-simple-regexp: ^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([
-              ]*)?(?P<error>.*)
-            error-log-snippet: "true"
-            hub-catalog-name: tekton
-            hub-url: https://api.hub.tekton.dev/v1
-            remote-tasks: "true"
-            secret-auto-create: "true"
-            secret-github-app-token-scoped: "true"
-        options:
-          disabled: false
-          configMaps: {}
-          deployments: {}
-          webhookConfigurationOptions: {}
 ```
+
 Look for the particular section to understand a particular field in the spec.
 
 ### Target Namespace
@@ -170,8 +175,9 @@ By default, namespace would be `tekton-pipelines` for Kubernetes and `openshift-
 
 This allows user to choose which all components to install on the cluster.
 There are 3 profiles available:
+
 - `all`: This profile will install all components (TektonPipeline, TektonTrigger, TektonResult and TektonChain)
-- `basic`:  This profile will install only TektonPipeline, TektonTrigger, TektonResult and TektonChain component
+- `basic`: This profile will install only TektonPipeline, TektonTrigger, TektonResult and TektonChain component
 - `lite`: This profile will install only TektonPipeline component
 
 On Kubernetes, `all` profile will install `TektonDashboard` and on OpenShift `TektonAddon` will be installed.
@@ -180,6 +186,7 @@ On Kubernetes, `all` profile will install `TektonDashboard` and on OpenShift `Te
 
 Config provides fields to configure deployments created by the Operator.
 This provides following fields:
+
 - [`nodeSelector`][node-selector]
 - [`tolerations`][tolerations]
 - [`priorityClassName`][priorityClassName]
@@ -188,23 +195,26 @@ User can pass the required fields and this would be passed to all Operator compo
 deployments created by Operator.
 
 Example:
+
 ```yaml
 config:
   nodeSelector:
     key: value
   tolerations:
-  - key: "key1"
-    operator: "Equal"
-    value: "value1"
-    effect: "NoSchedule"
+    - key: "key1"
+      operator: "Equal"
+      value: "value1"
+      effect: "NoSchedule"
   priorityClassName: system-node-critical
 ```
 
 This is an `Optional` section.
 
-**NOTE**: If `spec.config.priorityClassName` is used, then the required [`priorityClass`][priorityClass] is 
+**NOTE**: If `spec.config.priorityClassName` is used, then the required [`priorityClass`][priorityClass] is
 expected to be created by the user to get the Tekton resources pods in running state
+
 ### Pipeline
+
 Pipeline section allows user to customize the Tekton pipeline features. This allow user to customize the values in configmaps.
 
 Refer to [properties](./TektonPipeline.md#properties) section in TektonPipeline for available options.
@@ -238,7 +248,6 @@ pipeline:
     kube-api-burst: 10
 ```
 
-
 ### Chain
 
 Chain section allows user to customize the Tekton Chain features. This allows user to customize the values in configmaps
@@ -249,11 +258,11 @@ Example:
 
 ```yaml
 chain:
-  disabled: false                  # - `disabled` : if the value set as `true`, chains feature will be disabled (default: `false`)
+  disabled: false # - `disabled` : if the value set as `true`, chains feature will be disabled (default: `false`)
   targetNamespace: tekton-pipelines
   generateSigningSecret: true # default value: false
   controllerEnvs:
-    - name: MONGO_SERVER_URL      # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller
+    - name: MONGO_SERVER_URL # This is the only field supported at the moment which is optional and when added by user, it is added as env to Chains controller
       value: #value               # This can be provided same as env field of container
   artifacts.taskrun.format: in-toto
   artifacts.taskrun.storage: tekton,oci (comma separated values)
@@ -310,7 +319,7 @@ Example:
 
 ```yaml
 result:
-  disabled: false                  # - `disabled` : if the value set as `true`, result component will be disabled (default: `false`)
+  disabled: false # - `disabled` : if the value set as `true`, result component will be disabled (default: `false`)
   targetNamespace: tekton-pipelines
   is_external_db: false # By default, this is set to false, TektonOperator will create Tekton Results database. If set to true, an external database will be used, and Tekton Results will retrieve its database credentials from the Kubernetes secret named tekton-results-postgres
   db_host: localhost
@@ -335,10 +344,23 @@ result:
   prometheus_histogram: false
 ```
 
+User can configure custom database secret name for internal/external database via Tekton Config CR.
+
+Example:
+
+```yaml
+result:
+  db_secret_name: # custom database secret name
+  db_secret_user_key: # optional: required if custom database secret user key is not "POSTGRES_USER"
+  db_secret_password_key: # optional: required if custom database secret password key is not "POSTGRES_PASSWORD"
+```
+
 ### Pruner
+
 Pruner provides auto clean up feature for the Tekton `pipelinerun` and `taskrun` resources. In the background pruner container runs `tkn` command.
 
 Example:
+
 ```yaml
 pruner:
   disabled: false
@@ -352,6 +374,7 @@ pruner:
   # NOTE: you can use either "keep" or "keep-since", not both
   prune-per-resource: true
 ```
+
 - `disabled` : if the value set as `true`, pruner feature will be disabled (default: `false`)
 - `schedule`: how often to run the pruner job. User can understand the schedule syntax [here][schedule].
 - `startingDeadlineSeconds`: Optional deadline in seconds for starting the job if it misses scheduled time for any reason. Missed jobs executions will be counted as failed ones
@@ -361,11 +384,14 @@ pruner:
 - `prune-per-resource`: if the value set as `true` (default value `false`), the `keep` applied to each resource. The resources(`pipeline` and/or `task`) taken dynamically from that namespace and applied. <br> example: in a namespace `ns-1` I have two `pipeline`, named `pipeline-1` and `pipeline-2`, the out come would be: `tkn pipelinerun delete --pipeline=my-pipeline-1 --keep=3 --namespace=ns-1`, `tkn pipelinerun delete --pipeline=my-pipeline-2 --keep=3 --namespace=ns-1`. the same way works for `task` too.<br> **We do not see any benefit by enabling `prune-per-resource=true`, when you use `keep-since`. As `keep-since` is limiting the resources by time(irrespective of resource count), there is no change on the outcome.**
 
 > ### Note:
+>
 > if `disabled: false` and `schedule: ` with empty value, global pruner job will be disabled.
 > however, if there is a prune schedule (`operator.tekton.dev/prune.schedule`) annotation present with a value in a namespace. a namespace wide pruner jobs will be created.
 
 #### Pruner Namespace annotations
+
 By default pruner job will be created from the global pruner config (`spec.pruner`), though user can customize a pruner config to a specific namespace with the following annotations. If some of the annotations are not present or has invalid value, for that value, falls back to global value or skipped the namespace.
+
 - `operator.tekton.dev/prune.skip` - pruner job will be skipped to a namespace, if the value set as `true`
 - `operator.tekton.dev/prune.schedule` - pruner job will be created on a specific schedule
 - `operator.tekton.dev/prune.keep` - maximum number of resources will be kept
@@ -374,10 +400,10 @@ By default pruner job will be created from the global pruner config (`spec.prune
 - `operator.tekton.dev/prune.resources` - can be `taskrun` and/or `pipelinerun`, both value can be specified with comma separated. example: `taskrun,pipelinerun`
 - `operator.tekton.dev/prune.strategy` - allowed values: either `keep` or `keep-since`
 
-> ### Note: 
-> if a global value is not present the following values will be consider as default value <br> 
-> `resources: pipelinerun` <br>
-> `keep: 100` <br>
+> ### Note:
+>
+> if a global value is not present the following values will be consider as default value <br> > `resources: pipelinerun` <br> > `keep: 100` <br>
+
 ### Addon
 
 TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few PipelineTemplates, ResolverTasks, ResolverStepActions and CommunityResolverTasks.
@@ -385,6 +411,7 @@ TektonAddon install some resources along with Tekton Pipelines on the cluster. T
 This section allows to customize installation of those resources through params. You can read more about the supported params [here](./TektonAddon.md).
 
 Example:
+
 ```yaml
 addon:
   params:
@@ -404,10 +431,11 @@ of Operator.
 ### Hub
 
 This is to enable/disable showing hub resources in pipeline builder of devconsole(OpenShift UI). By default, the field is
-not there in the config object. If you want to disable the integration, you can add the param like below in config with value `false`. 
+not there in the config object. If you want to disable the integration, you can add the param like below in config with value `false`.
 The possible values are `true` and `false`.
 
 Example:
+
 ```yaml
 hub:
   params:
@@ -472,10 +500,12 @@ spec:
       tekton-hub-api: "https://my-custom-tekton-hub.example.com"
       artifact-hub-api: "https://my-custom-artifact-hub.example.com"
 ```
+
 Under the `hub-resolver-config`, the `tekton-hub-api` and `artifact-hub-api` will be passed as environment variable into `tekton-pipelines-remote-resolvers` controller.<br>
 In the deployment the environment name will be converted as follows,
-* `tekton-hub-api` => `TEKTON_HUB_API` 
-* `artifact-hub-api` => `ARTIFACT_HUB_API`
+
+- `tekton-hub-api` => `TEKTON_HUB_API`
+- `artifact-hub-api` => `ARTIFACT_HUB_API`
 
 ### OpenShiftPipelinesAsCode
 
@@ -507,7 +537,8 @@ platforms:
         custom-console-url-pr-tasklog: ""
         error-detection-from-container-logs: "false"
         error-detection-max-number-of-lines: "50"
-        error-detection-simple-regexp: ^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([
+        error-detection-simple-regexp:
+          ^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([
           ]*)?(?P<error>.*)
         error-log-snippet: "true"
         hub-catalog-name: tekton
@@ -520,12 +551,14 @@ platforms:
 **NOTE**: OpenShiftPipelinesAsCode is currently available for the OpenShift Platform only.
 
 ### Additional fields as `options`
+
 There is a field called `options` available in all the components.<br>
 
->**NOTE:** There is a possibility to have two different values for a field.<br> 
-An example: with a pre-defined field you can set value and the same field may be defined under `options` as well. In that case value from `options` will be final.
+> **NOTE:** There is a possibility to have two different values for a field.<br>
+> An example: with a pre-defined field you can set value and the same field may be defined under `options` as well. In that case value from `options` will be final.
 
 A sample `options` field,
+
 ```yaml
 options:
   disabled: false
@@ -609,12 +642,12 @@ options:
         minReplicas: 2
         maxReplicas: 7
         metrics:
-        - resource:
-            name: cpu
-            target:
-              averageUtilization: 85
-              type: Utilization
-          type: Resource
+          - resource:
+              name: cpu
+              target:
+                averageUtilization: 85
+                type: Utilization
+            type: Resource
   webhookConfigurationOptions:
     validation.webhook.pipeline.tekton.dev:
       failurePolicy: Fail
@@ -625,112 +658,123 @@ options:
       timeoutSeconds: 20
       sideEffects: None
 ```
-* `disabled` - disables the additional `options` support, if `disabled` set to `true`. default: `false`
+
+- `disabled` - disables the additional `options` support, if `disabled` set to `true`. default: `false`
 
 #### ConfigMaps
+
 Supports to update existing configMap also supports to create new configMap.
 
 The following fields are supported in `configMap`
-* `metadata`
-  * `labels` - supports add and update
-  * `annotations` - supports add and update
-* `data` - supports add and update
+
+- `metadata`
+  - `labels` - supports add and update
+  - `annotations` - supports add and update
+- `data` - supports add and update
 
 #### Deployments
+
 Supports to update the existing deployments. But not supported to create new deployment.
 
 The following fields are supported in `deployment`
-* `metadata`
-  * `labels` - supports add and update
-  * `annotations` - supports add and update
-* `spec`
-  * `replicas` - updates deployment replicas count
-  * `template`
-    * `metadata`
-      * `labels` - supports add and update
-      * `annotations` - supports add and update
-    * `spec`
-      * `affinity` - replaces the existing Affinity with this, if not empty
-      * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
-      * `nodeSelector` - replaces the existing NodeSelector with this, if not empty
-      * `tolerations` - replaces the existing tolerations with this, if not empty
-      * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
-      * `runtimeClassName` - adds and updates runtimeClassName
-      * `volumes` - adds and updates volumes
-      * `initContainers` - adds and updates init-containers
-        * `resources` - replaces the resources requirements with this, if not empty
-        * `envs` - adds and updates environments
-        * `volumeMounts` - adds and updates VolumeMounts
-        * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
-      * `containers` - adds and updates containers
-        * `resources` - replaces the resources requirements with this, if not empty
-        * `envs` - adds and updates environments
-        * `volumeMounts` - adds and updates VolumeMounts
-        * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
+
+- `metadata`
+  - `labels` - supports add and update
+  - `annotations` - supports add and update
+- `spec`
+  - `replicas` - updates deployment replicas count
+  - `template`
+    - `metadata`
+      - `labels` - supports add and update
+      - `annotations` - supports add and update
+    - `spec`
+      - `affinity` - replaces the existing Affinity with this, if not empty
+      - `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
+      - `nodeSelector` - replaces the existing NodeSelector with this, if not empty
+      - `tolerations` - replaces the existing tolerations with this, if not empty
+      - `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
+      - `runtimeClassName` - adds and updates runtimeClassName
+      - `volumes` - adds and updates volumes
+      - `initContainers` - adds and updates init-containers
+        - `resources` - replaces the resources requirements with this, if not empty
+        - `envs` - adds and updates environments
+        - `volumeMounts` - adds and updates VolumeMounts
+        - `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
+      - `containers` - adds and updates containers
+        - `resources` - replaces the resources requirements with this, if not empty
+        - `envs` - adds and updates environments
+        - `volumeMounts` - adds and updates VolumeMounts
+        - `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
 
 #### StatefulSets
+
 Supports to update the existing StatefulSet. But not supported to create new StatefulSet.
 
 The following fields are supported in `StatefulSet`
-* `metadata`
-  * `labels` - supports add and update
-  * `annotations` - supports add and update
-* `spec`
-  * `replicas` - updates statefulSets replicas count
-  * `serviceName` - updates service name
-  * `podManagementPolicy` - updates pod management policy
-  * `volumeClaimTemplates` - updates volume claim templates
-  * `template`
-    * `metadata`
-      * `labels` - supports add and update
-      * `annotations` - supports add and update
-    * `spec`
-      * `affinity` - replaces the existing Affinity with this, if not empty
-      * `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
-      * `nodeSelector` - replaces the existing NodeSelector with this, if not empty
-      * `tolerations` - replaces the existing tolerations with this, if not empty
-      * `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
-      * `runtimeClassName` - adds and updates runtimeClassName
-      * `volumes` - adds and updates volumes
-      * `initContainers` - adds and updates init-containers
-        * `resources` - replaces the resources requirements with this, if not empty
-        * `envs` - adds and updates environments
-        * `volumeMounts` - adds and updates VolumeMounts
-        * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
-      * `containers` - adds and updates containers
-        * `resources` - replaces the resources requirements with this, if not empty
-        * `envs` - adds and updates environments
-        * `volumeMounts` - adds and updates VolumeMounts
-        * `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
+
+- `metadata`
+  - `labels` - supports add and update
+  - `annotations` - supports add and update
+- `spec`
+  - `replicas` - updates statefulSets replicas count
+  - `serviceName` - updates service name
+  - `podManagementPolicy` - updates pod management policy
+  - `volumeClaimTemplates` - updates volume claim templates
+  - `template`
+    - `metadata`
+      - `labels` - supports add and update
+      - `annotations` - supports add and update
+    - `spec`
+      - `affinity` - replaces the existing Affinity with this, if not empty
+      - `priorityClassName` - replaces the existing PriorityClassName with this, if not empty
+      - `nodeSelector` - replaces the existing NodeSelector with this, if not empty
+      - `tolerations` - replaces the existing tolerations with this, if not empty
+      - `topologySpreadConstraints` - replaces the existing TopologySpreadConstraints with this, if not empty
+      - `runtimeClassName` - adds and updates runtimeClassName
+      - `volumes` - adds and updates volumes
+      - `initContainers` - adds and updates init-containers
+        - `resources` - replaces the resources requirements with this, if not empty
+        - `envs` - adds and updates environments
+        - `volumeMounts` - adds and updates VolumeMounts
+        - `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
+      - `containers` - adds and updates containers
+        - `resources` - replaces the resources requirements with this, if not empty
+        - `envs` - adds and updates environments
+        - `volumeMounts` - adds and updates VolumeMounts
+        - `args` - appends given args with existing arguments. **NOTE: THIS OPERATION DO NOT REPLACE EXISTING ARGS**
 
 #### HorizontalPodAutoscalers
+
 Supports to update the existing HorizontalPodAutoscaler(HPA) also supports to create new HPA.
 
 The following fields are supported in `HorizontalPodAutoscaler` (aka HPA)
-* `metadata`
-  * `labels` - supports add and update
-  * `annotations` - supports add and update
-* `spec`
-  * `scaleTargetRef` - replaces scaleTargetRef with this, if `kind` and `name` are not empty
-  * `minReplicas` - updates minimum replicas count
-  * `maxReplicas` - updates maximum replicas count
-  * `metrics` - replaces the metrics details with this array, if not empty
-  * `behavior` - updates behavior data with this, if not empty
-    * `scaleUp` - replaces scaleUp with this, if not empty
-    * `scaleDown` - replaces scaleDown with this, if not empty
+
+- `metadata`
+  - `labels` - supports add and update
+  - `annotations` - supports add and update
+- `spec`
+  - `scaleTargetRef` - replaces scaleTargetRef with this, if `kind` and `name` are not empty
+  - `minReplicas` - updates minimum replicas count
+  - `maxReplicas` - updates maximum replicas count
+  - `metrics` - replaces the metrics details with this array, if not empty
+  - `behavior` - updates behavior data with this, if not empty
+    - `scaleUp` - replaces scaleUp with this, if not empty
+    - `scaleDown` - replaces scaleDown with this, if not empty
 
 **NOTE**: If a Deployment or StatefulSet has a Horizontal Pod Autoscaling (HPA) and is in active state, Operator will not control the replicas to that resource. However if `status.desiredReplicas` and `spec.minReplicas` not present in HPA, operator takes the control. Also if HPA disabled, operator takes control. Even though the operator takes the control, the replicas value will be adjusted to the hpa's scaling range.
 
 #### webhookConfigurationOptions
+
 Defines additional options for each webhooks. Use webhook name as a key to define options for a webhook. Options are ignored if the webhook does not exist with the name key. To get detailed information about webhooks options visit https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 
 the following options are supported for webhookConfigurationOptions
-* `failurePolicy` -  defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are `Ignore` or `Fail`
-* `timeoutSeconds` - allows configuring how long the API server should wait for a webhook to respond before treating the call as a failure.
-* `sideEffects` -  indicates whether the webhook have a side effet. Allowed values are `None`, `NoneOnDryRun`, `Unknown`, or `Some`
 
-[node-selector]:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-[tolerations]:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-[schedule]:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
+- `failurePolicy` - defines how unrecognized errors and timeout errors from the admission webhook are handled. Allowed values are `Ignore` or `Fail`
+- `timeoutSeconds` - allows configuring how long the API server should wait for a webhook to respond before treating the call as a failure.
+- `sideEffects` - indicates whether the webhook have a side effet. Allowed values are `None`, `NoneOnDryRun`, `Unknown`, or `Some`
+
+[node-selector]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+[tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[schedule]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax
 [priorityClassName]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
 [priorityClass]: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass

--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -51,6 +51,9 @@ spec:
   db_sslmode: verify-full
   db_sslrootcert: /etc/tls/db/ca.crt
   db_enable_auto_migration: true
+  db_secret_name: # optional: custom database secret name
+  db_secret_user_key: # optional
+  db_secret_password_key: # optional
   log_level: debug
   logs_api: true
   logs_type: File

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -84,6 +84,9 @@ type ResultsAPIProperties struct {
 	DBSSLMode             string `json:"db_sslmode,omitempty"`
 	DBSSLRootCert         string `json:"db_sslrootcert,omitempty"`
 	DBEnableAutoMigration *bool  `json:"db_enable_auto_migration,omitempty"`
+	DBSecretName          string `json:"db_secret_name,omitempty"`
+	DBSecretUserKey       string `json:"db_secret_user_key,omitempty"`
+	DBSecretPasswordKey   string `json:"db_secret_password_key,omitempty"`
 	ServerPort            *int64 `json:"server_port,omitempty"`
 	PrometheusPort        *int64 `json:"prometheus_port,omitempty"`
 	PrometheusHistogram   *bool  `json:"prometheus_histogram,omitempty"`

--- a/test/e2e/kubernetes/tektonresultdeployment_test.go
+++ b/test/e2e/kubernetes/tektonresultdeployment_test.go
@@ -129,7 +129,7 @@ func createSecret(t *testing.T, clients *utils.Clients, namespace string) {
 
 	dbSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tektonresult.DbSecretName,
+			Name: tektonresult.DefaultDbSecretName,
 		},
 		Data: map[string][]byte{
 			"POSTGRES_USER":     []byte("postgres"),


### PR DESCRIPTION
Currently, Results is installed by default and operator creates default postgres database with default user name and password. Now with this PR users can configure their results db secret by adding in the tekton config CR.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Currently, Results is installed by default and operator creates default postgres database with default user name and password. Now with this PR users can configure their results db secret by adding in the tekton config CR.
```