### PR TITLE
Fix subpath capitalisation

### DIFF
--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -84,7 +84,7 @@ spec:
     workspaces:
       - name: output
         workspace: workarea
-        subpath: git
+        subPath: git
     params:
     - name: url
       value: https://$(params.package)
@@ -114,7 +114,7 @@ spec:
     workspaces:
     - name: source-to-release
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: unit-tests
     runAfter:
     - precheck
@@ -137,7 +137,7 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: fetch-component-releases
     runAfter:
     - unit-tests
@@ -155,7 +155,7 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
     params:
     - name: components
       value: $(params.components)
@@ -183,7 +183,7 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
   - name: publish-images-platform-kubernetes
     runAfter:
     - build-test
@@ -226,10 +226,10 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
     - name: output
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     - name: release-secret
       workspace: release-images-secret
   - name: publish-images-platform-openshift
@@ -274,10 +274,10 @@ spec:
     workspaces:
     - name: source
       workspace: workarea
-      subpath: git
+      subPath: git
     - name: output
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     - name: release-secret
       workspace: release-images-secret
   - name: publish-to-bucket
@@ -298,7 +298,7 @@ spec:
       workspace: release-secret
     - name: source
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     params:
     - name: location
       value: $(params.releaseBucket)/previous/$(params.versionTag)
@@ -329,7 +329,7 @@ spec:
       workspace: release-secret
     - name: source
       workspace: workarea
-      subpath: bucket
+      subPath: bucket
     params:
     - name: location
       value: $(params.releaseBucket)/latest


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The latest Tekton Pipelines release is stricter about validation and rejects the incorrect `subpath` field name. Update this to the expected `subPath`.

Follow-up to https://github.com/tektoncd/plumbing/pull/2537
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
