### PR TITLE
call transformation function for statefulsets

### DIFF
--- a/pkg/apis/operator/v1alpha1/performance_validation.go
+++ b/pkg/apis/operator/v1alpha1/performance_validation.go
@@ -37,7 +37,9 @@ func (ppp *PerformanceProperties) Validate(path string) *apis.FieldError {
 	if ppp.StatefulsetOrdinals != nil && *ppp.StatefulsetOrdinals {
 		if ppp.Replicas != nil {
 			replicas := uint(*ppp.Replicas)
-			if *ppp.Buckets != replicas {
+			if ppp.Buckets == nil {
+				errs = errs.Also(apis.ErrMissingField(bucketsPath, "spec.performance.buckets must be set when statefulset ordinals is enabled"))
+			} else if *ppp.Buckets != replicas {
 				errs = errs.Also(apis.ErrInvalidValue(*ppp.Replicas, fmt.Sprintf("%s.replicas", path), "spec.performance.replicas must equal spec.performance.buckets for statefulset ordinals"))
 			}
 		}

--- a/pkg/reconciler/openshift/common/testdata/test-cabundle-statefulset-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-cabundle-statefulset-expected.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          name: service-ca-bundle
+          readOnly: true
+      volumes:
+      - name: config-volume
+        configMap:
+          name: test-config
+      - configMap:
+          name: trusted-ca-bundle
+          optional: true
+        name: trusted-ca-bundle
+      - configMap:
+          name: service-ca-bundle
+          optional: true
+        name: service-ca-bundle

--- a/pkg/reconciler/openshift/common/testdata/test-cabundle-statefulset.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-cabundle-statefulset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: test-config

--- a/pkg/reconciler/openshift/common/testdata/test-remove-fsgroup-statefulset-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fsgroup-statefulset-expected.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      securityContext: {}
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-remove-fsgroup-statefulset.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-fsgroup-statefulset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      securityContext:
+        fsGroup: 2000
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-remove-runasgroup-statefulset-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-runasgroup-statefulset-expected.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-remove-runasgroup-statefulset.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-runasgroup-statefulset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-remove-runasuser-statefulset-expected.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-runasuser-statefulset-expected.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsGroup: 2000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/testdata/test-remove-runasuser-statefulset.yaml
+++ b/pkg/reconciler/openshift/common/testdata/test-remove-runasuser-statefulset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  serviceName: test-service
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test-container
+        image: test-image
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL

--- a/pkg/reconciler/openshift/common/transformer_test.go
+++ b/pkg/reconciler/openshift/common/transformer_test.go
@@ -165,3 +165,90 @@ func TestUpdateServiceMonitorTargetNamespace(t *testing.T) {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
 	}
 }
+
+func TestRemoveRunAsUserForStatefulSet(t *testing.T) {
+	testData := path.Join("testdata", "test-remove-runasuser-statefulset.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-remove-runasuser-statefulset-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(RemoveRunAsUserForStatefulSet("test-statefulset"))
+	assert.NilError(t, err)
+
+	got := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, got)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	expected := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expected)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("failed to update statefulset %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestRemoveFsGroupForStatefulSet(t *testing.T) {
+	testData := path.Join("testdata", "test-remove-fsgroup-statefulset.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-remove-fsgroup-statefulset-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(RemoveFsGroupForStatefulSet("test-statefulset"))
+	assert.NilError(t, err)
+
+	got := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, got)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	expected := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expected)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("failed to update statefulset %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestRemoveRunAsGroupForStatefulSet(t *testing.T) {
+	testData := path.Join("testdata", "test-remove-runasgroup-statefulset.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	testData = path.Join("testdata", "test-remove-runasgroup-statefulset-expected.yaml")
+	expectedManifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(RemoveRunAsGroupForStatefulSet("test-statefulset"))
+	assert.NilError(t, err)
+
+	got := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, got)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	expected := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedManifest.Resources()[0].Object, expected)
+	if err != nil {
+		t.Errorf("failed to load statefulset yaml")
+	}
+
+	if d := cmp.Diff(expected, got); d != "" {
+		t.Errorf("failed to update statefulset %s", diff.PrintWantGot(d))
+	}
+}

--- a/pkg/reconciler/openshift/tektonchain/extension.go
+++ b/pkg/reconciler/openshift/tektonchain/extension.go
@@ -27,6 +27,10 @@ import (
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 )
 
+const (
+	tektonChainsControllerName = "tekton-chains-controller"
+)
+
 func OpenShiftExtension(ctx context.Context) common.Extension {
 	ext := openshiftExtension{
 		operatorClientSet: operatorclient.Get(ctx),
@@ -42,7 +46,10 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
+		occommon.RemoveRunAsUserForStatefulSet(tektonChainsControllerName),
+		occommon.RemoveRunAsGroupForStatefulSet(tektonChainsControllerName),
 		occommon.ApplyCABundles,
+		occommon.ApplyCABundlesForStatefulSet(tektonChainsControllerName),
 	}
 }
 func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -37,6 +37,9 @@ const (
 	monitoringLabelKey = "openshift.io/cluster-monitoring"
 	enableMetricsKey   = "enableMetrics"
 	versionKey         = "VERSION"
+
+	tektonPipelinesControllerName       = "tekton-pipelines-controller"
+	tektonRemoteResolversControllerName = "tekton-pipelines-remote-resolvers"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -65,6 +68,10 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	trns := []mf.Transformer{
 		occommon.ApplyCABundles,
 		occommon.RemoveRunAsUser(),
+		occommon.RemoveRunAsUserForStatefulSet(tektonPipelinesControllerName),
+		occommon.RemoveRunAsUserForStatefulSet(tektonRemoteResolversControllerName),
+		occommon.ApplyCABundlesForStatefulSet(tektonPipelinesControllerName),
+		occommon.ApplyCABundlesForStatefulSet(tektonRemoteResolversControllerName),
 	}
 	return trns
 }

--- a/pkg/reconciler/openshift/tektonresult/extension.go
+++ b/pkg/reconciler/openshift/tektonresult/extension.go
@@ -47,6 +47,7 @@ const (
 	boundSAVolume           = "bound-sa-token"
 	boundSAPath             = "/var/run/secrets/openshift/serviceaccount"
 	lokiStackTLSCAEnvVar    = "LOGGING_PLUGIN_CA_CERT"
+	tektonResultWatcherName = "tekton-results-watcher"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -97,6 +98,9 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundles,
+		occommon.RemoveRunAsUserForStatefulSet(tektonResultWatcherName),
+		occommon.RemoveRunAsGroupForStatefulSet(tektonResultWatcherName),
+		occommon.ApplyCABundlesForStatefulSet(tektonResultWatcherName),
 		injectBoundSAToken(instance.Spec.ResultsAPIProperties),
 		injectLokiStackTLSCACert(instance.Spec.LokiStackProperties),
 		injectResultsAPIServiceCACert(instance.Spec.ResultsAPIProperties),


### PR DESCRIPTION
# Changes
Issue: Pods in the tekton-chains-controller StatefulSet failed to start due to SCC (Security Context Constraints) validation errors. The pod’s runAsUser: 65532 does not fall within any allowed SCC UID range ([1000770000, 1000779999]), and none of the available SCCs are permitted for the service
Fix: This PR introduces calls transformation function when using statefusets

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
