### PR TITLE
Skip default TLS secret creation on OpenShift platform

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -489,6 +489,11 @@ func (r *Reconciler) createDBSecret(ctx context.Context, tr *v1alpha1.TektonResu
 func (r *Reconciler) createTLSSecret(ctx context.Context, tr *v1alpha1.TektonResult) error {
 	logger := logging.FromContext(ctx)
 
+	if v1alpha1.IsOpenShiftPlatform() {
+		logger.Info("Skipping default TLS secret creation: running on OpenShift platform")
+		return nil
+	}
+
 	_, err := r.kubeClientSet.CoreV1().Secrets(tr.Spec.TargetNamespace).Get(ctx, TlsSecretName, metav1.GetOptions{})
 	if err == nil {
 		return nil


### PR DESCRIPTION
# Changes
On OpenShift platform TLS certificate is handled by the OpenShift serving ca operator and injected by the Operator as label in the Result Api Service , earlier Operator checks if TLS certificate is present it doesn't create otherwise creates. Sometime it's is created by the Operator as well and Result api pod started failing.
So this PR will skip the creation of default TLS secret creation in case of OpenShift platform.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Skip default TLS secret creation on OpenShift platform.
```
