### PR TITLE
feat: add recursive manifest fetching support

### DIFF
--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -77,6 +77,34 @@ func TestAppendManifest(t *testing.T) {
 	}
 
 	if len(newManifest.Resources()) != 1 {
-		t.Fatalf("failed to find expected number of resource: %d found, expected 3", len(newManifest.Resources()))
+		t.Fatalf("failed to find expected number of resource: %d found, expected 1", len(newManifest.Resources()))
 	}
+}
+
+func TestFetchAndFetchRecursive(t *testing.T) {
+	// Set up test environment
+	koPath := "testdata/kodata"
+	t.Setenv(KoEnvKey, koPath)
+
+	// Test Fetch not recursive
+	t.Run("Fetch should return manifest from path", func(t *testing.T) {
+		manifest, err := Fetch("testdata/kodata/tekton-addon")
+		if err != nil {
+			t.Fatalf("Fetch failed: %v", err)
+		}
+		if len(manifest.Resources()) != 1 {
+			t.Fatalf("expected 1 resource, got %d", len(manifest.Resources()))
+		}
+	})
+
+	// Test FetchRecursive
+	t.Run("FetchRecursive should return manifest from path recursively", func(t *testing.T) {
+		manifest, err := FetchRecursive("testdata/kodata/tekton-addon")
+		if err != nil {
+			t.Fatalf("FetchRecursive failed: %v", err)
+		}
+		if len(manifest.Resources()) != 3 {
+			t.Fatalf("expected 3 resources, got %d", len(manifest.Resources()))
+		}
+	})
 }


### PR DESCRIPTION
# Changes
- Add cacheRecursive to store recursive manifest results
- Refactor Fetch function to use generic fetchWithCache
- Add FetchRecursive function to support recursive manifest fetching
- Update TargetManifest to use FetchRecursive
- Add tests for Fetch and FetchRecursive functions
- Fix incorrect test assertion message in TestAppendManifest

# Description
Indeed, currently Tekton only has sub directories in `pipelines-as-code` and the manifests in the `hub`, but I haven’t encountered it in other components yet.
However, we shouldn’t restrict this feature to be used only for PAC.

For example, if I want to add some common `ClusterTriggerBindings` in the trigger component, I would like to maintain these files in subdirectories, such as separating resources for `GitLab` and `GitHub`, rather than mixing them in a single final YAML file.

Like this: https://github.com/tektoncd/operator/pull/2421

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
feat: add recursive manifest fetching support
```
