### PR TITLE
fix pruner crd v1alpha1 not found issue

### DIFF
--- a/charts/tekton-operator/README.md
+++ b/charts/tekton-operator/README.md
@@ -31,7 +31,10 @@ helm install tekton-operator \
 The Tekton operator is installed into the `tekton-operator` namespace for Kubernetes clusters and into `openshift-operators` for Openshift clusters (`openshift.enabled=true`).
 
 The Tekton Custom Resource Definitions (CRDs) can either be installed manually (the recommended approach, see the [Tekton Operator Releases page](https://github.com/tektoncd/operator/releases)) or as part of the Helm chart (`installCRDs=true`).
-Installing the CRDs as part of the Helm chart is not recommended for production setups, since uninstalling the Helm chart will also uninstall the CRDs and subsequently delete any remaining CRs.
+
+**Important:** The Tekton operator components (especially the webhook) require the CRDs to be present during startup. If you set `installCRDs=false`, you **MUST** install the CRDs manually **BEFORE** installing the operator, otherwise the operator pods will fail to start with errors like "the server could not find the requested resource".
+
+Installing the CRDs as part of the Helm chart(`installCRDs=true`) is not recommended for production setups, since uninstalling the Helm chart will also uninstall the CRDs and subsequently delete any remaining CRs.
 The CRDs allow you to configure individual parts of your Tekton setup:
 
 * [`TektonConfig`](https://tekton.dev/docs/operator/tektonconfig/)
@@ -40,6 +43,8 @@ The CRDs allow you to configure individual parts of your Tekton setup:
 * [`TektonDashboard`](https://tekton.dev/docs/operator/tektondashboard/)
 * [`TektonResult`](https://tekton.dev/docs/operator/tektonresult/)
 * [`TektonAddon`](https://tekton.dev/docs/operator/tektonaddon/)
+* [`TektonChain`](https://tekton.dev/docs/operator/tektonchain/)
+
 
 After the installation of the Tekton-operater chart, you can start inject the Custom Resources (CRs) into your cluster.
 The Tekton operator will then automatically start installing the components.
@@ -50,7 +55,7 @@ Please see the documentation of each CR for details.
 Before removing the Tekton operator from your cluster, you should first make sure that there are no instances of resources managed by the operator left:
 
 ```sh
-kubectl get TektonConfig,TektonPipeline,TektonDashboard,TektonInstallerSet,TektonResults,TektonTrigger,TektonAddon --all-namespaces
+kubectl get TektonConfig,TektonPipeline,TektonDashboard,TektonInstallerSet,TektonResults,TektonTrigger,TektonAddon,TektonPruner,TektonChain --all-namespaces
 ```
 
 Now you can use Helm to uninstall the Tekton operator:

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -346,4 +346,42 @@ spec:
       storage: true
       subresources:
         status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.tekton.dev/release: "devel"
+    version: "devel"
+  name: tektonpruners.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the TektonPruner API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 {{- end -}}

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -387,4 +387,42 @@ spec:
       storage: true
       subresources:
         status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.tekton.dev/release: "devel"
+    version: "devel"
+  name: tektonpruners.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Schema for the TektonPruner API
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}
 {{- end -}}

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -558,6 +558,22 @@ platforms:
 
 **NOTE**: OpenShiftPipelinesAsCode is currently available for the OpenShift Platform only.
 
+### **Tech Preview** Event based pruner 
+
+The `tektonpruner` section in the TektonConfig spec allows  to manage the event-driven Tekton Pruner, which enables configuration-based cleanup of Tekton resources.
+
+> Important: This component is **disabled by default**. To enable the event-based pruner, the existing job-based pruner `pruner` **MUST** be disabled.
+
+```yaml
+  tektonpruner:
+    disabled: true
+    options: {}
+```
+**Configuration Notes :**
+- In this Tech Preview, only enabled/disabled status is configurable via `tektonconfig` spec.
+
+- For all other  [configurations](https://github.com/openshift-pipelines/tektoncd-pruner/blob/main/docs/tutorials/getting-started.md#basic-pruner-configuration)(e.g., TTLs, history limits), use the ConfigMap: `tekton-pruner-default-spec`
+
 ### Additional fields as `options`
 
 There is a field called `options` available in all the components.<br>

--- a/docs/TektonPruner.md
+++ b/docs/TektonPruner.md
@@ -1,0 +1,65 @@
+<!--
+---
+linkTitle: "TektonPruner"
+weight: 30
+---
+-->
+# Tekton Pruner
+
+TektonPruner custom resource allows user to install and manage [Event Based Tekton Pruner][pruner].
+
+It is recommended to install the component through [TektonConfig](./TektonConfig.md).
+
+**NOTE**: Job based pruner **MUST** be disabled for the new event based pruner to be enabled.
+
+- TektonPruner CR is as below
+
+    - On Kubernetes, TektonPruner CR is as below:
+
+    ```yaml
+    apiVersion: operator.tekton.dev/v1alpha1
+    kind: TektonPruner
+    metadata:
+      name: pruner
+    spec:
+      disabled: false
+      targetNamespace: tekton-pipelines
+    ```
+
+    - On OpenShift, TektonPruner CR is as below:
+
+    ```yaml
+    apiVersion: operator.tekton.dev/v1alpha1
+    kind: TektonPruner
+    metadata:
+      name: pruner
+    spec:
+      disabled: false
+      targetNamespace: openshift-pipelines
+    ```
+
+- Check the status of installation using following command:
+
+    ```sh
+    kubectl get tektonpruners.operator.tekton.dev
+    ```
+
+## Pruner Config
+
+Right now, event based pruner config just allows to either enable or disable the new pruner.
+
+
+### Properties (Mandatory)
+
+ - `targetNamespace`
+
+    Setting this field to provide the namespace in which you want to install the pruner component.
+
+- `disabled` : if the value set as `true`, pruner feature will be disabled (default: `true`)
+
+Rest of the configurations as defined [here][pruner-config] are currently managed with the configmap [`tekton-pruner-default-spec`](https://github.com/openshift-pipelines/tektoncd-pruner/blob/main/config/600-tekton-pruner-default-spec.yaml).
+
+
+
+[pruner]:https://github.com/openshift-pipelines/tektoncd-pruner
+[pruner-config]:https://github.com/openshift-pipelines/tektoncd-pruner/blob/main/docs/tutorials/README.md


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This PR fixes the issue https://github.com/tektoncd/operator/issues/2773 

Custom Resource Definition to manage new event based Tekton Pruner controller introduced in 0.76.0  were missing in the helm specs. This has been added in this PR now.

This PR was Co-authored with @pramodbindal 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
