### PR TITLE
Fix: Corrected PostgreSQL PGDATA and volume mount path to ensure data persistence

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/internal-db/db.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/internal-db/db.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - env:
             - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
+              value: /var/lib/pgsql/data
             - name: POSTGRESQL_DATABASE
               valueFrom:
                 configMapKeyRef:
@@ -79,7 +79,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
-            - mountPath: /var/lib/postgresql
+            - mountPath: /var/lib/pgsql/data
               name: postgredb
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
# Changes

### Fix: Pipeline console contents lost after tekton-results-postgres-0 restart

#### Issue:
The PostgreSQL StatefulSet was using an incorrect volume mount and PGDATA path:
- `PGDATA` was set to `/var/lib/postgresql/data/pgdata`
- Volume was mounted at `/var/lib/postgresql`

#### Resolution:
- Updated `PGDATA` to `/var/lib/pgsql/data`
- Updated `volumeMount` path to `/var/lib/pgsql/data`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
