### PR TITLE
add additionalEnvs capability to operator deployment

### DIFF
--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
               {{- end }}
             - name: CONFIG_OBSERVABILITY_NAME
               value: {{ include "tekton-operator.fullname" . }}-observability
+            {{- range .Values.additionalEnvs }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
           args:
             - "-controllers"
             - {{ .Values.controllers | default "tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonresult,tektondashboard,manualapprovalgate,tektonpruner" | quote }}


### PR DESCRIPTION
  # Changes

Add additionalEnvs capability to the Tekton operator Helm chart deployment template. This enables custom environment variables to be injected into the operator container via Helm values configuration. It provides flexibility for users to pass custom configuration without modifying the core deployment template.

  Usage example:

We use this to override images so that we can pull them through our private ECR registry.
  ```yaml
  additionalEnvs:
    - name: IMAGE_DASHBOARD_TEKTON_DASHBOARD
      value: "<account id>.dkr.ecr.<region>.amazonaws.com/ghcr/tektoncd/github.com/tektoncd/dashboard/cmd/dashboard:v0.49.0"
    - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
      value: "<account id>.dkr.ecr.<region>.amazonaws.com/ghcr/tektoncd/github.com/tektoncd/pipeline/cmd/controller:v0.62.3"
    - ...

This allows users to specify additional environment variables in their values.yaml file that will be automatically added to the operator container during deployment.

  Submitter Checklist

  These are the criteria that every PR should meet, please check them off as you
  review them:

  - [x] Run make test lint before submitting a PR
  - [ ] Includes https://github.com/tektoncd/community/blob/master/standards.md#principles (if functionality changed/added)
  - [ ]Includes https://github.com/tektoncd/community/blob/master/standards.md#principles (if user facing)
  - [x] Commit messages follow https://github.com/tektoncd/community/blob/master/standards.md#commit-messages

  See https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md for more details.

  Release Notes

  Add `additionalEnvs` capability to Helm chart allowing custom environment variables to be injected into the operator deployment