### PR TITLE
add init container support to tekton-operator deployment

### DIFF
--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.operator.deployment.initContainers.enabled }}
+      initContainers:
+        {{- toYaml .Values.operator.deployment.initContainers.containers | nindent 8 }}
+      {{- end }}
       containers:
         - env:
             - name: SYSTEM_NAMESPACE

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -48,6 +48,12 @@ operator:
   deployment:
     # Custom labels for the Deployment resource.
     customLabels: ""
+    # Custom init containers for the Deployment resource.
+    # Can be used for pre-deployment setup and validation (e.g. waiting for specific resources to be available prior to starting the operator)
+    # see https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+    initContainers:
+      enabled: false
+      containers: []
     # Custom labels for the Deployment Pod Template.
     podTemplateCustomLabels: ""
 


### PR DESCRIPTION
# Changes

  Allow configuring init containers in the Helm chart deployment template when `operator.initContainers.enabled` is set to true.

  Usage example:

  We use this to inject a `initContainer` before Tekton Operator bootup, like so:

```yaml
operator:
  initContainers:
    enabled: true
    containers:
      - name: init-setup
        image: "<image>"
        command: ['sh', '-c', '<custom operation>']
```

  # Submitter Checklist

  These are the criteria that every PR should meet, please check them off as you
  review them:

  - [x] Run `make test lint` before submitting a PR
  - [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
  - [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
  - [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

  _See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

  # Release Notes

  ```release-note
  Add support for configuring init containers in Tekton Operator Helm chart deployment template