### PR TITLE
fix: prevent panic when pruner field is nil during upgrade

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -88,5 +88,9 @@ func (tp *TektonPruner) GetStatus() TektonComponentStatus {
 
 // IsDisabled returns true if the TektonPruner is disabled
 func (p *Pruner) IsDisabled() bool {
+	if p == nil || p.Disabled == nil {
+		// When the Pruner is nil or Disabled is nil, we assume it is the default state.
+		return DefaultPrunerDisabled
+	}
 	return *p.Disabled
 }


### PR DESCRIPTION
Add nil pointer checks to `TektonPruner.IsDisabled()` method to safely handle cases where Pruner or Disabled pointer is nil during upgrade scenarios.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Fix panic in `TektonPruner` when `Disabled` field is nil during upgrade
```