### PR TITLE
fix(openshift git resolver): mount the trusted-ca-configmap into component's system ca store in Openshift

### DIFF
--- a/docs/TektonOperator.md
+++ b/docs/TektonOperator.md
@@ -92,3 +92,18 @@ After installing the resources, `TektonInstallerSet` waits for deployment pods t
 
   As we have extension mechanism where we handle platform specific resources, in case of OpenShift we create additional resources in Pre and Post Reconciler in TektonPipeline. In both the cases we have an `TektonInstallerSet` created, on upgrade or target namespace change we delete the old and create a new `TektonInstallerSet`. 
 
+## Tekton Operator on Openshift
+When the Tekton Operator is [installed](./install.md) for Openshift, the
+Operator configure Tekton in order to cater Tekton the deployment for an
+Openshift cluster.
+
+### Custom CA Certificates
+When installed for Openshift, the Operator will inject the Openshift
+Proxy's custom certificates into the Tekton components' pods system trust
+store. This allows components such as the remote resolvers to connect
+to domains which use self-signed or private certificates for TLS.
+
+Documentation on configuring custom certificates for Openshift Proxy can
+be found in the [Openshift Network Configuration documentation][openshift-proxy-configuration].
+
+[openshift-proxy-configuration]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/configuring_network_settings/configuring-a-custom-pki

--- a/pkg/reconciler/common/certificates.go
+++ b/pkg/reconciler/common/certificates.go
@@ -35,8 +35,8 @@ const (
 	ServiceCAKey             = "service-ca.crt"
 )
 
-// newVolumeWithConfigMap creates a new volume with the given ConfigMap
-func newVolumeWithConfigMap(volumeName, configMapName, configMapKey, configMapPath string) corev1.Volume {
+// NewVolumeWithConfigMap creates a new volume with the given ConfigMap
+func NewVolumeWithConfigMap(volumeName, configMapName, configMapKey, configMapPath string) corev1.Volume {
 	return corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -68,8 +68,8 @@ func AddCABundleConfigMapsToVolumes(volumes []corev1.Volume) []corev1.Volume {
 
 	return append(
 		volumes,
-		newVolumeWithConfigMap(TrustedCAConfigMapVolume, TrustedCAConfigMapName, TrustedCAKey, TrustedCAKey),
-		newVolumeWithConfigMap(ServiceCAConfigMapVolume, ServiceCAConfigMapName, ServiceCAKey, ServiceCAKey),
+		NewVolumeWithConfigMap(TrustedCAConfigMapVolume, TrustedCAConfigMapName, TrustedCAKey, TrustedCAKey),
+		NewVolumeWithConfigMap(ServiceCAConfigMapVolume, ServiceCAConfigMapName, ServiceCAKey, ServiceCAKey),
 	)
 }
 

--- a/pkg/reconciler/openshift/common/cabundle.go
+++ b/pkg/reconciler/openshift/common/cabundle.go
@@ -21,14 +21,21 @@ import (
 
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-// ApplyCABundles is a transformer that add the trustedCA volume, mount and
+const (
+	systemCAVolume = "config-trusted-system-cabundle-volume"
+	systemCAKey    = "tls-ca-bundle.pem"
+	systemCADir    = "/etc/pki/ca-trust/extracted/pem"
+)
+
+// ApplyCABundlesToDeployment is a transformer that add the trustedCA volume, mount and
 // environment variables so that the deployment uses it.
-func ApplyCABundles(u *unstructured.Unstructured) error {
+func ApplyCABundlesToDeployment(u *unstructured.Unstructured) error {
 	if u.GetKind() != "Deployment" {
 		// Don't do anything on something else than Deployment
 		return nil
@@ -42,12 +49,17 @@ func ApplyCABundles(u *unstructured.Unstructured) error {
 	// Let's add the trusted and service CA bundle ConfigMaps as a volume in
 	// the PodSpec which will later be mounted to add certs in the pod.
 	deployment.Spec.Template.Spec.Volumes = common.AddCABundleConfigMapsToVolumes(deployment.Spec.Template.Spec.Volumes)
+	deployment.Spec.Template.Spec.Volumes = append(
+		deployment.Spec.Template.Spec.Volumes,
+		common.NewVolumeWithConfigMap(systemCAVolume, common.TrustedCAConfigMapName, common.TrustedCAKey, systemCAKey),
+	)
 
 	// Now that the injected certificates have been added as a volume, let's
 	// mount them via volumeMounts in the containers
 	for i := range deployment.Spec.Template.Spec.Containers {
 		c := deployment.Spec.Template.Spec.Containers[i] // Create a copy of the container
 		common.AddCABundlesToContainerVolumes(&c)
+		addCABundlesToContainerSystemCAStore(&c)
 		deployment.Spec.Template.Spec.Containers[i] = c
 	}
 
@@ -97,12 +109,17 @@ func ApplyCABundlesForStatefulSet(name string) func(u *unstructured.Unstructured
 		// Let's add the trusted and service CA bundle ConfigMaps as a volume in
 		// the PodSpec which will later be mounted to add certs in the pod.
 		sts.Spec.Template.Spec.Volumes = common.AddCABundleConfigMapsToVolumes(sts.Spec.Template.Spec.Volumes)
+		sts.Spec.Template.Spec.Volumes = append(
+			sts.Spec.Template.Spec.Volumes,
+			common.NewVolumeWithConfigMap(systemCAVolume, common.TrustedCAConfigMapName, common.TrustedCAKey, systemCAKey),
+		)
 
 		// Now that the injected certificates have been added as a volume, let's
 		// mount them via volumeMounts in the containers
 		for i := range sts.Spec.Template.Spec.Containers {
 			c := sts.Spec.Template.Spec.Containers[i] // Create a copy of the container
 			common.AddCABundlesToContainerVolumes(&c)
+			addCABundlesToContainerSystemCAStore(&c)
 			sts.Spec.Template.Spec.Containers[i] = c
 		}
 
@@ -118,4 +135,30 @@ func ApplyCABundlesForStatefulSet(name string) func(u *unstructured.Unstructured
 		u.SetUnstructuredContent(m.Object)
 		return nil
 	}
+}
+
+// addCABundlesToContainerSystemCAStore mounts the trusted-ca-configmap into the system ca store.
+// This is necessary for components shelling out to "legacy applications" (e.g. cURL or git) to
+// use the CA bundles, as "legacy applications"  do not respect SSL_CERT_DIR. In the Openshift
+// environment the TrustedCAConfigMap has both the default and custom certificates combined.
+// Note that the TrustedCAConfigMap does not contain the Service CA bundle. However that is
+// utilized for the internal image registry and its tooling respects SSL_CERT_DIR.
+//
+// NOTE: This transformer should not be applied to pod templates which could reference
+// user-defined images such as a TaskRun or PipelineRun since the transformer both assumes the
+// image is a RHEL or a similar environment and because it may override a user's image's custom
+// certificate bundle.
+//
+// See `man(8) update-ca-trust` for documentation on the directory structure and usage
+// See openshift documentation for CA mounting details:
+//
+//	https://github.com/openshift/openshift-docs/blob/a8269cf65696fbd08647c8f3b5d065d53a8a1f52/modules/certificate-injection-using-operators.adoc
+func addCABundlesToContainerSystemCAStore(container *corev1.Container) {
+	container.VolumeMounts = append(container.VolumeMounts,
+		corev1.VolumeMount{
+			Name:      systemCAVolume,
+			MountPath: systemCADir,
+			ReadOnly:  true,
+		})
+
 }

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/transform.go
@@ -55,7 +55,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.DeploymentImages(images),
 			common.DeploymentEnvVarKubernetesMinVersion(),
 			common.AddConfiguration(pac.Spec.Config),
-			occommon.ApplyCABundles,
+			occommon.ApplyCABundlesToDeployment,
 			common.CopyConfigMap(pipelinesAsCodeCM, pac.Spec.Settings),
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
 		}
@@ -86,7 +86,7 @@ func additionalControllerTransform(extension common.Extension, name string) clie
 			common.InjectOperandNameLabelOverwriteExisting(openshift.OperandOpenShiftPipelineAsCode),
 			common.DeploymentImages(images),
 			common.AddConfiguration(pac.Spec.Config),
-			occommon.ApplyCABundles,
+			occommon.ApplyCABundlesToDeployment,
 			occommon.UpdateServiceMonitorTargetNamespace(pac.Spec.TargetNamespace),
 			updateAdditionControllerDeployment(additionalPACControllerConfig, name),
 			updateAdditionControllerService(name),

--- a/pkg/reconciler/openshift/tektonchain/extension.go
+++ b/pkg/reconciler/openshift/tektonchain/extension.go
@@ -48,7 +48,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsGroup(),
 		occommon.RemoveRunAsUserForStatefulSet(tektonChainsControllerName),
 		occommon.RemoveRunAsGroupForStatefulSet(tektonChainsControllerName),
-		occommon.ApplyCABundles,
+		occommon.ApplyCABundlesToDeployment,
 		occommon.ApplyCABundlesForStatefulSet(tektonChainsControllerName),
 	}
 }

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -66,7 +66,7 @@ type openshiftExtension struct {
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
 	trns := []mf.Transformer{
-		occommon.ApplyCABundles,
+		occommon.ApplyCABundlesToDeployment,
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsUserForStatefulSet(tektonPipelinesControllerName),
 		occommon.RemoveRunAsUserForStatefulSet(tektonRemoteResolversControllerName),

--- a/pkg/reconciler/openshift/tektonresult/extension.go
+++ b/pkg/reconciler/openshift/tektonresult/extension.go
@@ -97,7 +97,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
-		occommon.ApplyCABundles,
+		occommon.ApplyCABundlesToDeployment,
 		occommon.RemoveRunAsUserForStatefulSet(tektonResultWatcherName),
 		occommon.RemoveRunAsGroupForStatefulSet(tektonResultWatcherName),
 		occommon.ApplyCABundlesForStatefulSet(tektonResultWatcherName),

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -53,7 +53,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
-		occommon.ApplyCABundles,
+		occommon.ApplyCABundlesToDeployment,
 		common.AddConfigMapValues(tektontrigger.ConfigDefaults, triggersData),
 		replaceDeploymentArgs("-el-events", "enable"),
 	}

--- a/test/e2e/openshift/openshiftpipelinesascode_test.go
+++ b/test/e2e/openshift/openshiftpipelinesascode_test.go
@@ -52,13 +52,14 @@ func TestOpenshiftPipelinesAsCode(t *testing.T) {
 		crNames.TargetNamespace = "openshift-pipelines"
 	}
 
-	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.OpenShiftPipelinesAsCode) })
-	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
-	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
-
-	defer utils.TearDownNamespace(clients, crNames.OpenShiftPipelinesAsCode)
-	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
-	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	for _, cleanupFunc := range []func(){
+		func() { utils.TearDownPipeline(clients, crNames.OpenShiftPipelinesAsCode) },
+		func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) },
+		func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) },
+	} {
+		utils.CleanupOnInterrupt(cleanupFunc)
+		defer cleanupFunc()
+	}
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
 

--- a/test/e2e/openshift/tektonaddondeployment_test.go
+++ b/test/e2e/openshift/tektonaddondeployment_test.go
@@ -108,5 +108,4 @@ func TestTektonAddonsDeployment(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
 		resources.TektonPipelineCRDelete(t, clients, crNames)
 	})
-
 }

--- a/test/e2e/openshift/transformers_test.go
+++ b/test/e2e/openshift/transformers_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshift
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+)
+
+// assertPodMountsSystemCAVolume asserts that the Openshift config-trusted-cabundle is
+// mounted at the appropriate path for RHEL-based systems.
+//
+// See openshift documentation for CA mounting details:
+//
+//	https://github.com/openshift/openshift-docs/blob/a8269cf65696fbd08647c8f3b5d065d53a8a1f52/modules/certificate-injection-using-operators.adoc
+func assertPodMountsSystemCAVolume(pod corev1.Pod) error {
+	containsVolume := false
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == "config-trusted-system-cabundle-volume" &&
+			volume.VolumeSource.ConfigMap != nil &&
+			len(volume.VolumeSource.ConfigMap.Items) == 1 &&
+			volume.VolumeSource.ConfigMap.LocalObjectReference.Name == "config-trusted-cabundle" &&
+			volume.VolumeSource.ConfigMap.Items[0].Key == "ca-bundle.crt" &&
+			volume.VolumeSource.ConfigMap.Items[0].Path == "tls-ca-bundle.pem" {
+			containsVolume = true
+			break
+		}
+	}
+
+	containsVolumeMount := false
+	for _, container := range pod.Spec.Containers {
+		for _, volumeMount := range container.VolumeMounts {
+			if volumeMount.Name == "config-trusted-system-cabundle-volume" &&
+				volumeMount.MountPath == "/etc/pki/ca-trust/extracted/pem" &&
+				volumeMount.ReadOnly {
+				containsVolumeMount = true
+				break
+			}
+		}
+	}
+	if !(containsVolume && containsVolumeMount) {
+		return fmt.Errorf("Pod %s does not mount the CA bundle at the system CA truste path", pod.Name)
+	}
+	return nil
+}
+
+// TestComponentVolumeMounts verifies the components are created with the appropriate volume mounts for Openshift.
+func TestComponentVolumeMounts(t *testing.T) {
+	crNames := utils.ResourceNames{
+		TektonConfig:    "config",
+		TektonPipeline:  "pipeline",
+		TektonTrigger:   "trigger",
+		TektonAddon:     "addon",
+		Namespace:       "",
+		TargetNamespace: "tekton-pipelines",
+	}
+
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	if os.Getenv("TARGET") == "openshift" {
+		crNames.TargetNamespace = "openshift-pipelines"
+	}
+
+	for _, cleanupFunc := range []func(){
+		func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) },
+	} {
+		utils.CleanupOnInterrupt(cleanupFunc)
+		defer cleanupFunc()
+	}
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	// Create a TektonPipeline
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+
+	// Test if TektonPipeline can reach the READY status
+	t.Run("create-pipeline", func(t *testing.T) {
+		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+	})
+
+	podList, err := clients.KubeClient.CoreV1().Pods(crNames.TargetNamespace).List(t.Context(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get any pods under the namespace %q: %v", crNames.TargetNamespace, err)
+	}
+	if len(podList.Items) == 0 {
+		t.Fatalf("No pods under the namespace %q found", crNames.TargetNamespace)
+	}
+
+	for _, pod := range podList.Items {
+		if err = assertPodMountsSystemCAVolume(pod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Delete the TektonPipeline CR instance to see if all resources will be removed
+	t.Run("delete-pipeline", func(t *testing.T) {
+		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+		resources.TektonPipelineCRDelete(t, clients, crNames)
+	})
+}


### PR DESCRIPTION
# Changes
Mount the trusted-ca-configmap into component's system ca store, allowing the git resolver to use the custom CA bundle.

This is necessary for "legacy applications" (e.g. cURL or git) to use the CA bundles as they do not respect `SSL_CERT_DIR`, when components such as the git-resolver utilize legacy applications. In the Openshift environment the TrustedCAConfigMap has both the default and custom certificates combined. Note that the TrustedCAConfigMap does not contain the Service CA bundle, however that bundle is utilized for the internal image registry and its tooling respects `SSL_CERT_DIR`. Also note that this transformer should not be applied to containers with user-defined images since it both assumes the image is a RHEL (or similar) environment and because it may override a user's image's custom certificate bundle (see #549 and [SRVKP-1497](https://issues.redhat.com/browse/SRVKP-1497))

Resolves [SRVKP-8204](https://issues.redhat.com/browse/SRVKP-8204)

See also:
- Openshift documentation on [certificate injection](https://github.com/openshift/openshift-docs/blob/a8269cf65696fbd08647c8f3b5d065d53a8a1f52/modules/certificate-injection-using-operators.adoc)
- System CA management - [man (8) update-ca-trust](https://man.archlinux.org/man/update-ca-trust.8)
- Openshift Pipelines bug - git resolver not respecting custom certificates - [SRVKP-8204](https://issues.redhat.com/browse/SRVKP-8204)



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:


For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Bug fix: Before this change, in Openshift Pipelines all components' deployents and statefulsets had the Openshift trusted CA bundle mounted at `/tekton-custom-certs/ca-bundle.crt` which was used by programs via the environment variable `SSL_CERT_DIR`. After this change, those deployments and statefulsets now also have the CA bundle mounted at `/etc/pki/ca-trust/extracted/tls-ca-bundle.pem` as if the certificates were installed on the system with `update-ca-trust extract`. This allows binaries such as `git` which do not recognize `SSL_CERT_DIR` to use the custom certificates without any additional configuration. Fixes SRVKP-8204
```