### PR TITLE
Delete default tekton results tls secret during pre upgrade

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -37,6 +37,8 @@ var (
 		// Todo: Remove the removeDeprecatedAddonParams upgrade function in next operator release
 		removeDeprecatedAddonParams,    // upgrade #3: remove the deprecated cluster task params from TektonConfig CR's addon params
 		copyResultConfigToTektonConfig, // upgrade #4: copy existing TektonResult configuration to the TektonConfig CR
+		// Todo: Remove the deleteTektonResultsTLSSecret upgrade function in next operator release
+		deleteTektonResultsTLSSecret, // upgrade #5: deletes default tekton results tls certificate
 	}
 
 	// post upgrade functions


### PR DESCRIPTION
This patch deletes default tekton results tls secret on openshift platform during pre upgrade which should not be created and during the upgrade scenarion causing tekton results api failure

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Delete default tekton results tls secret during pre upgrade
```