### PR TITLE
Optimize proxy webhook performance by eliminating API calls during pod admission

### DIFF
--- a/pkg/reconciler/common/certificates_test.go
+++ b/pkg/reconciler/common/certificates_test.go
@@ -22,6 +22,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestAddCABundleConfigMapsToVolumes(t *testing.T) {
@@ -338,5 +339,289 @@ func TestAddCABundlesToContainerVolumes(t *testing.T) {
 		t.Logf("Running test: %v", test.name)
 		AddCABundlesToContainerVolumes(test.input)
 		assert.DeepEqual(t, test.input, test.expected)
+	}
+}
+
+// TestNewVolumeWithConfigMapOptional tests the new function that creates optional ConfigMap volumes
+func TestNewVolumeWithConfigMapOptional(t *testing.T) {
+	type testStructure struct {
+		name          string
+		volumeName    string
+		configMapName string
+		configMapKey  string
+		configMapPath string
+		expected      corev1.Volume
+	}
+
+	tests := []testStructure{
+		{
+			name:          "Basic optional ConfigMap volume creation",
+			volumeName:    "test-volume",
+			configMapName: "test-configmap",
+			configMapKey:  "test-key",
+			configMapPath: "test-path",
+			expected: corev1.Volume{
+				Name: "test-volume",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "test-configmap"},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "test-key",
+								Path: "test-path",
+							},
+						},
+						Optional: ptr.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name:          "Trusted CA bundle volume with optional",
+			volumeName:    TrustedCAConfigMapVolume,
+			configMapName: TrustedCAConfigMapName,
+			configMapKey:  TrustedCAKey,
+			configMapPath: TrustedCAKey,
+			expected: corev1.Volume{
+				Name: TrustedCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  TrustedCAKey,
+								Path: TrustedCAKey,
+							},
+						},
+						Optional: ptr.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name:          "Service CA bundle volume with optional",
+			volumeName:    ServiceCAConfigMapVolume,
+			configMapName: ServiceCAConfigMapName,
+			configMapKey:  ServiceCAKey,
+			configMapPath: ServiceCAKey,
+			expected: corev1.Volume{
+				Name: ServiceCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: ServiceCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  ServiceCAKey,
+								Path: ServiceCAKey,
+							},
+						},
+						Optional: ptr.Bool(true),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test: %v", test.name)
+		actualOutput := NewVolumeWithConfigMapOptional(test.volumeName, test.configMapName, test.configMapKey, test.configMapPath)
+		assert.DeepEqual(t, actualOutput, test.expected)
+
+		// Verify that Optional is specifically set to true
+		assert.Assert(t, actualOutput.ConfigMap.Optional != nil, "Optional field should be set")
+		assert.DeepEqual(t, *actualOutput.ConfigMap.Optional, true)
+	}
+}
+
+// TestAddCABundleConfigMapsToVolumesOptional tests the new function that adds optional CA bundle volumes
+func TestAddCABundleConfigMapsToVolumesOptional(t *testing.T) {
+	type testStructure struct {
+		name     string
+		input    []corev1.Volume
+		expected []corev1.Volume
+	}
+
+	tests := []testStructure{
+		{
+			name:  "Vanilla test without any input volumes - optional variant",
+			input: nil,
+			expected: []corev1.Volume{
+				{
+					Name: TrustedCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  TrustedCAKey,
+									Path: TrustedCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+				{
+					Name: ServiceCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ServiceCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  ServiceCAKey,
+									Path: ServiceCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Check if volumes are appended - optional variant",
+			input: []corev1.Volume{
+				{
+					Name: "existing-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "existing-configmap"},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "existing-key",
+									Path: "existing-path",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []corev1.Volume{
+				{
+					Name: "existing-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "existing-configmap"},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "existing-key",
+									Path: "existing-path",
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: TrustedCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  TrustedCAKey,
+									Path: TrustedCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+				{
+					Name: ServiceCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ServiceCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  ServiceCAKey,
+									Path: ServiceCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Check if duplicate volumes are removed - optional variant",
+			input: []corev1.Volume{
+				{
+					Name: TrustedCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "old-config"},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "old-key",
+									Path: "old-path",
+								},
+							},
+							// Note: old volume might not have Optional set
+						},
+					},
+				},
+				{
+					Name: ServiceCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "old-service-config"},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "old-service-key",
+									Path: "old-service-path",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []corev1.Volume{
+				{
+					Name: TrustedCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: TrustedCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  TrustedCAKey,
+									Path: TrustedCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+				{
+					Name: ServiceCAConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ServiceCAConfigMapName},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  ServiceCAKey,
+									Path: ServiceCAKey,
+								},
+							},
+							Optional: ptr.Bool(true),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test: %v", test.name)
+		actualOutput := AddCABundleConfigMapsToVolumesOptional(test.input)
+		assert.DeepEqual(t, actualOutput, test.expected)
+
+		// Verify that all CA bundle volumes have Optional=true
+		for _, volume := range actualOutput {
+			if volume.Name == TrustedCAConfigMapVolume || volume.Name == ServiceCAConfigMapVolume {
+				assert.Assert(t, volume.ConfigMap.Optional != nil, "CA bundle volume should have Optional field set")
+				assert.DeepEqual(t, *volume.ConfigMap.Optional, true)
+			}
+		}
 	}
 }

--- a/pkg/reconciler/proxy/proxy_test.go
+++ b/pkg/reconciler/proxy/proxy_test.go
@@ -35,7 +35,8 @@ func TestUpdateVolume(t *testing.T) {
 			},
 		},
 	}
-	podUpdated := updateVolume(pod)
+	// Test the new optional approach that doesn't require API calls
+	podUpdated := updateVolumeOptional(pod)
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].Env), 1)
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Name, "SSL_CERT_DIR")
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].Env[0].Value, "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs")
@@ -43,12 +44,138 @@ func TestUpdateVolume(t *testing.T) {
 	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 2)
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].Name, "config-trusted-cabundle-volume")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[0].ConfigMap.Name, "config-trusted-cabundle")
+	assert.Assert(t, podUpdated.Spec.Volumes[0].ConfigMap.Optional != nil)
+	assert.DeepEqual(t, *podUpdated.Spec.Volumes[0].ConfigMap.Optional, true)
+
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[1].Name, "config-service-cabundle-volume")
 	assert.DeepEqual(t, podUpdated.Spec.Volumes[1].ConfigMap.Name, "config-service-cabundle")
+	assert.Assert(t, podUpdated.Spec.Volumes[1].ConfigMap.Optional != nil)
+	assert.DeepEqual(t, *podUpdated.Spec.Volumes[1].ConfigMap.Optional, true)
 
 	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 2)
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].Name, "config-trusted-cabundle-volume")
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[0].SubPath, "ca-bundle.crt")
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[1].Name, "config-service-cabundle-volume")
 	assert.DeepEqual(t, podUpdated.Spec.Containers[0].VolumeMounts[1].SubPath, "service-ca.crt")
+}
+
+// TestUpdateVolumeOptionalWithExistingVolumes tests that optional volumes replace existing ones correctly
+func TestUpdateVolumeOptionalWithExistingVolumes(t *testing.T) {
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "config-trusted-cabundle-volume",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{Name: "old-config"},
+						},
+					},
+				},
+				{
+					Name: "other-volume",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:  "testc",
+					Image: "testi",
+				},
+			},
+		},
+	}
+	podUpdated := updateVolumeOptional(pod)
+
+	// Should have 3 volumes: other-volume + 2 CA bundle volumes
+	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 3)
+
+	// Check that old volume is preserved
+	var otherVolumeFound bool
+	for _, vol := range podUpdated.Spec.Volumes {
+		if vol.Name == "other-volume" {
+			otherVolumeFound = true
+			break
+		}
+	}
+	assert.Assert(t, otherVolumeFound, "other-volume should be preserved")
+
+	// Check that CA bundle volumes are properly configured with Optional=true
+	var trustedVolumeFound, serviceVolumeFound bool
+	for _, vol := range podUpdated.Spec.Volumes {
+		switch vol.Name {
+		case "config-trusted-cabundle-volume":
+			trustedVolumeFound = true
+			assert.DeepEqual(t, vol.ConfigMap.Name, "config-trusted-cabundle")
+			assert.Assert(t, vol.ConfigMap.Optional != nil)
+			assert.DeepEqual(t, *vol.ConfigMap.Optional, true)
+		case "config-service-cabundle-volume":
+			serviceVolumeFound = true
+			assert.DeepEqual(t, vol.ConfigMap.Name, "config-service-cabundle")
+			assert.Assert(t, vol.ConfigMap.Optional != nil)
+			assert.DeepEqual(t, *vol.ConfigMap.Optional, true)
+		}
+	}
+	assert.Assert(t, trustedVolumeFound, "trusted CA volume should be present")
+	assert.Assert(t, serviceVolumeFound, "service CA volume should be present")
+}
+
+// TestUpdateVolumeOptionalEmptyConfigMaps tests behavior when ConfigMaps don't exist
+// With Optional=true, pods should start successfully even with missing ConfigMaps
+func TestUpdateVolumeOptionalEmptyConfigMaps(t *testing.T) {
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{},
+			Containers: []v1.Container{
+				{
+					Name:  "testc",
+					Image: "testi",
+					Env: []v1.EnvVar{
+						{
+							Name:  "EXISTING_ENV",
+							Value: "existing_value",
+						},
+					},
+				},
+			},
+		},
+	}
+	podUpdated := updateVolumeOptional(pod)
+
+	// Environment variables should be preserved and SSL_CERT_DIR added
+	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].Env), 2)
+
+	// Check existing env var is preserved
+	var existingEnvFound bool
+	for _, env := range podUpdated.Spec.Containers[0].Env {
+		if env.Name == "EXISTING_ENV" {
+			existingEnvFound = true
+			assert.DeepEqual(t, env.Value, "existing_value")
+			break
+		}
+	}
+	assert.Assert(t, existingEnvFound, "existing environment variable should be preserved")
+
+	// Check SSL_CERT_DIR is added
+	var sslCertDirFound bool
+	for _, env := range podUpdated.Spec.Containers[0].Env {
+		if env.Name == "SSL_CERT_DIR" {
+			sslCertDirFound = true
+			assert.DeepEqual(t, env.Value, "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs")
+			break
+		}
+	}
+	assert.Assert(t, sslCertDirFound, "SSL_CERT_DIR should be added")
+
+	// Volumes should still be added with Optional=true (this allows graceful handling of missing ConfigMaps)
+	assert.DeepEqual(t, len(podUpdated.Spec.Volumes), 2)
+	for _, vol := range podUpdated.Spec.Volumes {
+		assert.Assert(t, vol.ConfigMap.Optional != nil, "ConfigMap volume should be optional")
+		assert.DeepEqual(t, *vol.ConfigMap.Optional, true)
+	}
+
+	// Volume mounts should be added (they won't fail with optional=true even if ConfigMap is missing)
+	assert.DeepEqual(t, len(podUpdated.Spec.Containers[0].VolumeMounts), 2)
 }


### PR DESCRIPTION
# Changes

During load tests, the proxy webhook was experiencing timeout issues that caused TaskRun failures with the error:
```
failed to create task run pod \"jhue05939bba6498044b9e123b65b3893c5-coverity-availability-check\": Internal error occurred: failed calling webhook \"proxy.operator.tekton.dev\": failed to call webhook: Post \"https://tekton-operator-proxy-webhook.openshift-pipelines.svc:443/defaulting?timeout=10s\": context deadline exceeded. Maybe missing or invalid Task jhutar-1-tenant/
```
The proxy webhook performed 2 synchronous API calls for every pod creation to check if CA bundle ConfigMaps exist:
checkConfigMapExist(client, ctx, namespace, "config-trusted-cabundle")
checkConfigMapExist(client, ctx, namespace, "config-service-cabundle")
Under high concurrency (load tests), these API calls became a bottleneck that exceeded the 10-second webhook timeout.
Solution
Replace API calls with optional ConfigMap volumes that gracefully handle missing ConfigMaps without requiring existence checks.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Eliminated proxy webhook timeout issues during high-concurrency load tests by removing synchronous API calls that checked ConfigMap existence during pod admission. The webhook now uses optional ConfigMap volumes that gracefully handle missing CA bundles without blocking pod creation, improving scalability while maintaining all existing SSL certificate functionality.
```
