### PR TITLE
Fix proxy namespace for tekton-results-api-service in ConsolePlugin

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -142,7 +142,7 @@ spec:
         type: Service
         service:
           name: tekton-results-api-service
-          namespace: openshift-pipeline
+          namespace: openshift-pipelines
           port: 8080
   i18n:
     loadType: Preload   # options: Preload, Lazy


### PR DESCRIPTION
# Changes

Fixes the namespace used by the ConsolePlugin proxy for `tekton-results-api-service`.  
- Before: `spec.proxy[0].endpoint.service.namespace: openshift-pipeline` (wrong)  
- After:  `openshift-pipelines`

The wrong namespace made the console proxy point to a non-existent Service, causing failed requests (and TLS handshake errors) when the console tried to reach the Results API.

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Resolve console proxy/TLS failures when reaching the Results API.
```

---

This is my first PR here. Happy to revise anything per your feedback—thanks!
