### PR TITLE
fix(openshift): deduplicate system ca-bundle volumes and mounts

### DIFF
--- a/pkg/reconciler/common/certificates.go
+++ b/pkg/reconciler/common/certificates.go
@@ -57,37 +57,23 @@ func NewVolumeWithConfigMap(volumeName, configMapName, configMapKey, configMapPa
 // ConfigMaps to the given list of volumes and removes duplicates, if any
 func AddCABundleConfigMapsToVolumes(volumes []corev1.Volume) []corev1.Volume {
 	// If CA bundle volumes already exists in the pod's volumes, then remove it
-	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
-		for i, v := range volumes {
-			if v.Name == volumeName {
-				volumes = append(volumes[:i], volumes[i+1:]...)
-				break
-			}
-		}
-	}
-
-	return append(
-		volumes,
+	for _, newVolume := range []corev1.Volume{
 		NewVolumeWithConfigMap(TrustedCAConfigMapVolume, TrustedCAConfigMapName, TrustedCAKey, TrustedCAKey),
 		NewVolumeWithConfigMap(ServiceCAConfigMapVolume, ServiceCAConfigMapName, ServiceCAKey, ServiceCAKey),
-	)
+	} {
+		volumes = AddOrReplaceInList(
+			volumes,
+			newVolume,
+			func(v corev1.Volume) string { return v.Name },
+		)
+	}
+
+	return volumes
 }
 
 // AddCABundlesToContainerVolumes adds the CA bundles to the container via VolumeMounts.
 // SSL_CERT_DIR environment variable is also set if it does not exist already.
 func AddCABundlesToContainerVolumes(c *corev1.Container) {
-	volumeMounts := c.VolumeMounts
-
-	// If volume mounts for CA bundles already exist then remove them
-	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
-		for i, vm := range volumeMounts {
-			if vm.Name == volumeName {
-				volumeMounts = append(volumeMounts[:i], volumeMounts[i+1:]...)
-				break
-			}
-		}
-	}
-
 	// We will mount the certs at /tekton-custom-certs so we don't override the existing certs
 	sslCertDir := "/tekton-custom-certs"
 	certEnvAvailable := false
@@ -132,22 +118,26 @@ func AddCABundlesToContainerVolumes(c *corev1.Container) {
 		})
 	}
 
-	// Let's mount the certificates now.
-	volumeMounts = append(volumeMounts,
-		corev1.VolumeMount{
-			Name: TrustedCAConfigMapVolume,
-			// We only want the first entry in SSL_CERT_DIR for the mount
-			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], TrustedCAKey),
+	// We only want the first entry in SSL_CERT_DIR for the mount
+	mountDir := strings.Split(sslCertDir, ":")[0]
+	for _, newVolumeMount := range []corev1.VolumeMount{
+		{
+			Name:      TrustedCAConfigMapVolume,
+			MountPath: filepath.Join(mountDir, TrustedCAKey),
 			SubPath:   TrustedCAKey,
 			ReadOnly:  true,
 		},
-		corev1.VolumeMount{
-			Name: ServiceCAConfigMapVolume,
-			// We only want the first entry in SSL_CERT_DIR for the mount
-			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], ServiceCAKey),
+		{
+			Name:      ServiceCAConfigMapVolume,
+			MountPath: filepath.Join(mountDir, ServiceCAKey),
 			SubPath:   ServiceCAKey,
 			ReadOnly:  true,
 		},
-	)
-	c.VolumeMounts = volumeMounts
+	} {
+		c.VolumeMounts = AddOrReplaceInList(
+			c.VolumeMounts,
+			newVolumeMount,
+			func(v corev1.VolumeMount) string { return v.Name },
+		)
+	}
 }

--- a/pkg/reconciler/common/utils.go
+++ b/pkg/reconciler/common/utils.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -71,4 +72,19 @@ func SerializeLabelsToJSON(labels map[string]string) (string, error) {
 		return "", fmt.Errorf("failed to serialize labels to JSON: %v", err)
 	}
 	return string(bytes), nil
+}
+
+// AddOrReplaceInList appends newItem to the provided list. If the new item exists in the list then the original
+// copy of the item is removed from the list before the new copy is appended. The identityFunc parameter is used
+// to uniquely identify an item during comparison.
+func AddOrReplaceInList[T any, V comparable](items []T, newItem T, identityFunc func(T) V) []T {
+	newItemIdentity := identityFunc(newItem)
+	for i, item := range items {
+		itemIdentity := identityFunc(item)
+		if itemIdentity == newItemIdentity {
+			items = slices.Delete(items, i, i+1)
+			break
+		}
+	}
+	return append(items, newItem)
 }

--- a/pkg/reconciler/openshift/common/cabundle_test.go
+++ b/pkg/reconciler/openshift/common/cabundle_test.go
@@ -110,6 +110,87 @@ func TestApplyCABundlesForDeployments(t *testing.T) {
 	assert.DeepEqual(t, actual, expected)
 }
 
+func TestApplyCABundlesForDeploymentsIdempotent(t *testing.T) {
+	actual := unstructuredDeployment(t,
+		withEnvs(
+			corev1.EnvVar{
+				Name:  "SSL_CERT_DIR",
+				Value: "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs",
+			},
+		),
+		withVolumes(corev1.Volume{
+			Name: common.TrustedCAConfigMapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  common.TrustedCAKey,
+							Path: common.TrustedCAKey,
+						},
+					},
+				},
+			},
+		},
+			corev1.Volume{
+				Name: common.ServiceCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ServiceCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.ServiceCAKey,
+								Path: common.ServiceCAKey,
+							},
+						},
+					},
+				},
+			},
+			corev1.Volume{
+				Name: systemCAVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.TrustedCAKey,
+								Path: systemCAKey,
+							},
+						},
+					},
+				},
+			}),
+		withVolumeMounts(
+			corev1.VolumeMount{
+				Name:      common.TrustedCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.TrustedCAKey),
+				SubPath:   common.TrustedCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      common.ServiceCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.ServiceCAKey),
+				SubPath:   common.ServiceCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      systemCAVolume,
+				MountPath: "/etc/pki/ca-trust/extracted/pem",
+				ReadOnly:  true,
+			},
+		),
+	)
+
+	// ApplyCABundlesForDeployments should not duplicate any of the mounts during transformation
+	expected := actual.DeepCopy()
+
+	if err := ApplyCABundlesToDeployment(actual); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.DeepEqual(t, actual, expected)
+}
+
 func TestApplyCABundlesForStatefulSet(t *testing.T) {
 	actual := unstructuredStatefulSet(t)
 	expected := unstructuredStatefulSet(t,
@@ -181,6 +262,87 @@ func TestApplyCABundlesForStatefulSet(t *testing.T) {
 			},
 		),
 	)
+
+	if err := ApplyCABundlesForStatefulSet("test-statefulset")(actual); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.DeepEqual(t, actual, expected)
+}
+
+func TestApplyCABundlesForStatefulSetIdempotent(t *testing.T) {
+	actual := unstructuredStatefulSet(t,
+		withStatefulSetEnvs(
+			corev1.EnvVar{
+				Name:  "SSL_CERT_DIR",
+				Value: "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs",
+			},
+		),
+		withStatefulSetVolumes(corev1.Volume{
+			Name: common.TrustedCAConfigMapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  common.TrustedCAKey,
+							Path: common.TrustedCAKey,
+						},
+					},
+				},
+			},
+		},
+			corev1.Volume{
+				Name: common.ServiceCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ServiceCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.ServiceCAKey,
+								Path: common.ServiceCAKey,
+							},
+						},
+					},
+				},
+			},
+			corev1.Volume{
+				Name: systemCAVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.TrustedCAKey,
+								Path: systemCAKey,
+							},
+						},
+					},
+				},
+			}),
+		withStatefulSetVolumeMounts(
+			corev1.VolumeMount{
+				Name:      common.TrustedCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.TrustedCAKey),
+				SubPath:   common.TrustedCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      common.ServiceCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.ServiceCAKey),
+				SubPath:   common.ServiceCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      systemCAVolume,
+				MountPath: "/etc/pki/ca-trust/extracted/pem",
+				ReadOnly:  true,
+			},
+		),
+	)
+
+	// ApplyCABundlesForStatefulSet should not duplicate the ca bundles during transformation
+	expected := actual.DeepCopy()
 
 	if err := ApplyCABundlesForStatefulSet("test-statefulset")(actual); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
This fix adds deduplication logic to the Openshift reconciler's system CA-bundle volumes and volume mounts. Before this change, if a deployment or statefulset was run through its respective `ApplyCABundlesTo____` method more than once (e.g. during a second reconciliation such as an upgrade) the system ca-bundle volumes and volumemounts would be added without removing the original volumes and volume mounts, causing validation issues due to name conflicts. After this change, the `ApplyCABundlesTo_____` transformers are effectively idempotent in that before they add the system ca-bundles they will remove any conflicting volumes and volume mounts.

Resolves https://issues.redhat.com/browse/SRVKP-8484

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->
```release-note
fix: dedupe system ca-bundle Volumes and VolumeMounts during Deployment and StatefulSet reconciliation
```