### PR TITLE
docs: add image registry override documentation

### DIFF
--- a/docs/AirGapImageConfiguration.md
+++ b/docs/AirGapImageConfiguration.md
@@ -10,7 +10,9 @@ When we have our cluster on a air gap or proxy environment,
 we need to copy the actual images into our custom registry and update image details via environment variables on the operator deployment under the container `tekton-operator-lifecycle` as follows,
 This will allow us to use images from our custom registry.
 
-##### Sample: images as environment variable in operator deployment
+## Rewrite image registry 
+
+We can rewrite the actual registry `ghcr.io` of all images by simply set the environment variable `TEKTON_REGISTRY_OVERRIDE` ad follow:
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -23,8 +25,17 @@ spec:
       containers:
         - name: tekton-operator-lifecycle
           env:
-            - name: IMAGE_DASHBOARD_TEKTON_DASHBOARD
-              value: custom-example.com/tektoncd/dashboard:v0.48.0
+            - name: TEKTON_REGISTRY_OVERRIDE
+              value: my-internal-registry.io/my-tekton-folder
+```
+
+## Rewrite image one by one
+
+We can also rewrite images one by one using the following:
+
+##### Sample: images as environment variable in operator deployment
+```yaml
+example.com/tektoncd/dashboard:v0.48.0
             - name: IMAGE_JOB_PRUNER_TKN
               value: custom-example.com/tektoncd/tkn:v0.31.0
 ```


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This documentation is part of the following [PR](https://github.com/tektoncd/operator/pull/2863) and this [Feature request](https://github.com/tektoncd/operator/issues/2684)

The aim is to change the registry used within images using only one environment variable.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
