### PR TITLE
[release-v0.77.x] fix(openshift): deduplicate system ca-bundle volumes and mounts 

### DIFF
--- a/pkg/reconciler/common/certificates.go
+++ b/pkg/reconciler/common/certificates.go
@@ -57,37 +57,23 @@ func NewVolumeWithConfigMap(volumeName, configMapName, configMapKey, configMapPa
 // ConfigMaps to the given list of volumes and removes duplicates, if any
 func AddCABundleConfigMapsToVolumes(volumes []corev1.Volume) []corev1.Volume {
 	// If CA bundle volumes already exists in the pod's volumes, then remove it
-	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
-		for i, v := range volumes {
-			if v.Name == volumeName {
-				volumes = append(volumes[:i], volumes[i+1:]...)
-				break
-			}
-		}
-	}
-
-	return append(
-		volumes,
+	for _, newVolume := range []corev1.Volume{
 		NewVolumeWithConfigMap(TrustedCAConfigMapVolume, TrustedCAConfigMapName, TrustedCAKey, TrustedCAKey),
 		NewVolumeWithConfigMap(ServiceCAConfigMapVolume, ServiceCAConfigMapName, ServiceCAKey, ServiceCAKey),
-	)
+	} {
+		volumes = AddOrReplaceInList(
+			volumes,
+			newVolume,
+			func(v corev1.Volume) string { return v.Name },
+		)
+	}
+
+	return volumes
 }
 
 // AddCABundlesToContainerVolumes adds the CA bundles to the container via VolumeMounts.
 // SSL_CERT_DIR environment variable is also set if it does not exist already.
 func AddCABundlesToContainerVolumes(c *corev1.Container) {
-	volumeMounts := c.VolumeMounts
-
-	// If volume mounts for CA bundles already exist then remove them
-	for _, volumeName := range []string{TrustedCAConfigMapVolume, ServiceCAConfigMapVolume} {
-		for i, vm := range volumeMounts {
-			if vm.Name == volumeName {
-				volumeMounts = append(volumeMounts[:i], volumeMounts[i+1:]...)
-				break
-			}
-		}
-	}
-
 	// We will mount the certs at /tekton-custom-certs so we don't override the existing certs
 	sslCertDir := "/tekton-custom-certs"
 	certEnvAvailable := false
@@ -132,22 +118,26 @@ func AddCABundlesToContainerVolumes(c *corev1.Container) {
 		})
 	}
 
-	// Let's mount the certificates now.
-	volumeMounts = append(volumeMounts,
-		corev1.VolumeMount{
-			Name: TrustedCAConfigMapVolume,
-			// We only want the first entry in SSL_CERT_DIR for the mount
-			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], TrustedCAKey),
+	// We only want the first entry in SSL_CERT_DIR for the mount
+	mountDir := strings.Split(sslCertDir, ":")[0]
+	for _, newVolumeMount := range []corev1.VolumeMount{
+		{
+			Name:      TrustedCAConfigMapVolume,
+			MountPath: filepath.Join(mountDir, TrustedCAKey),
 			SubPath:   TrustedCAKey,
 			ReadOnly:  true,
 		},
-		corev1.VolumeMount{
-			Name: ServiceCAConfigMapVolume,
-			// We only want the first entry in SSL_CERT_DIR for the mount
-			MountPath: filepath.Join(strings.Split(sslCertDir, ":")[0], ServiceCAKey),
+		{
+			Name:      ServiceCAConfigMapVolume,
+			MountPath: filepath.Join(mountDir, ServiceCAKey),
 			SubPath:   ServiceCAKey,
 			ReadOnly:  true,
 		},
-	)
-	c.VolumeMounts = volumeMounts
+	} {
+		c.VolumeMounts = AddOrReplaceInList(
+			c.VolumeMounts,
+			newVolumeMount,
+			func(v corev1.VolumeMount) string { return v.Name },
+		)
+	}
 }

--- a/pkg/reconciler/common/utils.go
+++ b/pkg/reconciler/common/utils.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	mf "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -71,4 +72,19 @@ func SerializeLabelsToJSON(labels map[string]string) (string, error) {
 		return "", fmt.Errorf("failed to serialize labels to JSON: %v", err)
 	}
 	return string(bytes), nil
+}
+
+// AddOrReplaceInList appends newItem to the provided list. If the new item exists in the list then the original
+// copy of the item is removed from the list before the new copy is appended. The identityFunc parameter is used
+// to uniquely identify an item during comparison.
+func AddOrReplaceInList[T any, V comparable](items []T, newItem T, identityFunc func(T) V) []T {
+	newItemIdentity := identityFunc(newItem)
+	for i, item := range items {
+		itemIdentity := identityFunc(item)
+		if itemIdentity == newItemIdentity {
+			items = slices.Delete(items, i, i+1)
+			break
+		}
+	}
+	return append(items, newItem)
 }

--- a/pkg/reconciler/openshift/common/cabundle_test.go
+++ b/pkg/reconciler/openshift/common/cabundle_test.go
@@ -110,6 +110,87 @@ func TestApplyCABundlesForDeployments(t *testing.T) {
 	assert.DeepEqual(t, actual, expected)
 }
 
+func TestApplyCABundlesForDeploymentsIdempotent(t *testing.T) {
+	actual := unstructuredDeployment(t,
+		withEnvs(
+			corev1.EnvVar{
+				Name:  "SSL_CERT_DIR",
+				Value: "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs",
+			},
+		),
+		withVolumes(corev1.Volume{
+			Name: common.TrustedCAConfigMapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  common.TrustedCAKey,
+							Path: common.TrustedCAKey,
+						},
+					},
+				},
+			},
+		},
+			corev1.Volume{
+				Name: common.ServiceCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ServiceCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.ServiceCAKey,
+								Path: common.ServiceCAKey,
+							},
+						},
+					},
+				},
+			},
+			corev1.Volume{
+				Name: systemCAVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.TrustedCAKey,
+								Path: systemCAKey,
+							},
+						},
+					},
+				},
+			}),
+		withVolumeMounts(
+			corev1.VolumeMount{
+				Name:      common.TrustedCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.TrustedCAKey),
+				SubPath:   common.TrustedCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      common.ServiceCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.ServiceCAKey),
+				SubPath:   common.ServiceCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      systemCAVolume,
+				MountPath: "/etc/pki/ca-trust/extracted/pem",
+				ReadOnly:  true,
+			},
+		),
+	)
+
+	// ApplyCABundlesForDeployments should not duplicate any of the mounts during transformation
+	expected := actual.DeepCopy()
+
+	if err := ApplyCABundlesToDeployment(actual); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.DeepEqual(t, actual, expected)
+}
+
 func TestApplyCABundlesForStatefulSet(t *testing.T) {
 	actual := unstructuredStatefulSet(t)
 	expected := unstructuredStatefulSet(t,
@@ -181,6 +262,87 @@ func TestApplyCABundlesForStatefulSet(t *testing.T) {
 			},
 		),
 	)
+
+	if err := ApplyCABundlesForStatefulSet("test-statefulset")(actual); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.DeepEqual(t, actual, expected)
+}
+
+func TestApplyCABundlesForStatefulSetIdempotent(t *testing.T) {
+	actual := unstructuredStatefulSet(t,
+		withStatefulSetEnvs(
+			corev1.EnvVar{
+				Name:  "SSL_CERT_DIR",
+				Value: "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs",
+			},
+		),
+		withStatefulSetVolumes(corev1.Volume{
+			Name: common.TrustedCAConfigMapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  common.TrustedCAKey,
+							Path: common.TrustedCAKey,
+						},
+					},
+				},
+			},
+		},
+			corev1.Volume{
+				Name: common.ServiceCAConfigMapVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ServiceCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.ServiceCAKey,
+								Path: common.ServiceCAKey,
+							},
+						},
+					},
+				},
+			},
+			corev1.Volume{
+				Name: systemCAVolume,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.TrustedCAConfigMapName},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  common.TrustedCAKey,
+								Path: systemCAKey,
+							},
+						},
+					},
+				},
+			}),
+		withStatefulSetVolumeMounts(
+			corev1.VolumeMount{
+				Name:      common.TrustedCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.TrustedCAKey),
+				SubPath:   common.TrustedCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      common.ServiceCAConfigMapVolume,
+				MountPath: filepath.Join("/tekton-custom-certs", common.ServiceCAKey),
+				SubPath:   common.ServiceCAKey,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      systemCAVolume,
+				MountPath: "/etc/pki/ca-trust/extracted/pem",
+				ReadOnly:  true,
+			},
+		),
+	)
+
+	// ApplyCABundlesForStatefulSet should not duplicate the ca bundles during transformation
+	expected := actual.DeepCopy()
 
 	if err := ApplyCABundlesForStatefulSet("test-statefulset")(actual); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Cherry pick of https://github.com/tektoncd/operator/pull/2864 into release v0.77.x

/assign @savitaashture @jkhelil 

```release-note
fix: dedupe system ca-bundle Volumes and VolumeMounts during Deployment and StatefulSet reconciliation
```