### PR TITLE
Add Route support for Tekton Results

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
@@ -41,3 +41,22 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:authenticated
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tekton-results-api
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-api
+    app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
+spec:
+  to:
+    kind: Service
+    name: tekton-results-api-service
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/config/openshift/base/role.yaml
+++ b/config/openshift/base/role.yaml
@@ -277,6 +277,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
@@ -29,5 +29,14 @@ func (tp *TektonResult) SetDefaults(ctx context.Context) {
 
 // Sets default values of Result
 func (c *Result) setDefaults() {
-	// TODO: Set the other default values for Result
+	// Set default values for route configuration
+	if c.RouteEnabled == nil {
+		// Default to true for OpenShift platforms to automatically create routes
+		enabled := IsOpenShiftPlatform()
+		c.RouteEnabled = &enabled
+	}
+
+	if c.RouteTLSTermination == "" {
+		c.RouteTLSTermination = "edge"
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestTektonResult_SetDefaults(t *testing.T) {
@@ -75,5 +77,26 @@ func TestTektonResult_SetDefaults(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestResult_SetDefaultsRoutes(t *testing.T) {
+	r := &Result{
+		ResultsAPIProperties: ResultsAPIProperties{
+			RouteEnabled: ptr.Bool(true),
+		},
+	}
+
+	want := &Result{
+		ResultsAPIProperties: ResultsAPIProperties{
+			RouteEnabled:        ptr.Bool(true),
+			RouteTLSTermination: "edge",
+		},
+	}
+
+	r.setDefaults()
+
+	if d := cmp.Diff(want, r); d != "" {
+		t.Errorf("failed to set defaults %s", diff.PrintWantGot(d))
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -121,6 +121,13 @@ type ResultsAPIProperties struct {
 	LoggingPluginQueryLimit             *uint  `json:"logging_plugin_query_limit,omitempty"`
 	LoggingPluginQueryParams            string `json:"logging_plugin_query_params,omitempty"`
 	LoggingPluginMultipartRegex         string `json:"logging_plugin_multipart_regex,omitempty"`
+
+	// Route configuration for Results API service exposure
+	RouteEnabled *bool  `json:"route_enabled,omitempty"`
+	RouteHost    string `json:"route_host,omitempty"`
+	RoutePath    string `json:"route_path,omitempty"`
+	// +optional
+	RouteTLSTermination string `json:"route_tls_termination,omitempty"`
 }
 
 // TektonResultStatus defines the observed state of TektonResult

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1295,6 +1295,11 @@ func (in *ResultsAPIProperties) DeepCopyInto(out *ResultsAPIProperties) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.RouteEnabled != nil {
+		in, out := &in.RouteEnabled, &out.RouteEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
+++ b/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
@@ -41,3 +41,22 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:authenticated
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: tekton-results-api
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-api
+    app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
+spec:
+  to:
+    kind: Service
+    name: tekton-results-api-service
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Enable Route support in Tekton Results. By default, a Route is created on the cluster
and users can optionally configure a custom host and path.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Enable Route support in Tekton Results. By default, a Route is created on the cluster, and users can optionally configure a custom host and path.
```
