### PR TITLE
fix: exclude system namespaces for tekton webhook validation

### DIFF
--- a/pkg/reconciler/openshift/namespace/namespace.go
+++ b/pkg/reconciler/openshift/namespace/namespace.go
@@ -263,6 +263,13 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 				},
 			},
 		}
+		// Exclude system namespaces
+		webhook.Webhooks[i].MatchConditions = []admissionregistrationv1.MatchCondition{
+			{
+				Name:       "exclude-system-namespaces",
+				Expression: "!(object.metadata.name.startsWith('kube-') || object.metadata.name.startsWith('openshift-'))",
+			},
+		}
 
 		webhook.Webhooks[i].ClientConfig.CABundle = caCert
 		if webhook.Webhooks[i].ClientConfig.Service == nil {

--- a/pkg/reconciler/openshift/namespace/namespace_test.go
+++ b/pkg/reconciler/openshift/namespace/namespace_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2023 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	operatorfake "github.com/tektoncd/operator/pkg/client/clientset/versioned/fake"
+	operatorinformers "github.com/tektoncd/operator/pkg/client/informers/externalversions"
+	"gotest.tools/v3/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestReconciler_Admit_BasicOperations(t *testing.T) {
+	tests := []struct {
+		name        string
+		operation   admissionv1.Operation
+		wantAllowed bool
+	}{
+		{
+			name:        "create operation should be processed",
+			operation:   admissionv1.Create,
+			wantAllowed: true,
+		},
+		{
+			name:        "update operation should be processed",
+			operation:   admissionv1.Update,
+			wantAllowed: true,
+		},
+		{
+			name:        "delete operation should be allowed (unhandled)",
+			operation:   admissionv1.Delete,
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create minimal reconciler
+			r := &reconciler{}
+
+			// Create simple namespace
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+				},
+			}
+
+			namespaceBytes, err := json.Marshal(namespace)
+			assert.NilError(t, err)
+
+			req := &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Namespace",
+				},
+				Object: runtime.RawExtension{
+					Raw: namespaceBytes,
+				},
+				Operation: tt.operation,
+			}
+
+			ctx := logging.WithLogger(context.Background(), logtesting.TestLogger(t))
+			response := r.Admit(ctx, req)
+
+			assert.Assert(t, response != nil, "response should not be nil")
+			assert.Equal(t, tt.wantAllowed, response.Allowed)
+		})
+	}
+}
+
+func TestReconciler_admissionAllowed_NoSCCAnnotation(t *testing.T) {
+	// Create namespace without SCC annotation
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			// No annotations
+		},
+	}
+
+	// Create minimal TektonConfig
+	tektonConfig := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+	}
+
+	// Setup fake client and informer
+	operatorClient := operatorfake.NewSimpleClientset(tektonConfig)
+	operatorInformerFactory := operatorinformers.NewSharedInformerFactory(operatorClient, 0)
+	tektonConfigInformer := operatorInformerFactory.Operator().V1alpha1().TektonConfigs()
+
+	err := tektonConfigInformer.Informer().GetStore().Add(tektonConfig)
+	assert.NilError(t, err)
+
+	r := &reconciler{
+		tektonConfigLister: tektonConfigInformer.Lister(),
+	}
+
+	// Create admission request
+	namespaceBytes, err := json.Marshal(namespace)
+	assert.NilError(t, err)
+
+	req := &admissionv1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Namespace",
+		},
+		Object: runtime.RawExtension{
+			Raw: namespaceBytes,
+		},
+		Operation: admissionv1.Create,
+	}
+
+	allowed, status, err := r.admissionAllowed(context.Background(), req)
+
+	// Should be allowed since no SCC annotation
+	assert.NilError(t, err)
+	assert.Equal(t, true, allowed)
+	assert.Assert(t, status == nil, "status should be nil")
+}
+
+func TestReconciler_admissionAllowed_InvalidKind(t *testing.T) {
+	r := &reconciler{}
+
+	req := &admissionv1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		},
+		Object: runtime.RawExtension{
+			Raw: []byte(`{}`),
+		},
+		Operation: admissionv1.Create,
+	}
+
+	allowed, status, err := r.admissionAllowed(context.Background(), req)
+
+	// Should return error for invalid kind
+	assert.Assert(t, err != nil, "expected error for invalid kind")
+	assert.Equal(t, false, allowed)
+	assert.Assert(t, status == nil, "status should be nil for error")
+}


### PR DESCRIPTION
This pull request partly addresses #2906  a key improvement to the OpenShift namespace admission webhook by excluding system namespaces from webhook processing and adds comprehensive unit tests for the namespace reconciler's admission logic.

* Updated the webhook configuration in `reconcileValidatingWebhook` to exclude system namespaces (those starting with `kube-` or `openshift-`) by adding a `MatchCondition` that prevents the webhook from acting on these namespaces.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
