### PR TITLE
Add GitHub Actions workflow for go coverage job

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,0 +1,65 @@
+name: Go coverage
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  # run at least once every 2 months to prevent the coverage artifact from expiring
+  schedule:
+    - cron: '14 3 5 */2 *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  go-coverage:
+    name: Go coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: ${{ github.workspace }}/src/github.com/tektoncd/operator
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/operator/go.mod"
+
+      - name: Generate coverage
+        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/operator
+        run: |
+          go test -cover -coverprofile=coverage.txt ./... || true
+          echo "Generated coverage profile"
+
+      - name: Archive coverage results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: code-coverage
+          path: ${{ github.workspace }}/src/github.com/tektoncd/operator/coverage.txt
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
+        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
+        with:
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "coverage.txt"


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/plumbing/issues/2842

It uses workflow artifacts to store current coverage on merged to main and uses this as a baseline for comparison when running on PRs.

It's also configured to run at least once every 2 months to avoid the workflow artifact expiring.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
