### PR TITLE
Update preupgrade function to update PAC settings

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
@@ -18,6 +18,7 @@ package upgrade
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektonpruner"
 	"gopkg.in/yaml.v3"
@@ -28,6 +29,7 @@ import (
 	"go.uber.org/zap"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -150,4 +152,201 @@ func preUpgradeTektonPruner(ctx context.Context, logger *zap.SugaredLogger, k8sC
 
 	_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Update(ctx, tc, metav1.UpdateOptions{})
 	return err
+}
+
+// preUpgradePipelinesAsCodeArtifacts checks if Pipelines as Code is installed and updates
+// the hub catalog settings to use the artifact hub URL. It cleans up hub-catalog-name from:
+// 1. TektonConfig CR settings
+// 2. OpenShiftPipelinesAsCode CR settings
+// 3. pipelines-as-code config map
+func preUpgradePipelinesAsCodeArtifacts(ctx context.Context, logger *zap.SugaredLogger, k8sClient kubernetes.Interface, operatorClient versioned.Interface, restConfig *rest.Config) error {
+	// Only run on OpenShift platform
+	if !v1alpha1.IsOpenShiftPlatform() {
+		logger.Infof("Not on OpenShift platform, skipping Pipelines as Code artifact upgrade")
+		return nil
+	}
+
+	// Get TektonConfig CR
+	logger.Infof("Performing preupgrade for Pipelines as Code artifact settings")
+	tc, err := operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			logger.Infof("TektonConfig CR not found, skipping Pipelines as Code artifact upgrade")
+			return nil
+		}
+		logger.Errorw("error on getting TektonConfig CR", err)
+		return err
+	}
+
+	// Check if Pipelines as Code is enabled
+	if tc.Spec.Platforms.OpenShift.PipelinesAsCode == nil ||
+		tc.Spec.Platforms.OpenShift.PipelinesAsCode.Enable == nil ||
+		!*tc.Spec.Platforms.OpenShift.PipelinesAsCode.Enable {
+		logger.Infof("Pipelines as Code is not enabled, skipping artifact upgrade")
+		return nil
+	}
+
+	// Initialize settings if nil
+	if tc.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings == nil {
+		tc.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings = make(map[string]string)
+	}
+
+	// Fetch PAC settings
+	settings := tc.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings
+
+	// Set hub-catalog-type to artifacthub if not already set or if it's set to tektonhub
+	if catalogType, exists := settings["hub-catalog-type"]; !exists || catalogType == "tektonhub" {
+		settings["hub-catalog-type"] = "artifacthub"
+		logger.Infof("Updated hub-catalog-type to artifacthub")
+	}
+
+	// Set hub-url to https://artifacthub.io if not already set or if it's set to the old API URL
+	if hubURL, exists := settings["hub-url"]; !exists || hubURL == "https://artifacthub.io/api/v1" || hubURL == "https://api.hub.tekton.dev/v1" {
+		settings["hub-url"] = "https://artifacthub.io"
+		logger.Infof("Updated hub-url to https://artifacthub.io")
+	}
+
+	// remove hub-catalog-name key from setting if found
+	if _, exists := settings["hub-catalog-name"]; exists {
+		delete(settings, "hub-catalog-name")
+		logger.Infof("Removed hub-catalog-name field from TektonConfig CR")
+	}
+
+	// Update the TektonConfig CR
+	_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Update(ctx, tc, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Errorw("error updating TektonConfig CR with artifact settings", err)
+		return err
+	}
+
+	// Also check and update the OpenShiftPipelinesAsCode CR if it exists
+	err = updateOpenShiftPipelinesAsCodeCR(ctx, logger, operatorClient)
+	if err != nil {
+		logger.Errorw("error updating OpenShiftPipelinesAsCode CR", err)
+		return err
+	}
+
+	// Also check and update the deployed pipelines-as-code config map if it exists
+	err = updatePipelinesAsCodeConfigMap(ctx, logger, k8sClient, tc.Spec.TargetNamespace)
+	if err != nil {
+		logger.Errorw("error updating pipelines-as-code config map", err)
+		return err
+	}
+
+	logger.Infof("Successfully updated Pipelines as Code artifact settings in TektonConfig CR, OpenShiftPipelinesAsCode CR, and config map")
+	return nil
+}
+
+// updatePipelinesAsCodeConfigMap checks and updates the deployed pipelines-as-code config map
+// to remove hub-catalog-name if it exists
+func updatePipelinesAsCodeConfigMap(ctx context.Context, logger *zap.SugaredLogger, k8sClient kubernetes.Interface, targetNamespace string) error {
+	configMapName := "pipelines-as-code"
+
+	// First check if the config map exists and has the hub-catalog-name field
+	cm, err := k8sClient.CoreV1().ConfigMaps(targetNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			logger.Infof("pipelines-as-code config map not found, skipping config map update")
+			return nil
+		}
+		return err
+	}
+
+	// Check if hub-catalog-name exists in the config map data
+	if cm.Data == nil {
+		logger.Infof("pipelines-as-code config map has no data, skipping config map update")
+		return nil
+	}
+
+	// Check if hub-catalog-name key exists
+	if val, exists := cm.Data["hub-catalog-name"]; exists {
+		// Create a patch to remove the hub-catalog-name field
+		// Setting the field to null in the patch will remove it
+		patch := map[string]interface{}{
+			"data": map[string]interface{}{
+				"hub-catalog-name": nil,
+			},
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			logger.Errorf("failed to marshal patch payload: %v", err)
+			return err
+		}
+
+		// Apply the patch to remove the hub-catalog-name field
+		_, err = k8sClient.CoreV1().ConfigMaps(targetNamespace).Patch(ctx, configMapName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			logger.Errorf("failed to patch pipelines-as-code config map: %v", err)
+			return err
+		}
+
+		if val == "" {
+			logger.Infof("Removed empty hub-catalog-name field from pipelines-as-code config map")
+		} else {
+			logger.Infof("Removed hub-catalog-name field (value: %s) from pipelines-as-code config map", val)
+		}
+		logger.Infof("Successfully updated pipelines-as-code config map")
+	} else {
+		logger.Infof("No catalog name entries found in pipelines-as-code config map, no update needed")
+	}
+
+	return nil
+}
+
+// updateOpenShiftPipelinesAsCodeCR checks and updates the OpenShiftPipelinesAsCode CR
+// to remove hub-catalog-name if it exists
+func updateOpenShiftPipelinesAsCodeCR(ctx context.Context, logger *zap.SugaredLogger, operatorClient versioned.Interface) error {
+	// First check if the OpenShiftPipelinesAsCode CR exists and has the hub-catalog-name field
+	pacCR, err := operatorClient.OperatorV1alpha1().OpenShiftPipelinesAsCodes().Get(ctx, v1alpha1.OpenShiftPipelinesAsCodeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			logger.Infof("OpenShiftPipelinesAsCode CR not found, skipping PAC CR update")
+			return nil
+		}
+		return err
+	}
+
+	// Check if PAC settings exist
+	if pacCR.Spec.PACSettings.Settings == nil {
+		logger.Infof("OpenShiftPipelinesAsCode CR has no settings, skipping PAC CR update")
+		return nil
+	}
+
+	// Check if hub-catalog-name key exists
+	if val, exists := pacCR.Spec.PACSettings.Settings["hub-catalog-name"]; exists {
+		// Create a patch to remove the hub-catalog-name field
+		// Setting the field to null in the patch will remove it
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"hub-catalog-name": nil,
+				},
+			},
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			logger.Errorf("failed to marshal patch payload: %v", err)
+			return err
+		}
+
+		// Apply the patch to remove the hub-catalog-name field
+		_, err = operatorClient.OperatorV1alpha1().OpenShiftPipelinesAsCodes().Patch(ctx, v1alpha1.OpenShiftPipelinesAsCodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			logger.Errorf("failed to patch OpenShiftPipelinesAsCode CR: %v", err)
+			return err
+		}
+
+		if val == "" {
+			logger.Infof("Removed empty hub-catalog-name field from OpenShiftPipelinesAsCode CR")
+		} else {
+			logger.Infof("Removed hub-catalog-name field (value: %s) from OpenShiftPipelinesAsCode CR", val)
+		}
+		logger.Infof("Successfully updated OpenShiftPipelinesAsCode CR")
+	} else {
+		logger.Infof("No catalog name entries found in OpenShiftPipelinesAsCode CR, no update needed")
+	}
+
+	return nil
 }

--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
@@ -193,3 +193,568 @@ func TestPreUpgradeTektonPruner(t *testing.T) {
 	assert.Equal(t, false, *tc.Spec.TektonPruner.Disabled)
 	assert.Equal(t, int32(88), *tc.Spec.TektonPruner.GlobalConfig.TTLSecondsAfterFinished)
 }
+
+func TestPreUpgradePipelinesAsCodeArtifacts(t *testing.T) {
+	t.Setenv("PLATFORM", "openshift")
+
+	tests := []struct {
+		name                   string
+		tc                     *v1alpha1.TektonConfig
+		expectedHubCatalogType string
+		expectedHubURL         string
+		shouldUpdate           bool
+	}{
+		{
+			name: "PAC enabled with no settings - should update",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           true,
+		},
+		{
+			name: "PAC enabled with tektonhub settings - should update",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+								PACSettings: v1alpha1.PACSettings{
+									Settings: map[string]string{
+										"hub-catalog-type": "tektonhub",
+										"hub-url":          "https://api.hub.tekton.dev/v1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           true,
+		},
+		{
+			name: "PAC enabled with old artifacthub API URL - should update",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+								PACSettings: v1alpha1.PACSettings{
+									Settings: map[string]string{
+										"hub-catalog-type": "artifacthub",
+										"hub-url":          "https://artifacthub.io/api/v1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           true,
+		},
+		{
+			name: "PAC enabled with correct settings - should not update",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+								PACSettings: v1alpha1.PACSettings{
+									Settings: map[string]string{
+										"hub-catalog-type": "artifacthub",
+										"hub-url":          "https://artifacthub.io",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           false,
+		},
+		{
+			name: "PAC enabled with hub-catalog-name - should update and remove hub-catalog-name",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+								PACSettings: v1alpha1.PACSettings{
+									Settings: map[string]string{
+										"hub-catalog-type": "artifacthub",
+										"hub-url":          "https://artifacthub.io",
+										"hub-catalog-name": "tekton",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           true,
+		},
+		{
+			name: "PAC enabled with tektonhub and hub-catalog-name - should update all",
+			tc: &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Platforms: v1alpha1.Platforms{
+						OpenShift: v1alpha1.OpenShift{
+							PipelinesAsCode: &v1alpha1.PipelinesAsCode{
+								Enable: ptr.Bool(true),
+								PACSettings: v1alpha1.PACSettings{
+									Settings: map[string]string{
+										"hub-catalog-type": "tektonhub",
+										"hub-url":          "https://api.hub.tekton.dev/v1",
+										"hub-catalog-name": "tekton",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHubCatalogType: "artifacthub",
+			expectedHubURL:         "https://artifacthub.io",
+			shouldUpdate:           true,
+		},
+	}
+
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			operatorClient := operatorFake.NewSimpleClientset()
+			k8sClient := k8sFake.NewSimpleClientset()
+
+			err := preUpgradePipelinesAsCodeArtifacts(ctx, logger, k8sClient, operatorClient, nil)
+			assert.NoError(t, err)
+
+			// create tektonConfig CR
+			if tt.tc != nil {
+				_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Create(ctx, tt.tc, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			// run the upgrade function
+			err = preUpgradePipelinesAsCodeArtifacts(ctx, logger, k8sClient, operatorClient, nil)
+			assert.NoError(t, err)
+
+			if tt.shouldUpdate {
+				tcData, err := operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.NotNil(t, tcData.Spec.Platforms.OpenShift.PipelinesAsCode)
+				assert.NotNil(t, tcData.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings)
+
+				settings := tcData.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings
+				assert.Equal(t, tt.expectedHubCatalogType, settings["hub-catalog-type"])
+				assert.Equal(t, tt.expectedHubURL, settings["hub-url"])
+
+				// Verify that hub-catalog-name is removed if it existed in the original settings
+				_, hubCatalogNameExists := settings["hub-catalog-name"]
+				assert.False(t, hubCatalogNameExists, "hub-catalog-name should be removed from settings")
+			}
+		})
+	}
+}
+
+func TestPreUpgradePipelinesAsCodeArtifacts_NonOpenShift(t *testing.T) {
+	// Test on non-OpenShift platform
+	t.Setenv("PLATFORM", "kubernetes")
+
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+	operatorClient := operatorFake.NewSimpleClientset()
+	k8sClient := k8sFake.NewSimpleClientset()
+
+	// Should return early without error on non-OpenShift platform
+	err := preUpgradePipelinesAsCodeArtifacts(ctx, logger, k8sClient, operatorClient, nil)
+	assert.NoError(t, err)
+}
+
+func TestPreUpgradePipelinesAsCodeArtifacts_NoTektonConfig(t *testing.T) {
+	t.Setenv("PLATFORM", "openshift")
+
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+	operatorClient := operatorFake.NewSimpleClientset()
+	k8sClient := k8sFake.NewSimpleClientset()
+
+	// Should return without error when TektonConfig CR doesn't exist
+	err := preUpgradePipelinesAsCodeArtifacts(ctx, logger, k8sClient, operatorClient, nil)
+	assert.NoError(t, err)
+}
+
+func TestUpdatePipelinesAsCodeConfigMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		configMapData  map[string]string
+		expectUpdate   bool
+		expectError    bool
+		expectedLogMsg string
+	}{
+		{
+			name: "ConfigMap with hub-catalog-name - should remove",
+			configMapData: map[string]string{
+				"hub-catalog-name": "tekton",
+				"other-setting":    "value",
+				"hub-url":          "https://artifacthub.io",
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "ConfigMap with empty hub-catalog-name - should remove",
+			configMapData: map[string]string{
+				"hub-catalog-name": "",
+				"other-setting":    "value",
+				"hub-url":          "https://artifacthub.io",
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "ConfigMap with multiple hub settings but no hub-catalog-name - should not update",
+			configMapData: map[string]string{
+				"hub-url":          "https://artifacthub.io",
+				"hub-catalog-type": "artifacthub",
+				"other-setting":    "value",
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "ConfigMap with only hub-catalog-name - should remove",
+			configMapData: map[string]string{
+				"hub-catalog-name": "tekton-catalog",
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "ConfigMap with hub-catalog-name and special characters - should remove",
+			configMapData: map[string]string{
+				"hub-catalog-name": "tekton-catalog-v1.0.0",
+				"secret-name":      "pac-secret",
+				"webhook-url":      "https://example.com/webhook",
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "ConfigMap without hub-catalog-name - should not update",
+			configMapData: map[string]string{
+				"other-setting": "value",
+			},
+			expectUpdate: false,
+		},
+		{
+			name:         "ConfigMap with nil data - should not update",
+			expectUpdate: false,
+		},
+		{
+			name:          "ConfigMap with empty data - should not update",
+			configMapData: map[string]string{},
+			expectUpdate:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			logger := logging.FromContext(ctx).Named("unit-test")
+			k8sClient := k8sFake.NewSimpleClientset()
+			targetNamespace := "test-namespace"
+
+			// Create config map if data is provided
+			if tt.configMapData != nil {
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pipelines-as-code",
+						Namespace: targetNamespace,
+					},
+					Data: tt.configMapData,
+				}
+				_, err := k8sClient.CoreV1().ConfigMaps(targetNamespace).Create(ctx, cm, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			} else if tt.name == "ConfigMap with nil data - should not update" {
+				// Create config map with nil data
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pipelines-as-code",
+						Namespace: targetNamespace,
+					},
+					Data: nil,
+				}
+				_, err := k8sClient.CoreV1().ConfigMaps(targetNamespace).Create(ctx, cm, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			// Call the function
+			err := updatePipelinesAsCodeConfigMap(ctx, logger, k8sClient, targetNamespace)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.expectUpdate && tt.configMapData != nil {
+				// Verify the config map was updated
+				updatedCM, err := k8sClient.CoreV1().ConfigMaps(targetNamespace).Get(ctx, "pipelines-as-code", metav1.GetOptions{})
+				assert.NoError(t, err)
+
+				// hub-catalog-name should be removed
+				_, exists := updatedCM.Data["hub-catalog-name"]
+				assert.False(t, exists, "hub-catalog-name should be removed from config map")
+
+				// Other settings should remain
+				if originalValue, hadOtherSetting := tt.configMapData["other-setting"]; hadOtherSetting {
+					assert.Equal(t, originalValue, updatedCM.Data["other-setting"])
+				}
+			}
+		})
+	}
+}
+
+func TestUpdatePipelinesAsCodeConfigMap_NotFound(t *testing.T) {
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+	k8sClient := k8sFake.NewSimpleClientset()
+	targetNamespace := "test-namespace"
+
+	// Should return without error when config map doesn't exist
+	err := updatePipelinesAsCodeConfigMap(ctx, logger, k8sClient, targetNamespace)
+	assert.NoError(t, err)
+}
+
+func TestUpdateOpenShiftPipelinesAsCodeCR(t *testing.T) {
+	tests := []struct {
+		name         string
+		pacCR        *v1alpha1.OpenShiftPipelinesAsCode
+		expectUpdate bool
+	}{
+		{
+			name: "PAC CR with hub-catalog-name - should remove",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"hub-catalog-name": "tekton",
+							"other-setting":    "value",
+							"hub-url":          "https://artifacthub.io",
+							"hub-catalog-type": "artifacthub",
+						},
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "PAC CR with empty hub-catalog-name - should remove",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"hub-catalog-name": "",
+							"other-setting":    "value",
+							"secret-name":      "pac-secret",
+						},
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "PAC CR with hub-catalog-name and complex settings - should remove only hub-catalog-name",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"hub-catalog-name":    "tekton-catalog-v2",
+							"hub-url":             "https://artifacthub.io",
+							"hub-catalog-type":    "artifacthub",
+							"secret-name":         "pipelines-as-code-secret",
+							"webhook-url":         "https://example.com/webhook",
+							"application-name":    "Pipelines as Code CI",
+							"custom-console-name": "tekton-pipelines",
+						},
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "PAC CR with only hub-catalog-name - should remove",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"hub-catalog-name": "tekton-only",
+						},
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "PAC CR with multiple hub settings but no hub-catalog-name - should not update",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"hub-url":          "https://artifacthub.io",
+							"hub-catalog-type": "artifacthub",
+							"other-setting":    "value",
+						},
+					},
+				},
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "PAC CR without hub-catalog-name - should not update",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{
+							"other-setting": "value",
+						},
+					},
+				},
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "PAC CR with nil settings - should not update",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: nil,
+					},
+				},
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "PAC CR with empty settings map - should not update",
+			pacCR: &v1alpha1.OpenShiftPipelinesAsCode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.OpenShiftPipelinesAsCodeName,
+				},
+				Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
+					PACSettings: v1alpha1.PACSettings{
+						Settings: map[string]string{},
+					},
+				},
+			},
+			expectUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			logger := logging.FromContext(ctx).Named("unit-test")
+			operatorClient := operatorFake.NewSimpleClientset()
+
+			// Create PAC CR
+			_, err := operatorClient.OperatorV1alpha1().OpenShiftPipelinesAsCodes().Create(ctx, tt.pacCR, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			// Store original settings for comparison
+			var originalSettings map[string]string
+			if tt.pacCR.Spec.PACSettings.Settings != nil {
+				originalSettings = make(map[string]string)
+				for k, v := range tt.pacCR.Spec.PACSettings.Settings {
+					originalSettings[k] = v
+				}
+			}
+
+			// Call the function
+			err = updateOpenShiftPipelinesAsCodeCR(ctx, logger, operatorClient)
+			assert.NoError(t, err)
+
+			if tt.expectUpdate {
+				// Verify the PAC CR was updated
+				updatedPAC, err := operatorClient.OperatorV1alpha1().OpenShiftPipelinesAsCodes().Get(ctx, v1alpha1.OpenShiftPipelinesAsCodeName, metav1.GetOptions{})
+				assert.NoError(t, err)
+
+				// hub-catalog-name should be removed
+				_, exists := updatedPAC.Spec.PACSettings.Settings["hub-catalog-name"]
+				assert.False(t, exists, "hub-catalog-name should be removed from PAC CR settings")
+
+				// Other settings should remain
+				if originalValue, hadOtherSetting := originalSettings["other-setting"]; hadOtherSetting {
+					assert.Equal(t, originalValue, updatedPAC.Spec.PACSettings.Settings["other-setting"])
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateOpenShiftPipelinesAsCodeCR_NotFound(t *testing.T) {
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+	operatorClient := operatorFake.NewSimpleClientset()
+
+	// Should return without error when PAC CR doesn't exist
+	err := updateOpenShiftPipelinesAsCodeCR(ctx, logger, operatorClient)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This updates preupgrade function for PAC to remove hub-catalog-name from pipelines-as-code configMap and CR

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
This updates preupgrade function for PAC to remove hub-catalog-name from pipelines-as-code configMap and CR
```
