### PR TITLE
fix: Apply options transformer to OpenShift pre-reconcile manifests

### DIFF
--- a/pkg/reconciler/openshift/tektonresult/extension.go
+++ b/pkg/reconciler/openshift/tektonresult/extension.go
@@ -197,6 +197,13 @@ func filterAndTransform() client.FilterAndTransform {
 		if err := common.Transform(ctx, manifest, comp, extra...); err != nil {
 			return nil, err
 		}
+
+		// Apply options transformer to pre-reconcile manifests (e.g., postgres StatefulSet)
+		// This enables configuration of postgres replicas and other deployment customizations
+		if err := common.ExecuteAdditionalOptionsTransformer(ctx, manifest, instance.Spec.GetTargetNamespace(), instance.Spec.Options); err != nil {
+			return nil, err
+		}
+
 		return manifest, nil
 	}
 }


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
On OpenShift, the postgres StatefulSet is deployed via a pre-reconcile installer set. The filterAndTransform() function was not calling ExecuteAdditionalOptionsTransformer(), which meant options configurations were never applied to pre-reconcile resources.

This fix adds the options transformer call to enable configuration of:
- Postgres replicas via options.statefulSets
- Other StatefulSet/Deployment customizations in pre-reconcile phase

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fixed an issue where the filterAndTransform() function did not invoke ExecuteAdditionalOptionsTransformer(), causing configuration options to be ignored for pre-reconcile resources. With this update, pre-reconcile installer sets (such as the PostgreSQL StatefulSet) now correctly apply customization options, including:

- Configuring PostgreSQL replicas via options.statefulSets
- Applying other StatefulSet and Deployment customizations during the pre-reconcile phase
```

