### PR TITLE
Add readOnlyRootFilesystem security hardening to tkn-cli-serve

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/04-tkncliserve/tkn_cli_serve.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/04-tkncliserve/tkn_cli_serve.yaml
@@ -20,16 +20,57 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: httpd-config
+          emptyDir: {}
+        - name: httpd-logs
+          emptyDir: {}
+        - name: app-root
+          emptyDir: {}
+      initContainers:
+        - name: copy-httpd-config
+          image: docker.io/rupali/serve-tkn:v2
+          command:
+            - sh
+            - -c
+            - |
+              cp -rL /etc/httpd/* /httpd-config/ 2>/dev/null || true
+              find /httpd-config -type f -exec chmod u+w {} \;
+              cp -rL /opt/app-root/* /app-root/ 2>/dev/null || true
+              find /app-root -type f -exec chmod u+w {} \;
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: httpd-config
+              mountPath: /httpd-config
+            - name: app-root
+              mountPath: /app-root
       containers:
         - name: tkn-cli-serve
           image: docker.io/rupali/serve-tkn:v2
           ports:
             - containerPort: 8080
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: httpd-config
+              mountPath: /etc/httpd
+            - name: httpd-logs
+              mountPath: /var/log/httpd
+            - name: app-root
+              mountPath: /opt/app-root
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Add readOnlyRootFilesystem: true to tkn-cli-serve container
- Add initContainer to copy httpd and app-root configs to writable volumes
- Mount emptyDir volumes for directories requiring write access:
  * /etc/httpd - Apache configuration files
  * /var/log/httpd - Log files
  * /opt/app-root - Application runtime files

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Enhanced security for `tkn-cli-serve` by enabling `readOnlyRootFilesystem` and isolating writable directories through `emptyDir` volumes and an initContainer.

```
