### PR TITLE
Set readOnlyRootFilesystem for pipelines-console-plugin

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -101,6 +101,12 @@ spec:
           configMap:
             name: pipelines-console-plugin
             defaultMode: 420
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
       containers:
       - name: pipelines-console-plugin
         image: ghcr.io/openshift-pipelines/console-plugin:main
@@ -108,6 +114,8 @@ spec:
         ports:
           - protocol: TCP
             containerPort: 8443
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
           - name: pipelines-console-plugin-cert
             readOnly: true
@@ -116,6 +124,12 @@ spec:
             readOnly: true
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+          - name: nginx-tmp
+            mountPath: /var/lib/nginx/tmp
+          - name: nginx-cache
+            mountPath: /var/cache/nginx
+          - name: nginx-run
+            mountPath: /var/run
 
 # Console plugin is a cluster wide resource
 # updates pipeline dynamic content provider service details

--- a/pkg/reconciler/openshift/tektonconfig/testdata/postreconcile_manifest/test_post_manifest.yaml
+++ b/pkg/reconciler/openshift/tektonconfig/testdata/postreconcile_manifest/test_post_manifest.yaml
@@ -90,6 +90,12 @@ spec:
           configMap:
             name: pipelines-console-plugin
             defaultMode: 420
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
       containers:
       - name: pipelines-console-plugin
         image: ghcr.io/openshift-pipelines/console-plugin:main
@@ -97,6 +103,8 @@ spec:
         ports:
           - protocol: TCP
             containerPort: 8443
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
           - name: pipelines-console-plugin-cert
             readOnly: true
@@ -105,6 +113,12 @@ spec:
             readOnly: true
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
+          - name: nginx-tmp
+            mountPath: /var/lib/nginx/tmp
+          - name: nginx-cache
+            mountPath: /var/cache/nginx
+          - name: nginx-run
+            mountPath: /var/run
 
 ---
 apiVersion: console.openshift.io/v1


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Add readOnlyRootFilesystem: true to container securityContext
- Add emptyDir volumes for nginx writable directories:
  - nginx-tmp for /var/lib/nginx/tmp
  - nginx-cache for /var/cache/nginx
  - nginx-run for /var/run
- Update testdata to match new configuration

This enhances security by ensuring the root filesystem is read-only while still allowing nginx to function properly with necessary writable temp directories.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Enhance security for the `pipelines-console-plugin` container by setting `readOnlyRootFilesystem: true` in its security context.  
Introduced writable `emptyDir` volumes for required nginx directories (`/var/lib/nginx/tmp`, `/var/cache/nginx`, `/var/run`) to ensure proper functionality with a read-only root filesystem.

```
