### PR TITLE
Fix to delete the Results Route when disabled

### DIFF
--- a/pkg/reconciler/openshift/tektonresult/extension.go
+++ b/pkg/reconciler/openshift/tektonresult/extension.go
@@ -135,7 +135,11 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, tc v1alpha1.Tekt
 
 	result := tc.(*v1alpha1.TektonResult)
 	if !isEnableRoute(result) {
-		manifest = manifest.Filter(mf.Not(mf.ByKind("Route")))
+		// If route is disable then delete the postset
+		if err := oe.installerSetClient.CleanupPostSet(ctx); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	return oe.installerSetClient.PostSet(ctx, tc, &manifest, filterAndTransform())


### PR DESCRIPTION
If the results route is disabled, delete the postset since the route is part of the result postset.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
