### PR TITLE
Fix: Transformer should replace initContainer images as well

### DIFF
--- a/cmd/openshift/operator/kodata/tekton-addon/addons/04-tkncliserve/tkn_cli_serve.yaml
+++ b/cmd/openshift/operator/kodata/tekton-addon/addons/04-tkncliserve/tkn_cli_serve.yaml
@@ -28,7 +28,7 @@ spec:
         - name: app-root
           emptyDir: {}
       initContainers:
-        - name: copy-httpd-config
+        - name: tkn-cli-serve-init-config
           image: docker.io/rupali/serve-tkn:v2
           command:
             - sh

--- a/docs/AirGapImageConfiguration.md
+++ b/docs/AirGapImageConfiguration.md
@@ -131,3 +131,4 @@ Supports all the images listed above in kubernetes and following are specific to
 | Addons                |                                   | `IMAGE_ADDONS_SKOPEO_RESULTS`                       |
 | Addons                |                                   | `IMAGE_ADDONS_TKN`                                  |
 | Addons                |                                   | `IMAGE_ADDONS_TKN_CLI_SERVE`                        |
+| Addons                |                                   | `IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG`            |

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -197,6 +197,7 @@ image-substitutions:
       containerName: openshift-pipelines-operator-lifecycle
       envKeys:
       - IMAGE_ADDONS_TKN_CLI_SERVE
+      - IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
 - image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@
   replaceLocations:
     containerTargets:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -929,6 +929,8 @@ spec:
                   value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@
                 - name: IMAGE_ADDONS_TKN_CLI_SERVE
                   value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@
+                - name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
+                  value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@
                 - name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
                   value: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@
                 - name: IMAGE_RESULTS_TEKTON_RESULTS_API
@@ -1132,6 +1134,8 @@ spec:
     name: IMAGE_ADDONS_PARAM_TKN_IMAGE
   - image: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@
     name: IMAGE_ADDONS_TKN_CLI_SERVE
+  - image: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@
+    name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
   - image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@
     name: TEKTON_OPERATOR_WEBHOOK
   - image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -227,6 +227,8 @@ func DeploymentImages(images map[string]string) mf.Transformer {
 
 		containers := d.Spec.Template.Spec.Containers
 		replaceContainerImages(containers, images)
+		initContainers := d.Spec.Template.Spec.InitContainers
+		replaceContainerImages(initContainers, images)
 
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 		if err != nil {


### PR DESCRIPTION
Currently, transformers.go does replace only container images which leaves the initContainer images to original state. Replacing initContainer images from transformers.go gives complete flexibility to downstream.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
