### PR TITLE
feat: update release targeting oci bucket

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -22,7 +22,7 @@ spec:
     description: The path (project) in the image registry
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""
   - name: imageRegistryUser
     description: Username to be used to login to the container registry
     default: "_json_key"

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -8,6 +8,9 @@ spec:
   - name: package
     description: package to release
     default: github.com/tektoncd/operator
+  - name: repoName
+    description: repository name (e.g., pipeline, triggers, etc.)
+    default: operator
   - name: gitRevision
     description: the git revision to release
   - name: imageRegistry
@@ -18,7 +21,7 @@ spec:
     default: tekton-releases
   - name: imageRegistryRegions
     description: The target image registry regions
-    default: "us eu asia"
+    default: ""  # Empty for GHCR, "us eu asia" for GCR
   - name: imageRegistryUser
     description: The user for the image registry credentials
     default: _json_key
@@ -26,7 +29,7 @@ spec:
     description: The X.Y.Z version that the artifacts should be tagged with
   - name: releaseBucket
     description: bucket where the release is stored. The bucket must be project specific.
-    default: gs://tekton-releases-nightly/operator
+    default: tekton-releases
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Operator's latest
     default: "true"
@@ -36,8 +39,6 @@ spec:
   - name: koExtraArgs
     description: Extra args to be passed to ko
     default: "--preserve-import-paths"
-  - name: serviceAccountPath
-    description: The path to the service account file within the release-secret workspace
   - name: serviceAccountImagesPath
     description: The path to the service account file or credentials within the release-images-secret workspace
   - name: runTests
@@ -75,21 +76,24 @@ spec:
   tasks:
   - name: git-clone
     taskRef:
-      resolver: hub
+      resolver: bundles
       params:
+        - name: bundle
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
         - name: name
           value: git-clone
-        - name: version
-          value: "0.7"
+        - name: kind
+          value: task
     workspaces:
       - name: output
         workspace: workarea
         subPath: git
     params:
-    - name: url
-      value: https://$(params.package)
-    - name: revision
-      value: $(params.gitRevision)
+      - name: url
+        value: https://$(params.package)
+      - name: revision
+        value: $(params.gitRevision)
+
   - name: precheck
     runAfter:
     - git-clone
@@ -113,6 +117,7 @@ spec:
     - name: source-to-release
       workspace: workarea
       subPath: git
+
   - name: unit-tests
     runAfter:
     - precheck
@@ -136,6 +141,7 @@ spec:
     - name: source
       workspace: workarea
       subPath: git
+
   - name: fetch-component-releases
     runAfter:
     - unit-tests
@@ -157,6 +163,7 @@ spec:
       value: $(params.components)
     - name: TARGET_PLATFORMS
       value: $(params.kubeDistros)
+
   - name: build-test
     runAfter:
     - fetch-component-releases
@@ -180,6 +187,7 @@ spec:
     - name: source
       workspace: workarea
       subPath: git
+
   - name: publish-images-platform-kubernetes
     runAfter:
     - build-test
@@ -226,6 +234,7 @@ spec:
       subPath: bucket
     - name: release-secret
       workspace: release-images-secret
+
   - name: publish-images-platform-openshift
     runAfter:
     - build-test
@@ -272,6 +281,7 @@ spec:
       subPath: bucket
     - name: release-secret
       workspace: release-images-secret
+
   - name: publish-to-bucket
     runAfter:
     - publish-images-platform-kubernetes
@@ -280,9 +290,9 @@ spec:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
         - name: name
-          value: gcs-upload
+          value: oracle-cloud-storage-upload
         - name: kind
           value: task
     workspaces:
@@ -292,12 +302,17 @@ spec:
       workspace: workarea
       subPath: bucket
     params:
-    - name: location
-      value: $(params.releaseBucket)/previous/$(params.versionTag)
     - name: path
       value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
+    - name: bucketName
+      value: $(params.releaseBucket)
+    - name: objectPrefix
+      value: $(params.repoName)/previous/$(params.versionTag)/
+    - name: replaceExistingFiles
+      value: "true"
+    - name: recursive
+      value: "true"
+
   - name: publish-to-bucket-latest
     runAfter:
     - publish-images-platform-kubernetes
@@ -311,9 +326,9 @@ spec:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/gcs-upload:0.3
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
         - name: name
-          value: gcs-upload
+          value: oracle-cloud-storage-upload
         - name: kind
           value: task
     workspaces:
@@ -323,12 +338,19 @@ spec:
       workspace: workarea
       subPath: bucket
     params:
-    - name: location
-      value: $(params.releaseBucket)/latest
     - name: path
       value: $(params.versionTag)
-    - name: serviceAccountPath
-      value: $(params.serviceAccountPath)
+    - name: bucketName
+      value: $(params.releaseBucket)
+    - name: objectPrefix
+      value: $(params.repoName)/latest/
+    - name: replaceExistingFiles
+      value: "true"
+    - name: recursive
+      value: "true"
+    - name: deleteExtraFiles
+      value: "true"
+
   - name: report-bucket
     runAfter:
     - publish-to-bucket
@@ -337,10 +359,13 @@ spec:
       value: $(params.releaseBucket)
     - name: versionTag
       value: $(params.versionTag)
+    - name: repoName
+      value: $(params.repoName)
     taskSpec:
       params:
       - name: releaseBucket
       - name: versionTag
+      - name: repoName
       results:
       - name: release
         description: The full URL of the release file in the bucket
@@ -355,8 +380,9 @@ spec:
         image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
         script: |
           BASE_URL=$(echo "$(params.releaseBucket)/previous/$(params.versionTag)")
-          # If the bucket is in the gs:// return the corresponding public https URL
-          BASE_URL=$(echo ${BASE_URL} | sed 's,gs://,https://storage.googleapis.com/,g')
+          # Oracle Cloud Storage: Construct public URL
+          # Format: https://infra.tekton.dev/<releaseBucket>/<repoName>/previous/<versionTag>
+          BASE_URL="https://infra.tekton.dev/${BASE_URL}"
           echo "${BASE_URL}/release.yaml" > $(results.release.path)
           echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
           echo "${BASE_URL}/openshift-release.yaml" > $(results.openshift-release.path)


### PR DESCRIPTION
# Changes

This pull request updates the Tekton release pipeline and related documentation to support publishing releases to Oracle Cloud Infrastructure (OCI) instead of Google Cloud Storage (GCS). It introduces new pipeline parameters, updates task references, and revises documentation for the new release workflow. Following updates are included:

* Switched release artifact upload tasks from GCS (`gcs-upload`) to Oracle Cloud Storage (`oracle-cloud-storage-upload`), including new parameters for bucket and object prefix, and added flags for file replacement and recursion. 
* Updated release artifact public URLs from `https://storage.googleapis.com/` to `https://infra.tekton.dev/`, and changed URL construction logic to match Oracle Cloud Storage conventions. 
* Added new pipeline parameter `repoName` and updated usage throughout the pipeline for more flexible repository naming. 
* Changed default values for `imageRegistryRegions` and `releaseBucket` to empty and `tekton-releases` respectively, reflecting OCI usage.
* Updated task resolvers and references for `git-clone` to use bundles instead of hub, and revised workspace secrets to match OCI credentials.

**Documentation Updates**
* Revised release cheat sheet to reflect new OCI-based workflow, including updated commands, workspace secrets, and bucket paths. 
* Updated dogfooding cluster setup instructions to use OCI CLI commands and new context naming conventions.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind misc