### PR TITLE
Auto-upgrade Results PostgreSQL 13 ->15 

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/internal-db/db.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/internal-db/db.yaml
@@ -10,6 +10,56 @@ metadata:
   namespace: tekton-pipelines
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-results-postgres
+    app.kubernetes.io/part-of: tekton-results
+  name: postgres-upgrade-scripts
+  namespace: tekton-pipelines
+data:
+  postgres-wrapper.sh: |
+    #!/bin/bash
+    set -eu
+
+    PGDATA="${PGDATA:-/var/lib/pgsql/data}"
+    CURRENT_VERSION="15"
+    UPGRADE_FROM_VERSION="13"
+    PG_VERSION_FILE="$PGDATA/userdata/PG_VERSION"
+
+    echo "=== PostgreSQL Container Starting ==="
+
+    # Check if data directory exists with previous version
+    if [ -f "$PG_VERSION_FILE" ]; then
+        DATA_VERSION=$(cat "$PG_VERSION_FILE")
+        echo "Data directory PostgreSQL version: $DATA_VERSION"
+
+        # Check if upgrade is needed from version 13 to 15
+        if [ "$DATA_VERSION" = "$UPGRADE_FROM_VERSION" ]; then
+            echo "========================================="
+            echo "PostgreSQL Upgrade Mode Activated"
+            echo "Upgrading from PostgreSQL $UPGRADE_FROM_VERSION to PostgreSQL $CURRENT_VERSION"
+            echo "========================================="
+
+            # Set the POSTGRESQL_UPGRADE environment variable
+            # The sclorg PostgreSQL container will detect this and run pg_upgrade
+            export POSTGRESQL_UPGRADE="copy"
+
+            echo "Starting PostgreSQL with POSTGRESQL_UPGRADE=copy"
+        elif [ "$DATA_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "PostgreSQL data is already version $CURRENT_VERSION - starting normally"
+        else
+            echo "WARNING: Unexpected PostgreSQL version $DATA_VERSION"
+        fi
+    else
+        echo "No existing data found - PostgreSQL will initialize new database"
+    fi
+
+    # Execute the standard PostgreSQL container entrypoint
+    exec run-postgresql
+immutable: true
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -63,7 +113,7 @@ spec:
                 secretKeyRef:
                   key: POSTGRES_USER
                   name: tekton-results-postgres
-          image: registry.redhat.io/rhel9/postgresql-16@sha256:7e6de7395c848a5b22ec8256ecc6a9e422995caed528cf67773453a7287d5cbb
+          image: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
           name: postgres
           ports:
             - containerPort: 5432

--- a/docs/results-postgresql-upgrade-13-to-15.md
+++ b/docs/results-postgresql-upgrade-13-to-15.md
@@ -1,0 +1,96 @@
+# PostgreSQL Upgrade from Version 13 to 15
+
+## Overview
+
+This document describes the automatic PostgreSQL upgrade mechanism implemented in the Tekton Operator to handle upgrades from PostgreSQL 13 to PostgreSQL 15 for the Tekton Results internal database. This only applies for OpenShift deployments. Kubernetes deployments use Bitnami Postgres images which do not have the same versioning issue.
+
+## Problem Statement
+
+When upgrading the operator from a version using PostgreSQL 13 to a version using PostgreSQL 15, the PostgreSQL pod would fail to start because:
+
+1. PostgreSQL 15 cannot directly read the data directory structure created by PostgreSQL 13
+2. The sclorg PostgreSQL container supports upgrades via the `POSTGRESQL_UPGRADE` environment variable, but this must only be set **once**
+3. If the env var remains set after the initial upgrade, subsequent pod restarts will fail
+4. The operator reconciliation loop continuously reapplies manifests, making it difficult to set a "one-time" environment variable
+
+## Solution: Wrapper Script Approach
+
+The solution uses a **wrapper script** that automatically detects when an upgrade is needed and applies the `POSTGRESQL_UPGRADE` environment variable exactly once.
+
+### Key Components
+
+1. **ConfigMap with Wrapper Script** (`postgres-upgrade-scripts`)
+   - `postgres-wrapper.sh`: Checks PostgreSQL version and conditionally sets upgrade env var
+
+2. **Modified Main Container**
+   - Uses wrapper script as entrypoint instead of default `run-postgresql`
+   - Wrapper checks `PG_VERSION` file in data directory
+   - Sets `POSTGRESQL_UPGRADE=copy` if version 13 is detected
+   - Executes normal PostgreSQL startup
+
+### How It Works
+
+```
+Pod Starts
+    ↓
+Main Container: postgres
+    ↓
+Wrapper Script Executes
+    ↓
+Check /var/lib/pgsql/data/userdata/PG_VERSION
+    ↓
+    ├─ If file doesn't exist → Fresh install (no action)
+    ├─ If version = 15 → Start normally (no action)
+    └─ If version = 13 → Set POSTGRESQL_UPGRADE=copy
+    ↓
+Execute run-postgresql
+    ↓
+PostgreSQL starts (with or without upgrade)
+    ↓
+PG_VERSION updated to 15 after successful upgrade
+    ↓
+Next restart → Version = 15 → Start normally
+```
+
+## Implementation Details
+
+### Files Modified
+
+1. **`cmd/openshift/operator/kodata/static/tekton-results/internal-db/db.yaml`**
+   - Changed PostgreSQL image from version 16 to version 15
+   - Added `postgres-upgrade-scripts` ConfigMap with wrapper script
+
+2. **`pkg/reconciler/openshift/tektonresult/extension.go`**
+   - Added `injectPostgresUpgradeSupport()` transformer
+   - Transformer modifies postgres container to use wrapper script
+
+3. **`pkg/reconciler/kubernetes/tektonresult/transform.go`**
+   - Added same `injectPostgresUpgradeSupport()` transformer for Kubernetes platform
+
+### Transformer Behavior
+
+The `injectPostgresUpgradeSupport()` transformer:
+
+1. **Only applies to** the `tekton-results-postgres` StatefulSet
+2. **Modifies main container** to:
+   - Mount the scripts ConfigMap at `/upgrade-scripts`
+   - Use wrapper script as command: `/bin/bash /upgrade-scripts/postgres-wrapper.sh`
+3. **Adds ConfigMap volume** for the upgrade scripts
+
+## Rollback Considerations
+
+⚠️ **Important**: This is a **one-way upgrade**. Once the PostgreSQL data has been upgraded from v13 to v15, you cannot downgrade back to v13.
+
+If you need to rollback the operator to a version using PostgreSQL 13:
+1. The PostgreSQL 13 pod will fail to start with the upgraded data
+2. You must either:
+   - Restore from a backup taken before the upgrade
+   - Accept data loss and start fresh
+
+**Recommendation**: Always take a backup of the PostgreSQL PVC before upgrading the operator.
+
+## References
+
+- [PostgreSQL Container Upgrade Documentation](https://github.com/sclorg/postgresql-container/tree/master/15#upgrading-database)
+- [sclorg PostgreSQL Container Repository](https://github.com/sclorg/postgresql-container)
+- [Tekton Operator Documentation](https://github.com/tektoncd/operator)

--- a/hack/openshift/update-image-sha.sh
+++ b/hack/openshift/update-image-sha.sh
@@ -46,7 +46,7 @@ EOF
 declare -A IMAGES=(
   ["buildah"]="registry.redhat.io/rhel9/buildah"
   ["kn"]="registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8"
-  ["postgresql"]="registry.redhat.io/rhel9/postgresql-16"
+  ["postgresql"]="registry.redhat.io/rhel9/postgresql-15"
   ["skopeo-copy"]="registry.redhat.io/rhel9/skopeo"
   ["s2i"]="registry.redhat.io/source-to-image/source-to-image-rhel9"
   ["ubi-minimal"]="registry.redhat.io/ubi9/ubi-minimal"

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -210,7 +210,7 @@ image-substitutions:
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-- image: registry.redhat.io/rhel9/postgresql-16@sha256:6a6bde62273e318b6bc2ee75fa368abf71f71dc1c37f85f1230649f595fde951
+- image: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator

--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -116,6 +116,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		common.StatefulSetImages(resultImgs),
 		common.AddConfigMapValues(tektonResultleaderElectionConfig, instance.Spec.Performance.PerformanceLeaderElectionConfig),
 		common.UpdatePerformanceFlagsInDeploymentAndLeaderConfigMap(&instance.Spec.Performance, tektonResultleaderElectionConfig, resultWatcherDeployment, resultWatcherContainer),
+		// Note: PostgreSQL upgrade transformer is NOT needed for Kubernetes
 	}
 
 	if instance.Spec.Performance.StatefulsetOrdinals != nil && *instance.Spec.Performance.StatefulsetOrdinals {


### PR DESCRIPTION
Added a wrapper script for the Postgres image which checks the version of the running DB directory structure and trigger a one time upgrade if required levereging the tools provided with the image. Easy to remove after two or three versions assuming all existing deployments have switched to version 15.

Assisted-by: Cursor

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Update Tekton Results PostgreSQL dependency to version 15. The update requires transformation of the directory structure used by PostgreSQL. This only applies in cases where Tekton Results is using the default deployment of PostgreSQL image. Such deployment is only recommended for preview and testing purposes and there is no support for such deployments or guarantees for the directory structure migration. For production environments it is recommended that Tekton Results is used external DB allowing proper scaling and management.
```
