### PR TITLE
revert postgres image pin from 16 to 13 until upgrade is fixed

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -88,7 +88,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: tekton-operator-controller-config-leader-election
         - name: IMAGE_HUB_TEKTON_HUB_DB
-          value: registry.redhat.io/rhel9/postgresql-16@sha256:1dbb6d28b453f8f1b5bc52f4b3281c3d5c40500ad0a2f12a5b154e1774166b55
+          value: registry.redhat.io/rhel9/postgresql-13@sha256:5105fc7494c8e9886204951ea6eed0a04dcc638ea65a2e1c15df5ebf99aae356
         - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
           value: registry.redhat.io/rhel9/buildah@sha256:18453ab0a62154283aaf4c45efd7543d1c8ecca1aebae46dedc7ddc0f410b232
         - name: IMAGE_ADDONS_PARAM_KN_IMAGE

--- a/hack/openshift/update-image-sha.sh
+++ b/hack/openshift/update-image-sha.sh
@@ -46,7 +46,7 @@ EOF
 declare -A IMAGES=(
   ["buildah"]="registry.redhat.io/rhel9/buildah"
   ["kn"]="registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel8"
-  ["postgresql"]="registry.redhat.io/rhel9/postgresql-16"
+  ["postgresql"]="registry.redhat.io/rhel9/postgresql-13"
   ["skopeo-copy"]="registry.redhat.io/rhel9/skopeo"
   ["s2i"]="registry.redhat.io/source-to-image/source-to-image-rhel9"
   ["ubi-minimal"]="registry.redhat.io/ubi9/ubi-minimal"

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -210,7 +210,7 @@ image-substitutions:
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-- image: registry.redhat.io/rhel9/postgresql-16@sha256:6a6bde62273e318b6bc2ee75fa368abf71f71dc1c37f85f1230649f595fde951
+- image: registry.redhat.io/rhel9/postgresql-13@sha256:5105fc7494c8e9886204951ea6eed0a04dcc638ea65a2e1c15df5ebf99aae356
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator


### PR DESCRIPTION
# Changes
- Revert changes to postgres image form 16 to 13, unti having the upgrade and migration issue resolved

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
