### PR TITLE
Switch rollout hash from MD5 to truncated SHA-256 (FIPS compliance)

### DIFF
--- a/pkg/reconciler/kubernetes/tektondashboard/testdata/test-dashboard-transformer-updated.yaml
+++ b/pkg/reconciler/kubernetes/tektondashboard/testdata/test-dashboard-transformer-updated.yaml
@@ -404,7 +404,7 @@ spec:
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/part-of: tekton-dashboard
         app.kubernetes.io/version: v0.48.0
-        operator.tekton.dev/deployment-spec-applied-hash: e521024acd6c6a280dc53fb4de0a6725
+        operator.tekton.dev/deployment-spec-applied-hash: bcc353ffd9dbb45db12ebd80c6abbd27
       name: tekton-dashboard
     spec:
       containers:

--- a/pkg/reconciler/shared/hash/hash.go
+++ b/pkg/reconciler/shared/hash/hash.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hash
 
 import (
-	"crypto/md5"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -35,18 +34,6 @@ func Compute(obj interface{}) (string, error) {
 	hashSha256 := sha256.New()
 	hashSha256.Write(d)
 	return fmt.Sprintf("%x", hashSha256.Sum(nil)), nil
-}
-
-// Compute generates an unique hash/string for the object pass to it.
-// with md5
-func ComputeMd5(obj interface{}) (string, error) {
-	d, err := json.Marshal(obj)
-	if err != nil {
-		return "", err
-	}
-	hashMd5 := md5.New()
-	hashMd5.Write(d)
-	return fmt.Sprintf("%x", hashMd5.Sum(nil)), nil
 }
 
 // computes has for the given directory, tasks the directory and files recursively

--- a/pkg/reconciler/shared/hash/hash_test.go
+++ b/pkg/reconciler/shared/hash/hash_test.go
@@ -26,10 +26,6 @@ func TestCompute(t *testing.T) {
 	testHashFunc(t, Compute)
 }
 
-func TestComputeMd5(t *testing.T) {
-	testHashFunc(t, ComputeMd5)
-}
-
 func testHashFunc(t *testing.T, computeFunc func(obj interface{}) (string, error)) {
 	tp := &v1alpha1.TektonPipeline{
 		Spec: v1alpha1.TektonPipelineSpec{


### PR DESCRIPTION
# Changes
- The label operator.tekton.dev/deployment-spec-applied-hash now uses SHA‑256 (hex), truncated to 32 chars, instead of MD5.
- Purpose: avoid failures in strict FIPS (GODEBUG=fips140=only).
````
lifecycle.github.com.tektoncd.operator.pkg.reconciler.kubernetes.tektonpipeline.reconciler.00-of-01\"","commit":"78470dd-dirty","knative.dev/pod":"openshift-pipelines-operator-7d796d46-fx6ft"}
panic: crypto/md5: use of MD5 is not allowed in FIPS 140-only mode
````
- Upgrade test done manually, and successful

Fixes https://github.com/tektoncd/operator/issues/3008

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Switch rollout hash from MD5 to truncated SHA-256 for FIPS-140 compliance
```
