### PR TITLE
cherry-pick: PR#2995 docs update for event based pruner

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -566,21 +566,108 @@ platforms:
 
 **NOTE**: OpenShiftPipelinesAsCode is currently available for the OpenShift Platform only.
 
-### **Tech Preview** Event based pruner 
+### Event based pruner 
 
-The `tektonpruner` section in the TektonConfig spec allows  to manage the event-driven Tekton Pruner, which enables configuration-based cleanup of Tekton resources.
+The `tektonpruner` section in the TektonConfig spec allows you to manage the event-driven Tekton Pruner, which enables configuration-based cleanup of Tekton resources such as PipelineRuns and TaskRuns.
 
 > Important: This component is **disabled by default**. To enable the event-based pruner, the existing job-based pruner `pruner` **MUST** be disabled.
 
+#### Basic Configuration
+
 ```yaml
+  pruner:
+    disabled: true  # Must disable job-based pruner
   tektonpruner:
-    disabled: true
+    disabled: false  # Enable event-based pruner
+    global-config:
+      enforcedConfigLevel: global  # Options: global, namespace
+      ttlSecondsAfterFinished: 3600  # Delete runs older than 1 hour (optional)
+      historyLimit: 100              # Keep only 100 runs total (optional)
+      successfulHistoryLimit: 50     # Keep only 50 successful runs (optional)
+      failedHistoryLimit: 20         # Keep only 20 failed runs (optional)
     options: {}
 ```
-**Configuration Notes :**
-- In this Tech Preview, only enabled/disabled status is configurable via `tektonconfig` spec.
 
-- For all other  [configurations](https://github.com/tektoncd/pruner/blob/main/docs/tutorials/getting-started.md#basic-pruner-configuration)(e.g., TTLs, history limits), use the ConfigMap: `tekton-pruner-default-spec`
+#### Configuration Levels
+
+The `enforcedConfigLevel` determines the configuration hierarchy:
+
+- **`global`**: Cluster-wide defaults apply to all namespaces (no namespace overrides allowed)
+- **`namespace`**: Allows namespace-level overrides via ConfigMaps in individual namespaces
+
+#### Pruning Fields
+
+You can specify any combination of these fields. The pruner deletes runs when **any one** of the specified conditions is met:
+
+- **`ttlSecondsAfterFinished`**: Time in seconds to retain completed runs before pruning
+- **`historyLimit`**: Maximum number of runs to retain for each status (applies independently to both successful and failed runs)
+- **`successfulHistoryLimit`**: Maximum number of successful runs to retain
+- **`failedHistoryLimit`**: Maximum number of failed runs to retain
+
+**Note:** If `successfulHistoryLimit` or `failedHistoryLimit` is not specified, `historyLimit` value is used as fallback for that status type.
+
+#### Namespace-Level Configuration
+
+Configure different default pruning policies for specific namespaces in the global config:
+
+```yaml
+  tektonpruner:
+    disabled: false
+    global-config:
+      enforcedConfigLevel: namespace
+      historyLimit: 100  # Global default
+      namespaces:
+        dev-namespace:
+          historyLimit: 50
+          ttlSecondsAfterFinished: 1800  # 30 minutes for dev
+        prod-namespace:
+          successfulHistoryLimit: 200
+          failedHistoryLimit: 50
+          ttlSecondsAfterFinished: 86400  # 24 hours for prod
+```
+
+> **Note:** For advanced configurations including resource-level selectors and per-namespace overrides via ConfigMaps, refer to the [TektonPruner documentation](./TektonPruner.md).
+
+#### Complete Example
+
+```yaml
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  targetNamespace: tekton-pipelines
+  profile: all
+  pruner:
+    disabled: true  # Disable job-based pruner
+  tektonpruner:
+    disabled: false
+    global-config:
+      enforcedConfigLevel: namespace
+      historyLimit: 100
+      ttlSecondsAfterFinished: 7200  # 2 hours
+      namespaces:
+        tekton-pipelines:
+          historyLimit: 200
+          successfulHistoryLimit: 150
+          failedHistoryLimit: 50
+        dev:
+          ttlSecondsAfterFinished: 3600  # 1 hour
+          historyLimit: 50
+    options:
+      disabled: false
+      deployments:
+        tekton-pruner-controller:
+          spec:
+            replicas: 1
+```
+
+**Configuration Notes:**
+- Both pruners (job-based and event-based) cannot be enabled simultaneously
+- The event-based pruner responds to resource events in real-time, providing more efficient cleanup
+- When `enforcedConfigLevel` is set to `namespace`, individual namespaces can override these settings using ConfigMaps
+
+
 
 ### Additional fields as `options`
 

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
@@ -336,7 +336,7 @@ spec:
     - Tekton Hub (tech-preview): {{ with index .Versions "hub"}}{{ .Version }}{{end}}
     - Tekton Results (tech-preview): {{ with index .Versions "results"}}{{ .Version }}{{end}}
     - Manual Approval Gate (tech-preview): {{ with index .Versions "manual-approval-gate"}}{{ .Version }}{{end}}
-    - Tekton Pruner (tech-preview): {{ with index .Versions "pruner"}}{{ .Version }}{{end}}
+    - Tekton Pruner: {{ with index .Versions "pruner"}}{{ .Version }}{{end}}
 
     ## Getting Started
 


### PR DESCRIPTION
# Changes

cherry-pick PR:https://github.com/tektoncd/operator/pull/2995. Updates pruner version in openshift csv & doc updates

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
