### PR TITLE
Auto upgrade Hub PostgreSQL 13 to 15

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-hub/postgresql-cm/cm.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-hub/postgresql-cm/cm.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: tekton-hub-postgres
+    app.kubernetes.io/part-of: tekton-hub
+  name: tekton-hub-postgres-upgrade-scripts
+data:
+  postgres-wrapper.sh: |
+    #!/bin/bash
+    set -eu
+    PGDATA="${PGDATA:-/var/lib/pgsql/data}"
+    CURRENT_VERSION="15"
+    UPGRADE_FROM_VERSION="13"
+    echo "=== PostgreSQL Container Starting ==="
+
+    # The sclorg PostgreSQL containers use a subdirectory for data
+    # Check both $PGDATA and $PGDATA/userdata for existing data
+    PG_VERSION_FILE=""
+    if [ -f "$PGDATA/PG_VERSION" ]; then
+        PG_VERSION_FILE="$PGDATA/PG_VERSION"
+    elif [ -f "$PGDATA/userdata/PG_VERSION" ]; then
+        PG_VERSION_FILE="$PGDATA/userdata/PG_VERSION"
+        echo "Found existing data in userdata subdirectory"
+    fi
+
+    # Check if data directory exists and has version file
+    if [ -n "$PG_VERSION_FILE" ]; then
+        DATA_VERSION=$(cat "$PG_VERSION_FILE")
+        echo "Data directory PostgreSQL version: $DATA_VERSION"
+        # Check if upgrade is needed from version 13 to 15
+        if [ "$DATA_VERSION" = "$UPGRADE_FROM_VERSION" ]; then
+            echo "========================================="
+            echo "PostgreSQL Upgrade Mode Activated"
+            echo "Upgrading from PostgreSQL $UPGRADE_FROM_VERSION to PostgreSQL $CURRENT_VERSION"
+            echo "This is a ONE-TIME operation"
+            echo "========================================="
+            # Set the POSTGRESQL_UPGRADE environment variable
+            # The sclorg PostgreSQL container will detect this and run pg_upgrade
+            export POSTGRESQL_UPGRADE="copy"
+            echo "Starting PostgreSQL with POSTGRESQL_UPGRADE=copy"
+            echo "Please monitor logs for upgrade progress..."
+        elif [ "$DATA_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "PostgreSQL data is already version $CURRENT_VERSION"
+            echo "Starting normally"
+        else
+            echo "WARNING: Unexpected PostgreSQL data version: $DATA_VERSION"
+            echo "Expected either $CURRENT_VERSION or $UPGRADE_FROM_VERSION"
+            echo "Starting PostgreSQL and letting it handle the situation"
+        fi
+    else
+        echo "No PG_VERSION file found - fresh installation"
+        echo "PostgreSQL will initialize a new database"
+    fi
+    # Execute the standard PostgreSQL container entrypoint
+    # This is the default command from the sclorg postgresql container
+    exec run-postgresql
+immutable: true

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -88,7 +88,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: tekton-operator-controller-config-leader-election
         - name: IMAGE_HUB_TEKTON_HUB_DB
-          value: registry.redhat.io/rhel9/postgresql-16@sha256:684ff665e4d0408565be6bb5472094bb07e114d84e5ff454b4ae838722fcc1aa
+          value: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
         - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
           value: registry.redhat.io/rhel9/buildah@sha256:4e604d18fc609d25b2fc99814281944acaac78e8cd5e47b8359709b8b505db86
         - name: IMAGE_ADDONS_PARAM_KN_IMAGE

--- a/pkg/reconciler/openshift/tektonhub/extension_test.go
+++ b/pkg/reconciler/openshift/tektonhub/extension_test.go
@@ -43,9 +43,64 @@ func TestUpdateDbDeployment(t *testing.T) {
 	env := d.Spec.Template.Spec.Containers[0].Env
 	assert.Equal(t, env[0].Name, "POSTGRESQL_DATABASE")
 
+	// Verify PGDATA environment variable value is updated
+	var pgdataValue string
+	for _, e := range env {
+		if e.Name == "PGDATA" {
+			pgdataValue = e.Value
+			break
+		}
+	}
+	assert.Equal(t, pgdataValue, "/var/lib/pgsql/data")
+
 	mountPath := d.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
 	assert.Equal(t, mountPath, "/var/lib/pgsql/data")
 
 	cmd := d.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command
 	assert.Equal(t, strings.Contains(cmd[2], "POSTGRESQL_USER"), true)
+}
+
+func TestInjectPostgresUpgradeSupport(t *testing.T) {
+	testData := path.Join("testdata", "update-db-deployment.yaml")
+
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+
+	newManifest, err := manifest.Transform(injectPostgresUpgradeSupport())
+	assert.NilError(t, err)
+
+	d := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newManifest.Resources()[0].Object, d)
+	assert.NilError(t, err)
+
+	// Verify command is set to use the wrapper script
+	command := d.Spec.Template.Spec.Containers[0].Command
+	assert.Equal(t, len(command), 2)
+	assert.Equal(t, command[0], "/bin/bash")
+	assert.Equal(t, command[1], "/upgrade-scripts/postgres-wrapper.sh")
+
+	// Verify volume mount for upgrade scripts is added
+	volumeMounts := d.Spec.Template.Spec.Containers[0].VolumeMounts
+	var upgradeScriptsMountFound bool
+	for _, vm := range volumeMounts {
+		if vm.Name == "upgrade-scripts" {
+			upgradeScriptsMountFound = true
+			assert.Equal(t, vm.MountPath, "/upgrade-scripts")
+			break
+		}
+	}
+	assert.Equal(t, upgradeScriptsMountFound, true)
+
+	// Verify volume for upgrade scripts ConfigMap is added
+	volumes := d.Spec.Template.Spec.Volumes
+	var upgradeScriptsVolumeFound bool
+	for _, vol := range volumes {
+		if vol.Name == "upgrade-scripts" {
+			upgradeScriptsVolumeFound = true
+			assert.Equal(t, vol.ConfigMap.Name, "tekton-hub-postgres-upgrade-scripts")
+			assert.Equal(t, *vol.ConfigMap.DefaultMode, int32(0755))
+			break
+		}
+	}
+	assert.Equal(t, upgradeScriptsVolumeFound, true)
 }


### PR DESCRIPTION
- This patch adds a wrapper script which checks the
 version of the running DB directory structure and
 trigger a one time upgrade if required.
- Fixed a bug in the Hub API Transformer method


This PR is copied from #2983. Thanks to @enarha for the original implementation.


# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Upgrade the Tekton Hub PostgreSQL container image from version 13 to version 15 to enhanced security and long-term support.
```
