### PR TITLE
fix: replace webhook namespaceselector value to target namespace

### DIFF
--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -852,6 +852,94 @@ func TestAddConfigMapValues(t *testing.T) {
 	}
 }
 
+func TestReplaceNamespaceInWebhookNamespaceSelector(t *testing.T) {
+	target := "openshift-pipelines"
+
+	// Build a minimal ValidatingWebhookConfiguration with two webhooks:
+	// 1) In selector referencing tekton-pipelines (should be replaced)
+	// 2) NotIn selector excluding kube-* namespaces (should remain unchanged)
+	vwc := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "admissionregistration.k8s.io/v1",
+		"kind":       "ValidatingWebhookConfiguration",
+		"metadata": map[string]interface{}{
+			"name": "validation.webhook.pruner.tekton.dev",
+		},
+		"webhooks": []interface{}{
+			map[string]interface{}{
+				"name": "validation.webhook.pruner.tekton.dev.global",
+				"clientConfig": map[string]interface{}{
+					"service": map[string]interface{}{ // this is NOT modified by the transformer
+						"name":      "tekton-pruner-webhook",
+						"namespace": "tekton-pipelines",
+						"path":      "/validate-configmap",
+					},
+				},
+				"namespaceSelector": map[string]interface{}{
+					"matchExpressions": []interface{}{
+						map[string]interface{}{
+							"key":      "kubernetes.io/metadata.name",
+							"operator": "In",
+							"values":   []interface{}{"tekton-pipelines"},
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "validation.webhook.pruner.tekton.dev.namespace",
+				"namespaceSelector": map[string]interface{}{
+					"matchExpressions": []interface{}{
+						map[string]interface{}{
+							"key":      "kubernetes.io/metadata.name",
+							"operator": "NotIn",
+							"values":   []interface{}{"kube-system", "kube-public", "kube-node-lease"},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{vwc}))
+	assertNoError(t, err)
+
+	manifest, err = manifest.Transform(ReplaceNamespaceInWebhookNamespaceSelector(target))
+	assertNoError(t, err)
+
+	got := manifest.Resources()[0].Object
+
+	// Assert first webhook In selector value replaced to target
+	webhooks, found, err := unstructured.NestedSlice(got, "webhooks")
+	assertNoError(t, err)
+	if !found || len(webhooks) != 2 {
+		t.Fatalf("expected 2 webhooks, got %v", len(webhooks))
+	}
+
+	wh0 := webhooks[0].(map[string]interface{})
+	nsSel0, _, _ := unstructured.NestedMap(wh0, "namespaceSelector")
+	mexprs0, _ := nsSel0["matchExpressions"].([]interface{})
+	expr0 := mexprs0[0].(map[string]interface{})
+	vals0, _ := expr0["values"].([]interface{})
+	assert.Equal(t, target, vals0[0].(string))
+
+	// Assert second webhook NotIn selector unchanged
+	wh1 := webhooks[1].(map[string]interface{})
+	nsSel1, _, _ := unstructured.NestedMap(wh1, "namespaceSelector")
+	mexprs1, _ := nsSel1["matchExpressions"].([]interface{})
+	expr1 := mexprs1[0].(map[string]interface{})
+	vals1, _ := expr1["values"].([]interface{})
+	assert.Equal(t, "kube-system", vals1[0].(string))
+	assert.Equal(t, "kube-public", vals1[1].(string))
+	assert.Equal(t, "kube-node-lease", vals1[2].(string))
+
+	// Assert clientConfig.service.namespace was not modified by transformer
+	svcMap, found, err := unstructured.NestedMap(wh0, "clientConfig", "service")
+	assertNoError(t, err)
+	if !found {
+		t.Fatalf("expected clientConfig.service present")
+	}
+	assert.Equal(t, "tekton-pipelines", svcMap["namespace"].(string))
+}
+
 func TestInjectLabelOnNamespace(t *testing.T) {
 	t.Run("TestInjectLabel", func(t *testing.T) {
 		testData := path.Join("testdata", "test-namespace-inject.yaml")


### PR DESCRIPTION
# Changes

This pull request introduces a new transformer to handle namespace replacement in `ValidatingWebhookConfiguration` resources and adds unit tests to verify its behavior.

## Background

During release testing of the event-based pruner, we found that webhook validations were not being applied. The root cause was that the namespaceSelector in the webhook configuration always pointed to tekton-pipelines, regardless of the target namespace. This transformer resolves that issue by ensuring the namespaceSelector is updated appropriately during resource transformation.

### Namespace selector transformation

* Added the `ReplaceNamespaceInWebhookNamespaceSelector` transformer to `pkg/reconciler/common/transformers.go`, which replaces occurrences of the default namespace in `namespaceSelector.matchExpressions.values` within `ValidatingWebhookConfiguration` resources with the target namespace. This ensures correct scoping of webhook configurations when deploying to custom namespaces.
* Integrated the new transformer into the main `transformers` function so it is applied during resource reconciliation.

### Testing improvements

* Added a dedicated unit test `TestReplaceNamespaceInWebhookNamespaceSelector` in `pkg/reconciler/common/transformers_test.go` to verify that the transformer correctly replaces the namespace in `In` selectors, leaves `NotIn` selectors unchanged, and does not modify unrelated fields like `clientConfig.service.namespace`.… target namespace

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind bug

Assisted-by: Co-Pilot(claude Sonnet 4.5)