### PR TITLE
fix: apply pruner webhook validation to tektonconfig

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -102,8 +102,13 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
-	// validate pruner specifications
+	// validate job-based pruner specifications (legacy)
 	errs = errs.Also(tc.Spec.Pruner.validate())
+
+	// validate TektonPruner (event-based) configuration using tektoncd/pruner webhook validation
+	// This ensures that the pruner config in TektonConfig is validated using the same
+	// comprehensive validation logic as the standalone TektonPruner resource
+	errs = errs.Also(tc.Spec.TektonPruner.validateInTektonConfig("spec"))
 
 	if !tc.Spec.Addon.IsEmpty() {
 		errs = errs.Also(validateAddonParams(tc.Spec.Addon.Params, "spec.addon.params"))

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pruner/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/yaml"
+)
+
+// Validate performs comprehensive validation on TektonPruner using the tektoncd/pruner webhook validation
+func (tp *TektonPruner) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// Skip validation if the resource is being deleted
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
+	// Validate that only one instance of TektonPruner exists with the correct name
+	if tp.GetName() != TektonPrunerResourceName {
+		errMsg := fmt.Sprintf("metadata.name, Only one instance of TektonPruner is allowed by name, %s", TektonPrunerResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(tp.GetName(), errMsg))
+	}
+
+	// Validate common spec fields (targetNamespace, etc.)
+	errs = errs.Also(tp.Spec.CommonSpec.validate("spec"))
+
+	// Disallow updating the targetNamespace
+	if apis.IsInUpdate(ctx) {
+		existingTP := apis.GetBaseline(ctx).(*TektonPruner)
+		if existingTP.Spec.GetTargetNamespace() != tp.Spec.GetTargetNamespace() {
+			errs = errs.Also(apis.ErrGeneric("Doesn't allow to update targetNamespace, delete existing TektonPruner and create the updated TektonPruner", "spec.targetNamespace"))
+		}
+	}
+
+	// Validate the TektonPrunerConfig using tektoncd/pruner webhook validation
+	errs = errs.Also(tp.Spec.Pruner.validate("spec"))
+
+	// Validate additional options
+	errs = errs.Also(tp.Spec.Options.validate("spec.options"))
+
+	return errs
+}
+
+// validate validates the Pruner configuration by leveraging tektoncd/pruner webhook validation
+// This ensures consistency with the upstream pruner validation logic
+func (p *Pruner) validate(path string) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// If pruner is disabled, no validation is required
+	if p.IsDisabled() {
+		return errs
+	}
+
+	// Validate the TektonPrunerConfig using tektoncd/pruner's validation functions
+	errs = errs.Also(p.TektonPrunerConfig.validate(path))
+
+	return errs
+}
+
+// validate validates the TektonPrunerConfig by calling tektoncd/pruner's validation functions
+// This delegates validation to the upstream pruner package to avoid code duplication
+func (tpc *TektonPrunerConfig) validate(path string) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// Create a ConfigMap object to leverage tektoncd/pruner's validation functions
+	// This allows us to reuse the comprehensive validation logic from the pruner package
+	cm, err := tpc.toConfigMap()
+	if err != nil {
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("failed to convert TektonPrunerConfig to ConfigMap: %v", err), path+".global-config"))
+		return errs
+	}
+
+	// Use tektoncd/pruner's ValidateConfigMap function
+	// This function performs comprehensive validation including:
+	// - EnforcedConfigLevel validation (global, namespace, resource)
+	// - TTLSecondsAfterFinished validation (non-negative, within limits)
+	// - SuccessfulHistoryLimit validation (non-negative, within limits)
+	// - FailedHistoryLimit validation (non-negative, within limits)
+	// - HistoryLimit validation (non-negative, within limits)
+	// - Namespace-level config validation (if global limits are set)
+	// - Selector validation (ensures selectors are only in namespace-level ConfigMaps)
+	if err := config.ValidateConfigMap(cm); err != nil {
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("pruner config validation failed: %v", err), path+".global-config"))
+	}
+
+	return errs
+}
+
+// toConfigMap converts TektonPrunerConfig to a corev1.ConfigMap for validation
+// This is a helper function to leverage tektoncd/pruner's ConfigMap-based validation
+func (tpc *TektonPrunerConfig) toConfigMap() (*corev1.ConfigMap, error) {
+	// Marshal the GlobalConfig to YAML
+	data, err := yaml.Marshal(tpc.GlobalConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GlobalConfig to YAML: %w", err)
+	}
+
+	// Create a ConfigMap with the global-config data
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			config.PrunerGlobalConfigKey: string(data),
+		},
+	}
+
+	return cm, nil
+}
+
+// validatePrunerConfigInTektonConfig validates the Pruner configuration in TektonConfig
+// This is used by TektonConfig validation to ensure pruner settings are valid
+func (p *Pruner) validateInTektonConfig(path string) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// If TektonPruner (event-based) is disabled, no validation is required
+	if p.IsDisabled() {
+		return errs
+	}
+
+	// Validate the TektonPrunerConfig using tektoncd/pruner's validation functions
+	errs = errs.Also(p.TektonPrunerConfig.validate(path + ".tektonpruner"))
+
+	return errs
+}

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pruner/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
+)
+
+func TestTektonPruner_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pruner  *TektonPruner
+		wantErr bool
+	}{
+		{
+			name: "valid tektonpruner with global config",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: TektonPrunerResourceName,
+				},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									TTLSecondsAfterFinished: ptr.Int32(3600),
+									SuccessfulHistoryLimit:  ptr.Int32(50),
+									FailedHistoryLimit:      ptr.Int32(20),
+									HistoryLimit:            ptr.Int32(100),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid name - only 'pruner' is allowed",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid-name"},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid ttlSecondsAfterFinished - negative value",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									TTLSecondsAfterFinished: ptr.Int32(-100),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid successfulHistoryLimit - negative value",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									SuccessfulHistoryLimit: ptr.Int32(-50),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid failedHistoryLimit - negative value",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									FailedHistoryLimit: ptr.Int32(-20),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid historyLimit - negative value",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									HistoryLimit: ptr.Int32(-100),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid enforcedConfigLevel - invalid value",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									EnforcedConfigLevel: (*config.EnforcedConfigLevel)(ptr.String("invalid")),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid enforcedConfigLevel - global",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									EnforcedConfigLevel:     (*config.EnforcedConfigLevel)(ptr.String("global")),
+									TTLSecondsAfterFinished: ptr.Int32(3600),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid - disabled pruner (no validation required)",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(true),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid - namespace-level config with selectors in global config (should fail)",
+			pruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									TTLSecondsAfterFinished: ptr.Int32(3600),
+								},
+								Namespaces: map[string]config.NamespaceSpec{
+									"test-namespace": {
+										PrunerConfig: config.PrunerConfig{
+											TTLSecondsAfterFinished: ptr.Int32(1800),
+										},
+										PipelineRuns: []config.ResourceSpec{
+											{
+												Name: "my-pipeline",
+												Selector: []config.SelectorSpec{
+													{
+														MatchLabels: map[string]string{
+															"app": "test",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true, // Selectors are not allowed in global ConfigMap
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pruner.Validate(context.TODO())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TektonPruner.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTektonPruner_ValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldPruner  *TektonPruner
+		newPruner  *TektonPruner
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name: "valid update - same targetNamespace",
+			oldPruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+					},
+				},
+			},
+			newPruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+						TektonPrunerConfig: TektonPrunerConfig{
+							GlobalConfig: config.GlobalConfig{
+								PrunerConfig: config.PrunerConfig{
+									TTLSecondsAfterFinished: ptr.Int32(7200),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid update - changing targetNamespace",
+			oldPruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "tekton-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+					},
+				},
+			},
+			newPruner: &TektonPruner{
+				ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+				Spec: TektonPrunerSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "openshift-pipelines",
+					},
+					Pruner: Pruner{
+						Disabled: ptr.Bool(false),
+					},
+				},
+			},
+			wantErr:    true,
+			errMessage: "targetNamespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := apis.WithinUpdate(context.Background(), tt.oldPruner)
+			err := tt.newPruner.Validate(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TektonPruner.Validate() on update error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMessage != "" {
+				if !containsString(err.Error(), tt.errMessage) {
+					t.Errorf("TektonPruner.Validate() error message = %v, want to contain %v", err.Error(), tt.errMessage)
+				}
+			}
+		})
+	}
+}
+
+func TestTektonPruner_ValidateDelete(t *testing.T) {
+	pruner := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{Name: TektonPrunerResourceName},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Pruner: Pruner{
+				Disabled: ptr.Bool(false),
+			},
+		},
+	}
+
+	err := pruner.Validate(apis.WithinDelete(context.Background()))
+	if err != nil {
+		t.Errorf("TektonPruner.Validate() on Delete expected no error, but got one: %v", err)
+	}
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/pkg/reconciler/kubernetes/tektonpruner/pruner_installerset.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/pruner_installerset.go
@@ -41,6 +41,21 @@ const (
 
 func (r *Reconciler) ensureInstallerSets(ctx context.Context, tp *v1alpha1.TektonPruner) error {
 	logger := logging.FromContext(ctx)
+
+	// Create Config InstallerSet FIRST (containing the ConfigMap that the controller needs)
+	// This ensures the ConfigMap exists before the controller pod starts
+	if err := r.ensureConfigInstallerSet(ctx, tp); err != nil {
+		msg := fmt.Sprintf("Config InstallerSet Reconcilation failed: %s", err.Error())
+		logger.Error(msg)
+		if errors.Is(err, v1alpha1.REQUEUE_EVENT_AFTER) {
+			return err
+		}
+		tp.Status.MarkInstallerSetNotReady(msg)
+		return err
+	}
+
+	// Create Main InstallerSet SECOND (containing controller and webhook deployments)
+	// By this point, the ConfigMap should exist, preventing controller startup failures
 	filteredManifest := r.manifest.Filter(mf.Not(mf.All(mf.ByKind("ConfigMap"), mf.ByName(config.PrunerConfigMapName))))
 	if err := r.installerSetClient.MainSet(ctx, tp, &filteredManifest, filterAndTransform(r.extension)); err != nil {
 		msg := fmt.Sprintf("Main Reconcilation failed: %s", err.Error())
@@ -49,17 +64,9 @@ func (r *Reconciler) ensureInstallerSets(ctx context.Context, tp *v1alpha1.Tekto
 			return err
 		}
 		tp.Status.MarkInstallerSetNotReady(msg)
+		return err
 	}
 
-	if err := r.ensureConfigInstallerSet(ctx, tp); err != nil {
-		msg := fmt.Sprintf("Config InstallerSet Reconcilation failed: %s", err.Error())
-		logger.Error(msg)
-		if errors.Is(err, v1alpha1.REQUEUE_EVENT_AFTER) {
-			return err
-		}
-		tp.Status.MarkInstallerSetNotReady(msg)
-
-	}
 	return nil
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -37,6 +37,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonHub):      &v1alpha1.TektonHub{},
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonResult):   &v1alpha1.TektonResult{},
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonChain):    &v1alpha1.TektonChain{},
+	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonPruner):   &v1alpha1.TektonPruner{},
 }
 
 func SetTypes(platform string) {


### PR DESCRIPTION
# Changes
This pull request adds webhook-based validation for the `TektonPruner` resource by reusing the upstream `tektoncd/pruner` validation logic.

Previously, invalid TektonConfig values for the pruner (such as negative numbers) were not rejected during validation. The invalid configuration would be accepted by the TektonConfig admission webhook, but later fail when the installer set attempted to update the corresponding ConfigMap, because the upstream pruner webhook would correctly reject those values.

This PR resolves that gap by invoking the pruner’s upstream validation function as part of TektonConfig validation. As a result, invalid pruner configuration is now caught early during TektonConfig admission, preventing inconsistent states and ensuring validation behavior is aligned between the operator and upstream Tekton.

Registered the new `TektonPruner` resource type with the webhook server in `webhook.go`, enabling admission control for pruner resources.

This PR also includes a sequencing issue with configmap installerset- `pkg/reconciler/kubernetes/tektonpruner/pruner_installerset.go`  which had the deployment of pruner controller before the configmap. This would create an issue because, the configmap is a prerequisite for the controllers configmap watcher to start.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind bug

Assisted by: Co-Pilot(Claude Sonnet 4.5)