### PR TITLE
WIP fix: invoke validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 replace (
 	github.com/alibabacloud-go/cr-20160607 => github.com/vdemeester/cr-20160607 v1.0.1
 	github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5
+	github.com/tektoncd/pruner => github.com/anithapriyanatarajan/pruner v0.0.0-20251129003540-fd45a2f79b3e
 	k8s.io/api => k8s.io/api v0.32.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.9
 	k8s.io/apimachinery => k8s.io/apimachinery v0.32.4

--- a/go.sum
+++ b/go.sum
@@ -1471,6 +1471,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/anithapriyanatarajan/pruner v0.0.0-20251129003540-fd45a2f79b3e h1:F7OW7fcoavQDCnfTaNIUrVhjnnraHrVvz13Ky16qmMc=
+github.com/anithapriyanatarajan/pruner v0.0.0-20251129003540-fd45a2f79b3e/go.mod h1:W4inEon/hXbdTEOJo7FeLNJ50aF4PO1yQu304sBF0Hw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
@@ -2623,8 +2625,6 @@ github.com/tektoncd/pipeline v1.6.0 h1:A+D+jzOVl2QNl/yiNT7csVgBUy2wpz6K6+/D4q5lf
 github.com/tektoncd/pipeline v1.6.0/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2 h1:v4UPEbe6MEto5i4ELtiXWBxUAUIAWL5U1DznfPhi4WE=
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2/go.mod h1:BC6F3DlZc+wpUT9YcwG9MoSfb4tUiH2olB9xYoIsB4I=
-github.com/tektoncd/pruner v0.3.2 h1:2ZTVjEOqUY+FjxzUP75TcXD0mrFPq9p9UegNfTKJObk=
-github.com/tektoncd/pruner v0.3.2/go.mod h1:bcTHS+kymlqQLGmv4T0THgetMqqpvpmWD1kMOhgL4Ko=
 github.com/tektoncd/triggers v0.34.0 h1:CuhG1moThPGEMlxPUcoBDDplJ3FAczzF8MMAjGScRY0=
 github.com/tektoncd/triggers v0.34.0/go.mod h1:iHqwCaS2ElaWt2RuxCbrHNd5lMfRzPxihqEEygkVn1w=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -102,8 +102,13 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
-	// validate pruner specifications
+	// validate pruner specifications (legacy job-based pruner)
 	errs = errs.Also(tc.Spec.Pruner.validate())
+
+	// validate TektonPruner (event-based) configuration using tektoncd/pruner webhook validation
+	// This ensures that the pruner config in TektonConfig is validated using the same
+	// comprehensive validation logic as the standalone TektonPruner resource
+	errs = errs.Also(tc.Spec.TektonPruner.validate("spec.tektonpruner"))
 
 	if !tc.Spec.Addon.IsEmpty() {
 		errs = errs.Also(validateAddonParams(tc.Spec.Addon.Params, "spec.addon.params"))

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/tektoncd/pruner/pkg/config"
 	"gotest.tools/v3/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 )
 
 func Test_ValidateTektonConfig_OnDelete(t *testing.T) {
@@ -295,4 +297,63 @@ func Test_ValidateTektonConfig_UpdateTargetNamespace(t *testing.T) {
 	ctx = apis.WithinUpdate(ctx, tc)
 	err := updatedTC.Validate(ctx)
 	assert.Equal(t, `Doesn't allow to update targetNamespace, delete existing TektonConfig and create the updated TektonConfig: spec.targetNamespace`, err.Error())
+}
+
+func Test_ValidateTektonConfig_PrunerConfig_Valid(t *testing.T) {
+	disabled := false
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Profile: "all",
+			TektonPruner: Pruner{
+				Disabled: &disabled,
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(5),
+							HistoryLimit:           ptr.Int32(10),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tc.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("Expected no error for valid pruner config, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonConfig_PrunerConfig_Invalid(t *testing.T) {
+	disabled := false
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Profile: "all",
+			TektonPruner: Pruner{
+				Disabled: &disabled,
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(-1), // Invalid: negative value
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tc.Validate(context.TODO())
+	assert.ErrorContains(t, err, "pruner config validation failed")
 }

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pruner/pkg/config"
+	"knative.dev/pkg/apis"
+)
+
+// Validate performs comprehensive validation on TektonPruner
+func (tp *TektonPruner) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// Skip validation when deleting
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
+	// Validate that only one instance exists with the correct name
+	if tp.GetName() != PrunerResourceName {
+		errMsg := fmt.Sprintf("metadata.name, Only one instance of TektonPruner is allowed by name, %s", PrunerResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(tp.GetName(), errMsg))
+	}
+
+	// Execute common spec validations
+	errs = errs.Also(tp.Spec.CommonSpec.validate("spec"))
+
+	// Validate pruner configuration using direct struct validation
+	errs = errs.Also(tp.Spec.Pruner.validate("spec.pruner"))
+
+	return errs
+}
+
+// validate validates the Pruner configuration using direct struct validation
+// This ensures consistency with the upstream pruner validation logic
+// This method is used by both TektonPruner.Validate() and TektonConfig.Validate()
+func (p *Pruner) validate(path string) *apis.FieldError {
+	// Skip validation if pruner is disabled
+	if p.IsDisabled() {
+		return nil
+	}
+
+	// Use the new ValidateGlobalConfig function from pruner package
+	// This validates the GlobalConfig struct directly without ConfigMap conversion
+	// This is the recommended approach for operator CRDs as documented in pruner PR #57
+	if err := config.ValidateGlobalConfig(&p.TektonPrunerConfig.GlobalConfig); err != nil {
+		return apis.ErrGeneric(
+			fmt.Sprintf("pruner config validation failed: %v", err),
+			path+".global-config",
+		)
+	}
+
+	return nil
+}

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pruner/pkg/config"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
+)
+
+func Test_ValidateTektonPruner_ValidConfig(t *testing.T) {
+	disabled := false
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pruner",
+		},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Pruner: Pruner{
+				Disabled: &disabled,
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(5),
+							HistoryLimit:           ptr.Int32(10),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonPruner_DisabledPruner(t *testing.T) {
+	disabled := true
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pruner",
+		},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Pruner: Pruner{
+				Disabled: &disabled,
+				// Even with invalid config, validation should pass when disabled
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(-1), // This would be invalid if enabled
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("Expected no error for disabled pruner, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonPruner_InvalidHistoryLimit(t *testing.T) {
+	disabled := false
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pruner",
+		},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Pruner: Pruner{
+				Disabled: &disabled,
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(-1), // Invalid: must be >= 0
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	assert.ErrorContains(t, err, "pruner config validation failed")
+}
+
+func Test_ValidateTektonPruner_InvalidResourceName(t *testing.T) {
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-name", // Should be PrunerResourceName
+		},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	assert.ErrorContains(t, err, "Only one instance of TektonPruner is allowed")
+}
+
+func Test_ValidateTektonPruner_MissingTargetNamespace(t *testing.T) {
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pruner",
+		},
+		Spec: TektonPrunerSpec{
+			// Missing TargetNamespace
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	assert.ErrorContains(t, err, "missing field(s): spec.targetNamespace")
+}
+
+func Test_ValidateTektonPruner_ComplexValidConfig(t *testing.T) {
+	disabled := false
+	tp := &TektonPruner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pruner",
+		},
+		Spec: TektonPrunerSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Pruner: Pruner{
+				Disabled: &disabled,
+				TektonPrunerConfig: TektonPrunerConfig{
+					GlobalConfig: config.GlobalConfig{
+						PrunerConfig: config.PrunerConfig{
+							SuccessfulHistoryLimit: ptr.Int32(5),
+							FailedHistoryLimit:     ptr.Int32(3),
+							HistoryLimit:           ptr.Int32(10),
+						},
+						Namespaces: map[string]config.NamespaceSpec{
+							"dev": {
+								PrunerConfig: config.PrunerConfig{
+									SuccessfulHistoryLimit: ptr.Int32(3),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := tp.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("Expected no error for complex valid config, got: %v", err)
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -37,6 +37,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonHub):      &v1alpha1.TektonHub{},
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonResult):   &v1alpha1.TektonResult{},
 	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonChain):    &v1alpha1.TektonChain{},
+	v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.KindTektonPruner):   &v1alpha1.TektonPruner{},
 }
 
 func SetTypes(platform string) {

--- a/vendor/github.com/tektoncd/pruner/pkg/config/config.go
+++ b/vendor/github.com/tektoncd/pruner/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -241,30 +242,30 @@ func getFromPrunerConfigResourceLevelwithSelector(namespacesSpec map[string]Name
 				}
 			}
 		}
-		// Name was specified but no match found - no fallback to selectors (field isolation)
-		return nil, ""
+		// Name was specified but no match found - continue to selector matching
 	}
 
-	// If name is not provided, proceed with selector matching
+	// If name-based matching didn't succeed, proceed with selector matching
 	if len(selector.MatchAnnotations) > 0 || len(selector.MatchLabels) > 0 {
 
 		for _, resourceSpec := range resourceSpecs {
 			// Check if the resourceSpec matches the provided selector by annotations AND labels
 			for _, selectorSpec := range resourceSpec.Selector {
 				// Both annotations and labels must match when both are specified (AND logic)
-				// If ResourceSpec has both, selector must also provide both
+				// The ConfigMap's selectorSpec defines the required labels/annotations to match
+				// The selector (from the PipelineRun/TaskRun) contains the actual labels/annotations
 				annotationsMatch := true
 				labelsMatch := true
 
-				// If ResourceSpec has annotations, check if selector provides matching annotations
+				// If ConfigMap's selectorSpec has matchAnnotations, check if resource has all of them
 				if len(selectorSpec.MatchAnnotations) > 0 {
 					if len(selector.MatchAnnotations) == 0 {
-						// ResourceSpec has annotations but selector doesn't - no match
+						// ConfigMap requires annotations but resource has none - no match
 						annotationsMatch = false
 					} else {
-						// Check if all selector annotations match
-						for key, value := range selector.MatchAnnotations {
-							if resourceAnnotationValue, exists := selectorSpec.MatchAnnotations[key]; !exists || resourceAnnotationValue != value {
+						// Check if all ConfigMap's required annotations exist in resource
+						for key, value := range selectorSpec.MatchAnnotations {
+							if resourceAnnotationValue, exists := selector.MatchAnnotations[key]; !exists || resourceAnnotationValue != value {
 								annotationsMatch = false
 								break
 							}
@@ -272,15 +273,15 @@ func getFromPrunerConfigResourceLevelwithSelector(namespacesSpec map[string]Name
 					}
 				}
 
-				// If ResourceSpec has labels, check if selector provides matching labels
+				// If ConfigMap's selectorSpec has matchLabels, check if resource has all of them
 				if len(selectorSpec.MatchLabels) > 0 {
 					if len(selector.MatchLabels) == 0 {
-						// ResourceSpec has labels but selector doesn't - no match
+						// ConfigMap requires labels but resource has none - no match
 						labelsMatch = false
 					} else {
-						// Check if all selector labels match
-						for key, value := range selector.MatchLabels {
-							if resourceLabelValue, exists := selectorSpec.MatchLabels[key]; !exists || resourceLabelValue != value {
+						// Check if all ConfigMap's required labels exist in resource
+						for key, value := range selectorSpec.MatchLabels {
+							if resourceLabelValue, exists := selector.MatchLabels[key]; !exists || resourceLabelValue != value {
 								labelsMatch = false
 								break
 							}
@@ -529,40 +530,48 @@ func (ps *prunerConfigStore) GetEnforcedConfigLevelFromNamespaceSpec(namespacesS
 		// Search by selectors
 		for _, resourceSpec := range resourceSpecs {
 			for _, selectorSpec := range resourceSpec.Selector {
-				// Try annotation matching first
-				if len(selector.MatchAnnotations) > 0 {
-					match := true
-					for key, value := range selector.MatchAnnotations {
-						if resourceAnnotationValue, exists := selectorSpec.MatchAnnotations[key]; !exists || resourceAnnotationValue != value {
-							match = false
-							break
+				annotationsMatch := true
+				labelsMatch := true
+
+				// Check if ConfigMap's required annotations exist in the resource
+				if len(selectorSpec.MatchAnnotations) > 0 {
+					if len(selector.MatchAnnotations) == 0 {
+						// ConfigMap requires annotations but resource has none - no match
+						annotationsMatch = false
+					} else {
+						// Check if all ConfigMap's required annotations exist in resource
+						for key, value := range selectorSpec.MatchAnnotations {
+							if resourceAnnotationValue, exists := selector.MatchAnnotations[key]; !exists || resourceAnnotationValue != value {
+								annotationsMatch = false
+								break
+							}
 						}
-					}
-					if match {
-						enforcedConfigLevel = resourceSpec.EnforcedConfigLevel
-						if enforcedConfigLevel != nil {
-							return enforcedConfigLevel
-						}
-						break
 					}
 				}
 
-				// Try label matching if no annotation match
-				if len(selector.MatchLabels) > 0 {
-					match := true
-					for key, value := range selector.MatchLabels {
-						if resourceLabelValue, exists := selectorSpec.MatchLabels[key]; !exists || resourceLabelValue != value {
-							match = false
-							break
+				// Check if ConfigMap's required labels exist in the resource
+				if len(selectorSpec.MatchLabels) > 0 {
+					if len(selector.MatchLabels) == 0 {
+						// ConfigMap requires labels but resource has none - no match
+						labelsMatch = false
+					} else {
+						// Check if all ConfigMap's required labels exist in resource
+						for key, value := range selectorSpec.MatchLabels {
+							if resourceLabelValue, exists := selector.MatchLabels[key]; !exists || resourceLabelValue != value {
+								labelsMatch = false
+								break
+							}
 						}
 					}
-					if match {
-						enforcedConfigLevel = resourceSpec.EnforcedConfigLevel
-						if enforcedConfigLevel != nil {
-							return enforcedConfigLevel
-						}
-						break
+				}
+
+				// Both annotations and labels must match (AND logic)
+				if annotationsMatch && labelsMatch {
+					enforcedConfigLevel = resourceSpec.EnforcedConfigLevel
+					if enforcedConfigLevel != nil {
+						return enforcedConfigLevel
 					}
+					break
 				}
 			}
 		}
@@ -641,6 +650,49 @@ func (ps *prunerConfigStore) GetTaskFailedHistoryLimitCount(namespace, name stri
 	return getResourceFieldData(ps.globalConfig, ps.namespaceConfig, namespace, name, selector, PrunerResourceTypeTaskRun, PrunerFieldTypeFailedHistoryLimit, enforcedConfigLevel)
 }
 
+// ValidateGlobalConfig validates a GlobalConfig struct directly without ConfigMap conversion
+// This is a convenience function for validating global config and all nested namespace configs
+// without the overhead of serialization/deserialization through ConfigMaps.
+//
+// Use this function when you have a GlobalConfig struct and want to validate it directly,
+// for example when validating configuration from operator CRDs or other non-ConfigMap sources.
+//
+// For ConfigMap-based validation, use ValidateConfigMap or ValidateConfigMapWithGlobal instead.
+func ValidateGlobalConfig(globalConfig *GlobalConfig) error {
+	if globalConfig == nil {
+		return nil
+	}
+
+	// Validate root-level global config
+	if err := validatePrunerConfig(&globalConfig.PrunerConfig, "global-config", nil); err != nil {
+		return err
+	}
+
+	// Validate nested namespace configs
+	// These are validated against the global limits
+	for ns, nsSpec := range globalConfig.Namespaces {
+		path := fmt.Sprintf("global-config.namespaces.%s", ns)
+		if err := validatePrunerConfig(&nsSpec.PrunerConfig, path, &globalConfig.PrunerConfig); err != nil {
+			return err
+		}
+
+		// CRITICAL: Validate that global ConfigMap namespace sections do NOT contain selectors
+		// Selectors are ONLY supported in namespace-level ConfigMaps (tekton-pruner-namespace-spec)
+		for i, pr := range nsSpec.PipelineRuns {
+			if len(pr.Selector) > 0 {
+				return fmt.Errorf("%s.pipelineRuns[%d]: selectors are NOT supported in global ConfigMap. Use namespace-level ConfigMap (tekton-pruner-namespace-spec) instead", path, i)
+			}
+		}
+		for i, tr := range nsSpec.TaskRuns {
+			if len(tr.Selector) > 0 {
+				return fmt.Errorf("%s.taskRuns[%d]: selectors are NOT supported in global ConfigMap. Use namespace-level ConfigMap (tekton-pruner-namespace-spec) instead", path, i)
+			}
+		}
+	}
+
+	return nil
+}
+
 func ValidateConfigMap(cm *corev1.ConfigMap) error {
 	return ValidateConfigMapWithGlobal(cm, nil)
 }
@@ -690,7 +742,7 @@ func ValidateConfigMapWithGlobal(cm *corev1.ConfigMap, globalConfigMap *corev1.C
 	if cm.Data[PrunerNamespaceConfigKey] != "" {
 		namespaceConfig := &NamespaceSpec{}
 		if err := yaml.Unmarshal([]byte(cm.Data[PrunerNamespaceConfigKey]), namespaceConfig); err != nil {
-			return fmt.Errorf("failed to parse namespace-config: %w", err)
+			return fmt.Errorf("failed to parse ns-config: %w", err)
 		}
 
 		// Extract global limits if global config is provided
@@ -698,15 +750,79 @@ func ValidateConfigMapWithGlobal(cm *corev1.ConfigMap, globalConfigMap *corev1.C
 			globalConfig := &GlobalConfig{}
 			if err := yaml.Unmarshal([]byte(globalConfigMap.Data[PrunerGlobalConfigKey]), globalConfig); err != nil {
 				// If we can't parse global config, just do basic validation
-				return validatePrunerConfig(&namespaceConfig.PrunerConfig, "namespace-config", nil)
+				return validatePrunerConfig(&namespaceConfig.PrunerConfig, "ns-config", nil)
 			}
 			globalLimits = &globalConfig.PrunerConfig
 		}
 
 		// Validate namespace config, enforcing global limits if available
-		if err := validatePrunerConfig(&namespaceConfig.PrunerConfig, "namespace-config", globalLimits); err != nil {
+		if err := validatePrunerConfig(&namespaceConfig.PrunerConfig, "ns-config", globalLimits); err != nil {
 			return err
 		}
+
+		// Validate selector-based limits (sum of selectors must not exceed namespace/global limits)
+		// Extract namespace name from ConfigMap metadata
+		namespace := cm.Namespace
+		var globalNamespaceSpec *NamespaceSpec
+		if globalConfigMap != nil && globalConfigMap.Data != nil && globalConfigMap.Data[PrunerGlobalConfigKey] != "" {
+			globalConfig := &GlobalConfig{}
+			if err := yaml.Unmarshal([]byte(globalConfigMap.Data[PrunerGlobalConfigKey]), globalConfig); err == nil {
+				if nsSpec, exists := globalConfig.Namespaces[namespace]; exists {
+					globalNamespaceSpec = &nsSpec
+				}
+				// Pass both globalConfig and globalNamespaceSpec for 4-tier hierarchy
+				if err := validateSelectorLimits(namespaceConfig, &globalConfig.PrunerConfig, globalNamespaceSpec, namespace); err != nil {
+					return err
+				}
+			}
+		} else {
+			// No global config, validate with system maximum only
+			if err := validateSelectorLimits(namespaceConfig, nil, nil, namespace); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateNamespaceSpec validates a NamespaceSpec struct directly without ConfigMap conversion
+// This function validates namespace-level configuration against optional global limits.
+//
+// Parameters:
+//   - namespaceSpec: The namespace configuration to validate
+//   - namespace: The namespace name (used for error messages)
+//   - globalConfig: Optional global config for limit enforcement (can be nil)
+//
+// Use this function when you have a NamespaceSpec struct and want to validate it directly,
+// for example when validating configuration from operator CRDs or other non-ConfigMap sources.
+//
+// For ConfigMap-based validation, use ValidateConfigMapWithGlobal instead.
+func ValidateNamespaceSpec(namespaceSpec *NamespaceSpec, namespace string, globalConfig *GlobalConfig) error {
+	if namespaceSpec == nil {
+		return nil
+	}
+
+	var globalLimits *PrunerConfig
+	var globalNamespaceSpec *NamespaceSpec
+
+	// Extract global limits if provided
+	if globalConfig != nil {
+		globalLimits = &globalConfig.PrunerConfig
+		// Check if there's a namespace-specific override in global config
+		if nsSpec, exists := globalConfig.Namespaces[namespace]; exists {
+			globalNamespaceSpec = &nsSpec
+		}
+	}
+
+	// Validate namespace config, enforcing global limits if available
+	if err := validatePrunerConfig(&namespaceSpec.PrunerConfig, "ns-config", globalLimits); err != nil {
+		return err
+	}
+
+	// Validate selector-based limits (sum of selectors must not exceed namespace/global limits)
+	if err := validateSelectorLimits(namespaceSpec, globalLimits, globalNamespaceSpec, namespace); err != nil {
+		return err
 	}
 
 	return nil
@@ -714,10 +830,17 @@ func ValidateConfigMapWithGlobal(cm *corev1.ConfigMap, globalConfigMap *corev1.C
 
 // validatePrunerConfig validates the fields of a PrunerConfig
 // If globalConfig is provided, namespace-level settings are validated to not exceed global limits
+// If globalConfig is nil and path indicates a namespace config, system maximums are enforced
 func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *PrunerConfig) error {
 	if config == nil {
 		return nil
 	}
+
+	// Determine if this is a namespace-level config validation (not a top-level global config)
+	// Namespace configs can be:
+	// - Standalone: path starts with "ns-config"
+	// - Nested in global: path contains ".namespaces."
+	isNamespaceConfig := strings.HasPrefix(path, "ns-config") || strings.Contains(path, ".namespaces.")
 
 	// Validate EnforcedConfigLevel
 	if config.EnforcedConfigLevel != nil {
@@ -740,8 +863,8 @@ func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *Prune
 				return fmt.Errorf("%s: ttlSecondsAfterFinished (%d) cannot exceed global limit (%d)",
 					path, *config.TTLSecondsAfterFinished, *globalConfig.TTLSecondsAfterFinished)
 			}
-		} else if globalConfig == nil || globalConfig.TTLSecondsAfterFinished == nil {
-			// If no global limit is set, enforce system maximum
+		} else if isNamespaceConfig && (globalConfig == nil || globalConfig.TTLSecondsAfterFinished == nil) {
+			// If this is a namespace config and no global limit is set, enforce system maximum
 			if *config.TTLSecondsAfterFinished > MaxTTLSecondsAfterFinished {
 				return fmt.Errorf("%s: ttlSecondsAfterFinished (%d) cannot exceed system maximum (%d seconds / 30 days)",
 					path, *config.TTLSecondsAfterFinished, MaxTTLSecondsAfterFinished)
@@ -754,14 +877,29 @@ func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *Prune
 		if *config.SuccessfulHistoryLimit < 0 {
 			return fmt.Errorf("%s: successfulHistoryLimit cannot be negative, got %d", path, *config.SuccessfulHistoryLimit)
 		}
-		// Namespace config cannot retain more successful runs than global config
-		if globalConfig != nil && globalConfig.SuccessfulHistoryLimit != nil {
-			if *config.SuccessfulHistoryLimit > *globalConfig.SuccessfulHistoryLimit {
-				return fmt.Errorf("%s: successfulHistoryLimit (%d) cannot exceed global limit (%d)",
-					path, *config.SuccessfulHistoryLimit, *globalConfig.SuccessfulHistoryLimit)
+		// For namespace configs, determine the upper limit based on global config
+		if isNamespaceConfig && globalConfig != nil {
+			// Priority 1: Use global successfulHistoryLimit if set
+			if globalConfig.SuccessfulHistoryLimit != nil {
+				if *config.SuccessfulHistoryLimit > *globalConfig.SuccessfulHistoryLimit {
+					return fmt.Errorf("%s: successfulHistoryLimit (%d) cannot exceed global limit (%d)",
+						path, *config.SuccessfulHistoryLimit, *globalConfig.SuccessfulHistoryLimit)
+				}
+			} else if globalConfig.HistoryLimit != nil {
+				// Priority 2: Use global historyLimit as fallback if no granular limit
+				if *config.SuccessfulHistoryLimit > *globalConfig.HistoryLimit {
+					return fmt.Errorf("%s: successfulHistoryLimit (%d) cannot exceed global historyLimit (%d)",
+						path, *config.SuccessfulHistoryLimit, *globalConfig.HistoryLimit)
+				}
+			} else {
+				// Priority 3: Use system maximum if global config exists but has no relevant limits
+				if *config.SuccessfulHistoryLimit > MaxHistoryLimit {
+					return fmt.Errorf("%s: successfulHistoryLimit (%d) cannot exceed system maximum (%d)",
+						path, *config.SuccessfulHistoryLimit, MaxHistoryLimit)
+				}
 			}
-		} else if globalConfig == nil || globalConfig.SuccessfulHistoryLimit == nil {
-			// If no global limit is set, enforce system maximum
+		} else if isNamespaceConfig && globalConfig == nil {
+			// Priority 3: Use system maximum if no global config at all
 			if *config.SuccessfulHistoryLimit > MaxHistoryLimit {
 				return fmt.Errorf("%s: successfulHistoryLimit (%d) cannot exceed system maximum (%d)",
 					path, *config.SuccessfulHistoryLimit, MaxHistoryLimit)
@@ -774,14 +912,29 @@ func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *Prune
 		if *config.FailedHistoryLimit < 0 {
 			return fmt.Errorf("%s: failedHistoryLimit cannot be negative, got %d", path, *config.FailedHistoryLimit)
 		}
-		// Namespace config cannot retain more failed runs than global config
-		if globalConfig != nil && globalConfig.FailedHistoryLimit != nil {
-			if *config.FailedHistoryLimit > *globalConfig.FailedHistoryLimit {
-				return fmt.Errorf("%s: failedHistoryLimit (%d) cannot exceed global limit (%d)",
-					path, *config.FailedHistoryLimit, *globalConfig.FailedHistoryLimit)
+		// For namespace configs, determine the upper limit based on global config
+		if isNamespaceConfig && globalConfig != nil {
+			// Priority 1: Use global failedHistoryLimit if set
+			if globalConfig.FailedHistoryLimit != nil {
+				if *config.FailedHistoryLimit > *globalConfig.FailedHistoryLimit {
+					return fmt.Errorf("%s: failedHistoryLimit (%d) cannot exceed global limit (%d)",
+						path, *config.FailedHistoryLimit, *globalConfig.FailedHistoryLimit)
+				}
+			} else if globalConfig.HistoryLimit != nil {
+				// Priority 2: Use global historyLimit as fallback if no granular limit
+				if *config.FailedHistoryLimit > *globalConfig.HistoryLimit {
+					return fmt.Errorf("%s: failedHistoryLimit (%d) cannot exceed global historyLimit (%d)",
+						path, *config.FailedHistoryLimit, *globalConfig.HistoryLimit)
+				}
+			} else {
+				// Priority 3: Use system maximum if global config exists but has no relevant limits
+				if *config.FailedHistoryLimit > MaxHistoryLimit {
+					return fmt.Errorf("%s: failedHistoryLimit (%d) cannot exceed system maximum (%d)",
+						path, *config.FailedHistoryLimit, MaxHistoryLimit)
+				}
 			}
-		} else if globalConfig == nil || globalConfig.FailedHistoryLimit == nil {
-			// If no global limit is set, enforce system maximum
+		} else if isNamespaceConfig && globalConfig == nil {
+			// Priority 3: Use system maximum if no global config at all
 			if *config.FailedHistoryLimit > MaxHistoryLimit {
 				return fmt.Errorf("%s: failedHistoryLimit (%d) cannot exceed system maximum (%d)",
 					path, *config.FailedHistoryLimit, MaxHistoryLimit)
@@ -794,14 +947,14 @@ func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *Prune
 		if *config.HistoryLimit < 0 {
 			return fmt.Errorf("%s: historyLimit cannot be negative, got %d", path, *config.HistoryLimit)
 		}
-		// Namespace config cannot retain more runs than global config
-		if globalConfig != nil && globalConfig.HistoryLimit != nil {
+		// For namespace configs, validate against global historyLimit
+		if isNamespaceConfig && globalConfig != nil && globalConfig.HistoryLimit != nil {
 			if *config.HistoryLimit > *globalConfig.HistoryLimit {
 				return fmt.Errorf("%s: historyLimit (%d) cannot exceed global limit (%d)",
 					path, *config.HistoryLimit, *globalConfig.HistoryLimit)
 			}
-		} else if globalConfig == nil || globalConfig.HistoryLimit == nil {
-			// If no global limit is set, enforce system maximum
+		} else if isNamespaceConfig && (globalConfig == nil || globalConfig.HistoryLimit == nil) {
+			// Use system maximum if no global historyLimit is set
 			if *config.HistoryLimit > MaxHistoryLimit {
 				return fmt.Errorf("%s: historyLimit (%d) cannot exceed system maximum (%d)",
 					path, *config.HistoryLimit, MaxHistoryLimit)
@@ -810,4 +963,167 @@ func validatePrunerConfig(config *PrunerConfig, path string, globalConfig *Prune
 	}
 
 	return nil
+}
+
+// validateSelectorLimits validates that the sum of selector-based limits does not exceed the allowed upper bound
+// Uses a 4-tier hierarchy to determine the upper bound:
+// 1. Namespace-level spec (in the same namespace config)
+// 2. Global namespace override (from global.namespaces[namespace])
+// 3. Global default spec
+// 4. System maximum
+func validateSelectorLimits(nsConfig *NamespaceSpec, globalConfig *PrunerConfig, globalNsSpec *NamespaceSpec, namespace string) error {
+	if nsConfig == nil {
+		return nil
+	}
+
+	// Validate PipelineRuns selectors
+	if err := validateResourceSelectorLimits(nsConfig.PipelineRuns, &nsConfig.PrunerConfig, globalConfig, globalNsSpec, namespace, "pipelineRuns"); err != nil {
+		return err
+	}
+
+	// Validate TaskRuns selectors
+	if err := validateResourceSelectorLimits(nsConfig.TaskRuns, &nsConfig.PrunerConfig, globalConfig, globalNsSpec, namespace, "taskRuns"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateResourceSelectorLimits validates selector limits for a specific resource type (PipelineRuns or TaskRuns)
+func validateResourceSelectorLimits(resources []ResourceSpec, nsConfig *PrunerConfig, globalConfig *PrunerConfig, globalNsSpec *NamespaceSpec, namespace, resourceType string) error {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	// Calculate sum of selector-based limits for each limit type
+	var sumSuccessful, sumFailed, sumHistory int32
+
+	for i, resource := range resources {
+		// Only count resources that have selectors (not name-based)
+		if len(resource.Selector) > 0 {
+			if resource.SuccessfulHistoryLimit != nil {
+				sumSuccessful += *resource.SuccessfulHistoryLimit
+			}
+			if resource.FailedHistoryLimit != nil {
+				sumFailed += *resource.FailedHistoryLimit
+			}
+			if resource.HistoryLimit != nil {
+				sumHistory += *resource.HistoryLimit
+			}
+		}
+
+		// Validate individual selector limits are non-negative
+		if resource.SuccessfulHistoryLimit != nil && *resource.SuccessfulHistoryLimit < 0 {
+			return fmt.Errorf("ns-config.%s[%d]: successfulHistoryLimit cannot be negative, got %d", resourceType, i, *resource.SuccessfulHistoryLimit)
+		}
+		if resource.FailedHistoryLimit != nil && *resource.FailedHistoryLimit < 0 {
+			return fmt.Errorf("ns-config.%s[%d]: failedHistoryLimit cannot be negative, got %d", resourceType, i, *resource.FailedHistoryLimit)
+		}
+		if resource.HistoryLimit != nil && *resource.HistoryLimit < 0 {
+			return fmt.Errorf("ns-config.%s[%d]: historyLimit cannot be negative, got %d", resourceType, i, *resource.HistoryLimit)
+		}
+	}
+
+	// Validate successfulHistoryLimit sum
+	if sumSuccessful > 0 {
+		upperBound := determineUpperBound(nsConfig.SuccessfulHistoryLimit, nsConfig.HistoryLimit,
+			globalNsSpec, globalConfig, "successfulHistoryLimit")
+		if sumSuccessful > upperBound {
+			return fmt.Errorf("namespace '%s' ns-config.%s: sum of selector successfulHistoryLimit (%d) cannot exceed upper bound (%d)",
+				namespace, resourceType, sumSuccessful, upperBound)
+		}
+	}
+
+	// Validate failedHistoryLimit sum
+	if sumFailed > 0 {
+		upperBound := determineUpperBound(nsConfig.FailedHistoryLimit, nsConfig.HistoryLimit,
+			globalNsSpec, globalConfig, "failedHistoryLimit")
+		if sumFailed > upperBound {
+			return fmt.Errorf("namespace '%s' ns-config.%s: sum of selector failedHistoryLimit (%d) cannot exceed upper bound (%d)",
+				namespace, resourceType, sumFailed, upperBound)
+		}
+	}
+
+	// Validate historyLimit sum
+	if sumHistory > 0 {
+		upperBound := determineUpperBound(nsConfig.HistoryLimit, nil,
+			globalNsSpec, globalConfig, "historyLimit")
+		if sumHistory > upperBound {
+			return fmt.Errorf("namespace '%s' ns-config.%s: sum of selector historyLimit (%d) cannot exceed upper bound (%d)",
+				namespace, resourceType, sumHistory, upperBound)
+		}
+	}
+
+	return nil
+}
+
+// determineUpperBound implements the 4-tier hierarchy to find the upper bound for selector validation
+// limitType should be "successfulHistoryLimit", "failedHistoryLimit", or "historyLimit"
+func determineUpperBound(nsGranularLimit, nsHistoryLimit *int32, globalNsSpec *NamespaceSpec, globalConfig *PrunerConfig, limitType string) int32 {
+	// Level 1: Namespace-level spec (most specific)
+	if nsGranularLimit != nil && limitType != "historyLimit" {
+		return *nsGranularLimit
+	}
+	if limitType != "historyLimit" && nsHistoryLimit != nil {
+		// For granular limits, fallback to namespace historyLimit if granular not set
+		return *nsHistoryLimit
+	}
+	if limitType == "historyLimit" && nsHistoryLimit != nil {
+		return *nsHistoryLimit
+	}
+
+	// Level 2: Global namespace override (from global.namespaces[namespace])
+	if globalNsSpec != nil {
+		switch limitType {
+		case "successfulHistoryLimit":
+			if globalNsSpec.SuccessfulHistoryLimit != nil {
+				return *globalNsSpec.SuccessfulHistoryLimit
+			}
+			// Fallback to globalNsSpec.HistoryLimit
+			if globalNsSpec.HistoryLimit != nil {
+				return *globalNsSpec.HistoryLimit
+			}
+		case "failedHistoryLimit":
+			if globalNsSpec.FailedHistoryLimit != nil {
+				return *globalNsSpec.FailedHistoryLimit
+			}
+			// Fallback to globalNsSpec.HistoryLimit
+			if globalNsSpec.HistoryLimit != nil {
+				return *globalNsSpec.HistoryLimit
+			}
+		case "historyLimit":
+			if globalNsSpec.HistoryLimit != nil {
+				return *globalNsSpec.HistoryLimit
+			}
+		}
+	}
+
+	// Level 3: Global default spec
+	if globalConfig != nil {
+		switch limitType {
+		case "successfulHistoryLimit":
+			if globalConfig.SuccessfulHistoryLimit != nil {
+				return *globalConfig.SuccessfulHistoryLimit
+			}
+			// Fallback to globalConfig.HistoryLimit
+			if globalConfig.HistoryLimit != nil {
+				return *globalConfig.HistoryLimit
+			}
+		case "failedHistoryLimit":
+			if globalConfig.FailedHistoryLimit != nil {
+				return *globalConfig.FailedHistoryLimit
+			}
+			// Fallback to globalConfig.HistoryLimit
+			if globalConfig.HistoryLimit != nil {
+				return *globalConfig.HistoryLimit
+			}
+		case "historyLimit":
+			if globalConfig.HistoryLimit != nil {
+				return *globalConfig.HistoryLimit
+			}
+		}
+	}
+
+	// Level 4: System maximum
+	return int32(MaxHistoryLimit)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1348,7 +1348,7 @@ github.com/tektoncd/pipeline/test/parse
 ## explicit; go 1.24.0
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts
-# github.com/tektoncd/pruner v0.3.2
+# github.com/tektoncd/pruner v0.3.2 => github.com/anithapriyanatarajan/pruner v0.0.0-20251129003540-fd45a2f79b3e
 ## explicit; go 1.24.0
 github.com/tektoncd/pruner/pkg/config
 github.com/tektoncd/pruner/pkg/metrics
@@ -2477,6 +2477,7 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/alibabacloud-go/cr-20160607 => github.com/vdemeester/cr-20160607 v1.0.1
 # github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5
+# github.com/tektoncd/pruner => github.com/anithapriyanatarajan/pruner v0.0.0-20251129003540-fd45a2f79b3e
 # k8s.io/api => k8s.io/api v0.32.4
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.9
 # k8s.io/apimachinery => k8s.io/apimachinery v0.32.4


### PR DESCRIPTION
# Changes

This pull request enhances the Tekton Operator's pruner configuration validation by integrating  event-based pruner validation logic from the upstream `tektoncd/pruner` project. 

* Added new file `pkg/apis/operator/v1alpha1/tektonpruner_validation.go` that implements  validation for the `TektonPruner` resource, including enforcing singleton resource name, common spec checks, and upstream pruner config validation.
* Updated `TektonConfig` validation to call  new event-based pruner validation as well, ensuring the operator validates pruner config with the same logic as standalone `TektonPruner`.
* Registered the `TektonPruner` resource type in the webhook's supported types map, enabling webhook-based validation for the new resource.

NOTE:  Updated `go.mod` to use a forked version of `tektoncd/pruner` for access to the latest validation logic. THis will be on hold until the pruner is released with the revised logic. Submitted this PR for feedback.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind bug