### PR TITLE
fix: correct repo name in slash config

### DIFF
--- a/.github/workflows/bump-payload-on-main.yaml
+++ b/.github/workflows/bump-payload-on-main.yaml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
     - name: run operator-tool bump
@@ -21,7 +21,7 @@ jobs:
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         make components/bump
     - name: create pull request
-      uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
+      uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412  # v7.0.9
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         commit-message: Bump payloads versions

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -26,10 +26,10 @@ jobs:
         branch: ${{ fromJSON(needs.build-release-matrix.outputs.branches) }}
         # branch: [release-v0.62.x, release-v0.63.x]
     steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
       with:
         ref: ${{ matrix.branch }}
-    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
     - name: run operator-tool bump-bugfix
@@ -37,7 +37,7 @@ jobs:
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         make components/bump-bugfix
     - name: create pull request
-      uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
+      uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412  # v7.0.9
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         commit-message: Bump payloads versions

--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -11,7 +11,8 @@
 name: Rerun Failed Actions
 on:
   repository_dispatch:
-    types: [retest-command]
+    types:
+      - retest-command
 
 jobs:
   retest:
@@ -61,7 +62,7 @@ jobs:
 
     - name: Create comment
       if: ${{ failure() && steps.landStack.outcome == 'failure' }}
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -73,7 +74,7 @@ jobs:
 
     - name: Add reaction
       if: ${{ success() }}
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ defaults:
 
 permissions:
   contents: read
-  checks: write # Used to annotate code in the PR
+  checks: write  # Used to annotate code in the PR
 
 jobs:
   changes:
@@ -130,7 +130,7 @@ jobs:
     - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
-    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
     - name: ko-resolve
       run: |
           cat <<EOF > .ko.yaml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main]
+    branches:
+      - main
   schedule:
     - cron: '30 20 * * 2'
 
@@ -38,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2  # v4.31.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +52,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: |
           ~/.cache/go-build
@@ -75,4 +77,4 @@ jobs:
         make bin/tool
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/analyze@fe4161a26a8629af62121b670040955b330f9af2  # v4.31.6

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,7 +1,8 @@
 name: Tekton Integration
 # Adapted from https://github.com/mattmoor/mink/blob/master/.github/workflows/minkind.yaml
 
-on: [workflow_call]
+on:
+  - workflow_call
 
 defaults:
   run:
@@ -15,7 +16,7 @@ jobs:
     name: e2e tests
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # Keep running if one leg fails.
+      fail-fast: false  # Keep running if one leg fails.
       matrix:
         k8s-name:
         - k8s-oldest
@@ -36,7 +37,7 @@ jobs:
     - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
-    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
 
     - name: Install Dependencies
       working-directory: ./
@@ -62,12 +63,12 @@ jobs:
           --e2e-env ./test/e2e-tests-kind.env
 
     - name: Upload test results
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
       with:
         name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}
         path: ${{ env.ARTIFACTS }}
 
-    - uses: chainguard-dev/actions/kind-diag@3e8a2a226fad9e1ecbf2d359b8a7697554a4ac6d # v1.5.10
+    - uses: chainguard-dev/actions/kind-diag@3e8a2a226fad9e1ecbf2d359b8a7697554a4ac6d  # v1.5.10
       if: ${{ failure() }}
       with:
         artifact-name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-logs

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -5,13 +5,15 @@ permissions:
 
 on:
   pull_request:
-    branches: ["main"]
+    branches:
+      - "main"
   push:
-    branches: ["main"]
+    branches:
+      - "main"
   # run at least once every 2 months to prevent the coverage artifact from expiring
   schedule:
     - cron: '14 3 5 */2 *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -30,12 +32,12 @@ jobs:
 
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2  # v2.13.2
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           path: ${{ github.workspace }}/src/github.com/tektoncd/operator
 
@@ -51,15 +53,15 @@ jobs:
           echo "Generated coverage profile"
 
       - name: Archive coverage results
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: code-coverage
           path: ${{ github.workspace }}/src/github.com/tektoncd/operator/coverage.txt
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
-        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
+        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682  # v1.2.0
+        continue-on-error: true  # This may fail if artifact on main branch does not exist (first run or expired)
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "coverage.txt"

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
       - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           fetch-depth: 0
 
@@ -22,11 +22,11 @@ jobs:
           git config user.email "dlorenc+tekton@google.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.8.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -20,14 +20,15 @@
 name: Slash Command Routing
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
 
 jobs:
   check_comments:
     runs-on: ubuntu-latest
     steps:
     - name: route-land
-      uses: peter-evans/slash-command-dispatch@e1b4e266bc781656359bb7e462e228daf68c04f6 # v5.0.0
+      uses: peter-evans/slash-command-dispatch@e1b4e266bc781656359bb7e462e228daf68c04f6  # v5.0.0
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         config: >
@@ -36,6 +37,6 @@ jobs:
               "command": "retest",
               "permission": "write",
               "issue_type": "pull-request",
-              "repository": "tektoncd/pipeline"
+              "repository": "tektoncd/operator"
             }
           ]

--- a/.github/workflows/update-tektoncd-task-versions.yml
+++ b/.github/workflows/update-tektoncd-task-versions.yml
@@ -3,18 +3,18 @@ name: Update Tekton Task Versions
 on:
   schedule:
     - cron: "0 0 * * *"  # Runs daily at midnight
-  workflow_dispatch:  # Allows manual trigger
+  workflow_dispatch: {}  # Allows manual trigger
 
 jobs:
   update-task-versions:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'tektoncd' # do not run this elsewhere
+    if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     permissions:
       contents: write
       pull-requests: write
     steps:
       - name: Checkout Operator Repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
# Changes

This pull request fixes /retest command routing to operator repo
Rest of the files are mainly corrected fro yamllint errors. 

* Changed the `repository` field from `"tektoncd/pipeline"` to `"tektoncd/operator"` in the slash command configuration in `.github/workflows/slash.yml` to ensure commands are routed to the correct repository.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
