### PR TITLE
Add readOnlyRootFilesystem to tekton-operator-proxy-webhook

### DIFF
--- a/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
+++ b/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
@@ -122,6 +122,12 @@ spec:
           securityContext:
             runAsUser: 65532
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 100m

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -128,6 +128,7 @@ spec:
               containerPort: 8443
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
The tekton-operator-proxy-webhook deployment was missing readOnlyRootFilesystem: true in its container securityContext, while all other deployments in openshift-pipelines namespace already have this security setting. This change adds readOnlyRootFilesystem: true to both OpenShift and Kubernetes webhook manifests to ensure consistent security posture across all operator-managed deployments.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Added `readOnlyRootFilesystem: true` to the `tekton-operator-proxy-webhook` deployment securityContext, ensuring consistent security hardening across all Tekton operator-managed deployments.
```
