### PR TITLE
chore: correct cheatsheet aligning to latest working params and versions

### DIFF
--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -103,9 +103,9 @@ spec:
       - name: url
         value: https://github.com/tektoncd/plumbing
       - name: revision
-        value: aeed19e5a36f335ebfdc4b96fa78d1ce5bb4f7b8
+        value: 8d3152d3d39982ce1768325b373d321efaa83031
       - name: pathInRepo
-        value: tekton/resources/release/base/prerelease_checks.yaml
+        value: tekton/resources/release/base/prerelease_checks_oci.yaml
     params:
     - name: package
       value: $(params.package)
@@ -117,6 +117,8 @@ spec:
     - name: source-to-release
       workspace: workarea
       subPath: git
+    - name: oci-credentials
+      workspace: release-secret
 
   - name: unit-tests
     runAfter:
@@ -290,7 +292,7 @@ spec:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
         - name: name
           value: oracle-cloud-storage-upload
         - name: kind
@@ -326,7 +328,7 @@ spec:
       resolver: bundles
       params:
         - name: bundle
-          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.1
+          value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
         - name: name
           value: oracle-cloud-storage-upload
         - name: kind


### PR DESCRIPTION
# Changes

This pull request updates both the Tekton Operator release pipeline YAML and the release process documentation to support OCI-based prerelease checks, update Oracle Cloud Storage upload tasks, and improve the release workflow with new environment variables and clearer instructions.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
