### PR TITLE
Override the catalog URL only when the Hub catalog type is set to artifacthub

### DIFF
--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_defaults.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_defaults.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	hubtypes "github.com/openshift-pipelines/pipelines-as-code/pkg/hub/vars"
 	pacSettings "github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
@@ -57,7 +58,9 @@ func (set *PACSettings) setPACDefaults(logger *zap.SugaredLogger) {
 	// Override the default ArtifactHub URL to use https://artifacthub.io instead of https://artifacthub.io/api/v1
 	if defaultCatalog, ok := defaultPacSettings.HubCatalogs.Load("default"); ok {
 		catalog := defaultCatalog.(pacSettings.HubCatalog)
-		catalog.URL = "https://artifacthub.io"
+		if catalog.Type == hubtypes.ArtifactHubType {
+			catalog.URL = "https://artifacthub.io"
+		}
 		defaultPacSettings.HubCatalogs.Store("default", catalog)
 	}
 


### PR DESCRIPTION
When a custom Hub catalog is configured, PAC’s syncConfig incorrectly forces the catalog type to artifacthub and overrides the Hub URL with https://artifacthub.io. This fix ensures the URL is overridden only when the catalog type is explicitly set to artifacthub.

PAC fix: https://github.com/openshift-pipelines/pipelines-as-code/pull/2351

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
