### PR TITLE
Fix: Pruner Config resetting to default when set to null

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -318,7 +318,7 @@ func Test_ValidateTektonConfig_PrunerConfig_Valid(t *testing.T) {
 			TektonPruner: Pruner{
 				Disabled: &disabled,
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(5),
 							HistoryLimit:           ptr.Int32(10),
@@ -354,7 +354,7 @@ func Test_ValidateTektonConfig_PrunerConfig_Invalid(t *testing.T) {
 			TektonPruner: Pruner{
 				Disabled: &disabled,
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(-1), // Invalid: negative value
 						},

--- a/pkg/apis/operator/v1alpha1/tektonpruner_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_defaults.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"context"
+
+	"github.com/tektoncd/pruner/pkg/config"
 )
 
 var DefaultPrunerDisabled = true
@@ -30,5 +32,8 @@ func (p *Pruner) SetDefaults() {
 	if p.Disabled == nil {
 		p.Disabled = &DefaultPrunerDisabled
 	}
-	p.GlobalConfig.SetDefaults()
+	if p.GlobalConfig == nil {
+		p.GlobalConfig = &config.GlobalConfig{}
+		p.GlobalConfig.SetDefaults()
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -42,7 +42,7 @@ type TektonPruner struct {
 }
 
 type TektonPrunerConfig struct {
-	GlobalConfig config.GlobalConfig `json:"global-config"`
+	GlobalConfig *config.GlobalConfig `json:"global-config"`
 }
 
 type Pruner struct {

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
@@ -59,7 +59,7 @@ func (p *Pruner) validate(path string) *apis.FieldError {
 	// Use the new ValidateGlobalConfig function from pruner package
 	// This validates the GlobalConfig struct directly without ConfigMap conversion
 	// This is the recommended approach for operator CRDs as documented in pruner PR #57
-	if err := config.ValidateGlobalConfig(&p.TektonPrunerConfig.GlobalConfig); err != nil {
+	if err := config.ValidateGlobalConfig(p.TektonPrunerConfig.GlobalConfig); err != nil {
 		return apis.ErrGeneric(
 			fmt.Sprintf("pruner config validation failed: %v", err),
 			path+".global-config",

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation_test.go
@@ -39,7 +39,7 @@ func Test_ValidateTektonPruner_ValidConfig(t *testing.T) {
 			Pruner: Pruner{
 				Disabled: &disabled,
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(5),
 							HistoryLimit:           ptr.Int32(10),
@@ -70,7 +70,7 @@ func Test_ValidateTektonPruner_DisabledPruner(t *testing.T) {
 				Disabled: &disabled,
 				// Even with invalid config, validation should pass when disabled
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(-1), // This would be invalid if enabled
 						},
@@ -99,7 +99,7 @@ func Test_ValidateTektonPruner_InvalidHistoryLimit(t *testing.T) {
 			Pruner: Pruner{
 				Disabled: &disabled,
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(-1), // Invalid: must be >= 0
 						},
@@ -187,7 +187,7 @@ func Test_ValidateTektonPruner_ComplexValidConfig(t *testing.T) {
 			Pruner: Pruner{
 				Disabled: &disabled,
 				TektonPrunerConfig: TektonPrunerConfig{
-					GlobalConfig: config.GlobalConfig{
+					GlobalConfig: &config.GlobalConfig{
 						PrunerConfig: config.PrunerConfig{
 							SuccessfulHistoryLimit: ptr.Int32(5),
 							FailedHistoryLimit:     ptr.Int32(3),

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -602,7 +602,7 @@ func TestAddConfigMapValues_StructValues(t *testing.T) {
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
 	assertNoError(t, err)
 	prop := v1alpha1.TektonPrunerConfig{
-		GlobalConfig: config.GlobalConfig{
+		GlobalConfig: &config.GlobalConfig{
 			PrunerConfig: config.PrunerConfig{
 				SuccessfulHistoryLimit: ptr.Int32(123),
 				HistoryLimit:           ptr.Int32(456),

--- a/test/resources/tektonpruner.go
+++ b/test/resources/tektonpruner.go
@@ -55,7 +55,7 @@ func EnsureTektonPrunerExists(clients TektonPrunerv1alpha1.TektonPrunerInterface
 				},
 				Pruner: v1alpha1.Pruner{
 					TektonPrunerConfig: v1alpha1.TektonPrunerConfig{
-						GlobalConfig: config.GlobalConfig{
+						GlobalConfig: &config.GlobalConfig{
 							PrunerConfig: config.PrunerConfig{
 								SuccessfulHistoryLimit: ptr.Int32(12),
 								HistoryLimit:           ptr.Int32(45),


### PR DESCRIPTION
When HistoryLimit is set to null in tektonconfig then it resets back to 100 
After this fix, value will be retained

This also fixes the issues of pruner config resetting to default on upgrade. 
Now after upgrade pruner should retain the old config

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
