### PR TITLE
fix: correct sed command to extract operator image SHA

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -167,10 +167,10 @@ need a checkout of the operator repo, a terminal window and a text editor.
     1. Find the Rekor UUID for the release:
 
         ```bash
-        RELEASE_FILE=https://infra.tekton.dev/tekton-releases/operator/previous/${TEKTON_VERSION}/release.yaml
-        CONTROLLER_IMAGE_SHA=$(curl -L $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*controller.*@//p;')
-        REKOR_UUID=$(rekor-cli search --sha $CONTROLLER_IMAGE_SHA | grep -v Found | head -1)
-        echo -e "CONTROLLER_IMAGE_SHA: ${CONTROLLER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
+        RELEASE_FILE=https://infra.tekton.dev/tekton-releases/operator/previous/${TEKTON_RELEASE_VERSION}/release.yaml
+        OPERATOR_IMAGE_SHA=$(curl -L $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io\/tektoncd\/operator\/operator-[^@]*@//p;' | head -1)
+        REKOR_UUID=$(rekor-cli search --sha $OPERATOR_IMAGE_SHA | grep -v Found | head -1)
+        echo -e "OPERATOR_IMAGE_SHA: ${OPERATOR_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
         ```
 
     2. Execute the Draft Release Pipeline.


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
This PR fixes the sed command in the release cheat sheet that extracts the operator image SHA for Rekor UUID lookup.
The previous command was looking for `controller` pattern which doesn't match the actual operator image naming and was using incorrect variable name `TEKTON_VERSION` instead of `TEKTON_RELEASE_VERSION`

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
