### PR TITLE
fix: multi-arch-build failures due to ko build issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,8 +141,9 @@ jobs:
             github.com/tektoncd/operator/cmd/openshift/proxy-webhook: registry.access.redhat.com/ubi9/ubi-minimal
           EOF
 
-          KO_DOCKER_REPO=example.com make TARGET=kubernetes resolve
-          KO_DOCKER_REPO=example.com make TARGET=openshift resolve
+          # Use ko from setup-ko action to avoid Go version mismatch
+          KO_BIN=$(which ko) KO_DOCKER_REPO=example.com make TARGET=kubernetes resolve
+          KO_BIN=$(which ko) KO_DOCKER_REPO=example.com make TARGET=openshift resolve
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml


### PR DESCRIPTION
# Changes
This pull request makes a minor update to the CI workflow to ensure consistent usage of the `ko` binary. Updated the build step to use the `ko` binary from the `setup-ko` action, preventing Go version mismatches during image resolution.

This relates to https://github.com/tektoncd/operator/pull/3105 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind bug