### PR TITLE
[release-v0.78.x]chore: bump hub version v1.23.5 to v1.23.6

### DIFF
--- a/bump-output.txt
+++ b/bump-output.txt
@@ -1,4 +1,4 @@
 BUMP_UPDATES_START
-hub|v1.23.4|v1.23.5|tektoncd/hub
+hub|v1.23.5|v1.23.6|tektoncd/hub
 pipelines-as-code|v0.39.2|v0.39.3|openshift-pipelines/pipelines-as-code
 BUMP_UPDATES_END

--- a/commit-message.txt
+++ b/commit-message.txt
@@ -1,6 +1,6 @@
 chore: bump component versions
 
-- hub: v1.23.4 → v1.23.5
+- hub: v1.23.5 → v1.23.6
 - pipelines-as-code: v0.39.2 → v0.39.3
 
 Signed-off-by: tekton-bot <tekton-bot@users.noreply.github.com>

--- a/components.yaml
+++ b/components.yaml
@@ -6,7 +6,7 @@ dashboard:
   version: v0.63.1
 hub:
   github: tektoncd/hub
-  version: v1.23.5
+  version: v1.23.6
 manual-approval-gate:
   github: openshift-pipelines/manual-approval-gate
   version: v0.7.0

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -334,7 +334,7 @@ spec:
     - Tekton Triggers: v0.34.0
     - Pipelines as Code: v0.39.3
     - Tekton Chains: v0.26.0
-    - Tekton Hub (tech-preview): v1.23.5
+    - Tekton Hub (tech-preview): v1.23.6
     - Tekton Results: v0.17.1
     - Manual Approval Gate (tech-preview): v0.7.0
     - Tekton Pruner: v0.3.3

--- a/pr-body.txt
+++ b/pr-body.txt
@@ -4,10 +4,10 @@ This PR updates the following component versions:
 
 ### hub
 
-- **Previous version:** `v1.23.4`
-- **New version:** `v1.23.5`
+- **Previous version:** `v1.23.5`
+- **New version:** `v1.23.6`
 - **Repository:** [tektoncd/hub](https://github.com/tektoncd/hub)
-- **Release notes:** [v1.23.4...v1.23.5](https://github.com/tektoncd/hub/compare/v1.23.4...v1.23.5)
+- **Release notes:** [v1.23.5...v1.23.6](https://github.com/tektoncd/hub/compare/v1.23.5...v1.23.6)
 
 ### pipelines-as-code
 


### PR DESCRIPTION
# Changes
This bumps Hub version v1.23.5 to v1.23.6

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
