### PR TITLE
Bump tektoncd/pruner from v0.3.4 to v0.3.5

### DIFF
--- a/components.nightly.yaml
+++ b/components.nightly.yaml
@@ -29,4 +29,4 @@ pipelines-as-code:
   version: nightly
 pruner:
   github: tektoncd/pruner
-  version: v0.3.4
+  version: v0.3.5

--- a/components.yaml
+++ b/components.yaml
@@ -18,7 +18,7 @@ pipelines-as-code:
   version: v0.39.3
 pruner:
   github: tektoncd/pruner
-  version: v0.3.4
+  version: v0.3.5
 results:
   github: tektoncd/results
   version: v0.17.2

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tektoncd/pipeline v1.7.0
 	github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2
-	github.com/tektoncd/pruner v0.3.4
+	github.com/tektoncd/pruner v0.3.5
 	github.com/tektoncd/triggers v0.34.0
 	go.opencensus.io v0.24.0
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -2623,8 +2623,8 @@ github.com/tektoncd/pipeline v1.7.0 h1:+Rd/YGpxV8sgEmW9unSiS8RgBE4DqbPdz6zPh2pYD
 github.com/tektoncd/pipeline v1.7.0/go.mod h1:+HsDce5knjq77Xv9FWg1W2wTuJRznR9lLEbkVjo62lU=
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2 h1:v4UPEbe6MEto5i4ELtiXWBxUAUIAWL5U1DznfPhi4WE=
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2/go.mod h1:BC6F3DlZc+wpUT9YcwG9MoSfb4tUiH2olB9xYoIsB4I=
-github.com/tektoncd/pruner v0.3.4 h1:C2M8VtqAwjxFCAhoD97mYypzF/J5ck03/+mme0bHmWQ=
-github.com/tektoncd/pruner v0.3.4/go.mod h1:JbH3IueCWn1rdawvEkM4oyO05lW/ae7GXV4vrUvu4ls=
+github.com/tektoncd/pruner v0.3.5 h1:eQTgnQ56Par9d/6BICsXfTkR0Ybx8c/0QLZeNoJnaYQ=
+github.com/tektoncd/pruner v0.3.5/go.mod h1:JbH3IueCWn1rdawvEkM4oyO05lW/ae7GXV4vrUvu4ls=
 github.com/tektoncd/triggers v0.34.0 h1:CuhG1moThPGEMlxPUcoBDDplJ3FAczzF8MMAjGScRY0=
 github.com/tektoncd/triggers v0.34.0/go.mod h1:iHqwCaS2ElaWt2RuxCbrHNd5lMfRzPxihqEEygkVn1w=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -337,7 +337,7 @@ spec:
     - Tekton Hub (tech-preview): v1.23.5
     - Tekton Results (tech-preview): v0.17.2
     - Manual Approval Gate (tech-preview): v0.7.0
-    - Tekton Pruner: v0.3.4
+    - Tekton Pruner: v0.3.5
 
     ## Getting Started
 

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	VERSION        = "0.15.2"
-	PRUNER_VERSION = "0.3.4"
+	PRUNER_VERSION = "0.3.5"
 )
 
 func TestGetLatestRelease(t *testing.T) {
@@ -50,7 +50,7 @@ func TestListReleases(t *testing.T) {
 	util.AssertDeepEqual(t, version, expectedVersionList)
 
 	// Pruner Versions
-	expectedPrunerVersions := []string{"0.3.4", "0.3.3", "0.1.0"}
+	expectedPrunerVersions := []string{"0.3.5", "0.3.4", "0.3.3", "0.1.0"}
 	version, err = allReleases(&v1alpha1.TektonPruner{})
 	util.AssertEqual(t, err, nil)
 	util.AssertDeepEqual(t, version, expectedPrunerVersions)

--- a/pkg/reconciler/common/testdata/kodata/pruner/0.3.5/release-v0.3.5.yaml
+++ b/pkg/reconciler/common/testdata/kodata/pruner/0.3.5/release-v0.3.5.yaml
@@ -1,0 +1,777 @@
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pruner-controller-cluster-access
+  labels:
+    pruner.tekton.dev/release: "v0.3.5"
+rules:
+  # Write permissions to publish events.
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "create"
+      - "update"
+      - "patch"
+  # allows to manage taskruns and pipelineruns
+  - apiGroups:
+      - "tekton.dev"
+    resources:
+      - "taskruns"
+      - "pipelineruns"
+      - "taskruns/finalizers"
+      - "pipelineruns/finalizers"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  # used in webhook
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  # used in webhook
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+  # permissions restricted to specific ConfigMap
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - tekton-pruner-namespace-spec
+    verbs:
+      - get
+  # used in webhook for certificate management
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+  labels:
+    pruner.tekton.dev/release: "v0.3.5"
+rules:
+  # Needed to watch and load configuration and secret data.
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs: ["get", "list", "update", "watch"]
+  # This is needed by leader election to run the controller in HA.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+  labels:
+    pruner.tekton.dev/release: "v0.3.5"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pruner-controller-cluster-access
+  labels:
+    pruner.tekton.dev/release: "v0.3.5"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pruner-controller
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-pruner-controller-cluster-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+  labels:
+    pruner.tekton.dev/release: "v0.3.5"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pruner-controller
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-pruner-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+    pruner.tekton.dev/config-type: global
+data:
+  global-config: |-
+    enforcedConfigLevel: global
+    historyLimit: 100
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tekton-pruner-webhook-certs
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+# The data is populated at install time.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.pruner.tekton.dev
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+webhooks:
+  # Webhook 1: Validates global/cluster-level pruner configuration
+  # Triggers: When tekton-pruner-default-spec ConfigMap with proper labels is created or updated
+  # This ConfigMap is mandatory and must exist with valid configuration when pruner is installed
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: tekton-pruner-webhook
+        namespace: tekton-pipelines
+        path: /validate-configmap
+    failurePolicy: Fail
+    sideEffects: None
+    timeoutSeconds: 5
+    name: validation.webhook.pruner.tekton.dev.global
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE", "DELETE"]
+        resources: ["configmaps"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - tekton-pipelines
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/part-of: tekton-pruner
+        pruner.tekton.dev/config-type: global
+  # Webhook 2: Validates namespace-level pruner configuration
+  # Triggers: When ConfigMap with proper labels is created or updated in any user namespace
+  # This ConfigMap is OPTIONAL - namespaces can choose to create it for custom pruning policies
+  # If not present, the namespace will use the global configuration
+  - admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: tekton-pruner-webhook
+        namespace: tekton-pipelines
+        path: /validate-configmap
+    failurePolicy: Fail
+    sideEffects: None
+    timeoutSeconds: 5
+    name: validation.webhook.pruner.tekton.dev.namespace
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE", "DELETE"]
+        resources: ["configmaps"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchExpressions:
+        # Exclude system namespaces - webhook only processes user namespaces
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kube-public
+            - kube-node-lease
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/part-of: tekton-pruner
+        pruner.tekton.dev/config-type: namespace
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pruner-info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tektoncd-pruner
+data:
+  version: "v0.3.5"
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging-tekton-pruner
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+  # Log level overrides
+  # Changes are be picked up immediately.
+  loglevel.tekton-pruner-controller: "info"
+  loglevel.pruner-webhook: "info"
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability-tekton-pruner
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+data:
+  # New Knative observability config format (required for v0.0.0-20250811181739-e06d4c9af190+)
+  metrics-protocol: "prometheus"
+  metrics-endpoint: ":9090"
+  tracing-protocol: "none"
+  # Legacy format for backward compatibility - TODO: Remove these after confirming new format works everywhere
+  metrics.backend-destination: "prometheus"
+  metrics.request-metrics-backend-destination: "prometheus"
+  metrics.allow-stackdriver-custom-metrics: "false"
+  tracing.backend: "none"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # If non-empty, this enables queue proxy writing request logs to stdout.
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. If non-empty, it enables queue proxy to send request metrics.
+    # Currently supported values: prometheus, stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "v0.3.5"
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pruner-controller
+      app.kubernetes.io/name: controller
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-pruner
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+      labels:
+        app: tekton-pruner-controller
+        app.kubernetes.io/name: controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: "v0.3.5"
+        app.kubernetes.io/part-of: tekton-pruner
+        version: "v0.3.5"
+        pruner.tekton.dev/release: "v0.3.5"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: controller
+                    app.kubernetes.io/name: controller
+                    app.kubernetes.io/component: controller
+                    app.kubernetes.io/instance: default
+                    app.kubernetes.io/part-of: tekton-pruner
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: tekton-pruner-controller
+      containers:
+        - name: controller
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: ghcr.io/tektoncd/pruner/controller-fb9e5cbe6aa14ed1aa64e966d9e4d295:v0.3.5@sha256:aa93722fde639a2b32cee1593ad29b8f87aa23d965d77d590e321482964ebf03
+          ports:
+            - name: metrics
+              containerPort: 9090
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging-tekton-pruner
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability-tekton-pruner
+            - name: METRICS_DOMAIN
+              value: pruner.tekton.dev
+            - name: CONFIG_LEADERELECTION_NAME
+              value: config-leader-election-tekton-pruner-controller
+            - name: KUBERNETES_MIN_VERSION
+              value: "1.0.0"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the distroless nonroot user ID
+            runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "v0.3.5"
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/release: "v0.3.5"
+    app: tekton-pruner-controller
+    version: "v0.3.5"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+    prometheus.io/path: "/metrics"
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+spec:
+  ports:
+    - name: http-metrics
+      protocol: TCP
+      targetPort: 9090
+      port: 9090
+  selector:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+
+---
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pruner-webhook
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-pruner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/part-of: tekton-pruner
+    spec:
+      serviceAccountName: tekton-pruner-controller
+      containers:
+        - name: webhook
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: ghcr.io/tektoncd/pruner/webhook-19748cdf3f89caca6b5e27d42f93fa7f:v0.3.5@sha256:c234602ca056b3c6485a7b1b14738e7f5817ce799c9ac544cfd28d14d735d7cb
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Logging configuration
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging-tekton-pruner
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability-tekton-pruner
+            - name: METRICS_DOMAIN
+              value: pruner.tekton.dev
+            # Webhook configuration
+            - name: WEBHOOK_PORT
+              value: "8443"
+            - name: WEBHOOK_SECRET_NAME
+              value: tekton-pruner-webhook-certs
+            - name: KUBERNETES_MIN_VERSION
+              value: "1.0.0"
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tekton-pruner-webhook
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+spec:
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner
+
+---

--- a/vendor/github.com/tektoncd/pruner/pkg/config/config.go
+++ b/vendor/github.com/tektoncd/pruner/pkg/config/config.go
@@ -67,34 +67,34 @@ const (
 // ResourceSpec is used to hold the config of a specific resource
 // Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
 type ResourceSpec struct {
-	Name         string         `yaml:"name,omitempty"`     // Exact name of the parent Pipeline or Task
-	Selector     []SelectorSpec `yaml:"selector,omitempty"` // Supports selection based on labels and annotations. If Name is given, Name takes precedence
-	PrunerConfig `yaml:",inline"`
+	Name         string         `yaml:"name,omitempty" json:"name,omitempty"`         // Exact name of the parent Pipeline or Task
+	Selector     []SelectorSpec `yaml:"selector,omitempty" json:"selector,omitempty"` // Supports selection based on labels and annotations. If Name is given, Name takes precedence
+	PrunerConfig `yaml:",inline,omitempty" json:",inline,omitempty"`
 }
 
 // SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
 // Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
 type SelectorSpec struct {
 	// Match by labels AND annotations. If both are specified, BOTH must match (AND logic)
-	MatchLabels      map[string]string `yaml:"matchLabels,omitempty"`
-	MatchAnnotations map[string]string `yaml:"matchAnnotations,omitempty"`
+	MatchLabels      map[string]string `yaml:"matchLabels,omitempty" json:"matchLabels,omitempty"`
+	MatchAnnotations map[string]string `yaml:"matchAnnotations,omitempty" json:"matchAnnotations,omitempty"`
 }
 
 // NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
 // Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
 // Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
 type NamespaceSpec struct {
-	PrunerConfig `yaml:",inline"` // Root-level defaults
-	PipelineRuns []ResourceSpec   `yaml:"pipelineRuns,omitempty"` // Selector-based configs (namespace ConfigMap only)
-	TaskRuns     []ResourceSpec   `yaml:"taskRuns,omitempty"`     // Selector-based configs (namespace ConfigMap only)
+	PrunerConfig `yaml:",inline,omitempty" json:",inline,omitempty"` // Root-level defaults
+	PipelineRuns []ResourceSpec                                      `yaml:"pipelineRuns,omitempty" json:"pipelineRuns,omitempty"` // Selector-based configs (namespace ConfigMap only)
+	TaskRuns     []ResourceSpec                                      `yaml:"taskRuns,omitempty" json:"taskRuns,omitempty"`         // Selector-based configs (namespace ConfigMap only)
 }
 
 // GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
 // Root-level fields are defaults; Namespaces map is for per-namespace defaults
 // NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
 type GlobalConfig struct {
-	PrunerConfig `yaml:",inline"`         // Global root-level defaults
-	Namespaces   map[string]NamespaceSpec `yaml:"namespaces,omitempty" json:"namespaces,omitempty"` // Per-namespace defaults (selectors ignored)
+	PrunerConfig `yaml:",inline,omitempty" json:",inline,omitempty"` // Global root-level defaults
+	Namespaces   map[string]NamespaceSpec                            `yaml:"namespaces,omitempty" json:"namespaces,omitempty"` // Per-namespace defaults (selectors ignored)
 }
 
 // PrunerConfig used to hold the cluster-wide pruning config as well as namespace specific pruning config
@@ -315,6 +315,65 @@ func getFromPrunerConfigResourceLevelwithSelector(namespacesSpec map[string]Name
 
 	// If no match found, return nil
 	return nil, ""
+}
+
+// getMatchingSelectorFromConfig retrieves the ConfigMap's selector that matches a resource
+func getMatchingSelectorFromConfig(namespacesSpec map[string]NamespaceSpec, namespace, name string, selector SelectorSpec, resourceType PrunerResourceType) *SelectorSpec {
+	prunerResourceSpec, found := namespacesSpec[namespace]
+	if !found {
+		return nil
+	}
+
+	var resourceSpecs []ResourceSpec
+	switch resourceType {
+	case PrunerResourceTypePipelineRun:
+		resourceSpecs = prunerResourceSpec.PipelineRuns
+	case PrunerResourceTypeTaskRun:
+		resourceSpecs = prunerResourceSpec.TaskRuns
+	}
+
+	if len(selector.MatchAnnotations) == 0 && len(selector.MatchLabels) == 0 {
+		return nil
+	}
+
+	for _, resourceSpec := range resourceSpecs {
+		for _, selectorSpec := range resourceSpec.Selector {
+			annotationsMatch := true
+			labelsMatch := true
+
+			if len(selectorSpec.MatchAnnotations) > 0 {
+				if len(selector.MatchAnnotations) == 0 {
+					annotationsMatch = false
+				} else {
+					for key, value := range selectorSpec.MatchAnnotations {
+						if resourceAnnotationValue, exists := selector.MatchAnnotations[key]; !exists || resourceAnnotationValue != value {
+							annotationsMatch = false
+							break
+						}
+					}
+				}
+			}
+
+			if len(selectorSpec.MatchLabels) > 0 {
+				if len(selector.MatchLabels) == 0 {
+					labelsMatch = false
+				} else {
+					for key, value := range selectorSpec.MatchLabels {
+						if resourceLabelValue, exists := selector.MatchLabels[key]; !exists || resourceLabelValue != value {
+							labelsMatch = false
+							break
+						}
+					}
+				}
+			}
+
+			if annotationsMatch && labelsMatch {
+				return &selectorSpec
+			}
+		}
+	}
+
+	return nil
 }
 
 // getResourceFieldData retrieves configuration field values based on enforcedConfigLevel
@@ -648,6 +707,20 @@ func (ps *prunerConfigStore) GetTaskFailedHistoryLimitCount(namespace, name stri
 	defer ps.mutex.Unlock()
 	enforcedConfigLevel := ps.GetTaskEnforcedConfigLevel(namespace, name, selector)
 	return getResourceFieldData(ps.globalConfig, ps.namespaceConfig, namespace, name, selector, PrunerResourceTypeTaskRun, PrunerFieldTypeFailedHistoryLimit, enforcedConfigLevel)
+}
+
+// GetPipelineMatchingSelector returns the ConfigMap's selector that matches a PipelineRun.
+func (ps *prunerConfigStore) GetPipelineMatchingSelector(namespace, name string, selector SelectorSpec) *SelectorSpec {
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
+	return getMatchingSelectorFromConfig(ps.namespaceConfig, namespace, name, selector, PrunerResourceTypePipelineRun)
+}
+
+// GetTaskMatchingSelector returns the ConfigMap's selector that matches a TaskRun.
+func (ps *prunerConfigStore) GetTaskMatchingSelector(namespace, name string, selector SelectorSpec) *SelectorSpec {
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
+	return getMatchingSelectorFromConfig(ps.namespaceConfig, namespace, name, selector, PrunerResourceTypeTaskRun)
 }
 
 // ValidateGlobalConfig validates a GlobalConfig struct directly without ConfigMap conversion

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1348,7 +1348,7 @@ github.com/tektoncd/pipeline/test/parse
 ## explicit; go 1.24.0
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts
-# github.com/tektoncd/pruner v0.3.4
+# github.com/tektoncd/pruner v0.3.5
 ## explicit; go 1.24.0
 github.com/tektoncd/pruner/pkg/config
 github.com/tektoncd/pruner/pkg/metrics


### PR DESCRIPTION
# Changes
This PR updates the Tekton Pruner component to the latest patch release v0.3.5.
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
