### PR TITLE
chore: remove temporary bump output from git tracking

### DIFF
--- a/.github/workflows/bump-payload-on-main.yaml
+++ b/.github/workflows/bump-payload-on-main.yaml
@@ -48,6 +48,9 @@ jobs:
           echo "pr_title=chore: bump payload versions" >> $GITHUB_OUTPUT
           echo "pr_body=Automated component version bump" >> $GITHUB_OUTPUT
         fi
+    - name: clean up temporary files
+      run: |
+        rm -f bump-output.txt commit-message.txt pr-body.txt
     - name: create pull request
       uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8.0.0
       with:

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -64,6 +64,9 @@ jobs:
           echo "pr_title=chore: bump payload versions" >> $GITHUB_OUTPUT
           echo "pr_body=Automated component version bump for ${{ matrix.branch }}" >> $GITHUB_OUTPUT
         fi
+    - name: clean up temporary files
+      run: |
+        rm -f bump-output.txt commit-message.txt pr-body.txt
     - name: create pull request
       uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8.0.0
       with:

--- a/bump-output.txt
+++ b/bump-output.txt
@@ -1,4 +1,0 @@
-BUMP_UPDATES_START
-hub|v1.23.5|v1.23.6|tektoncd/hub
-pipelines-as-code|v0.39.3|v0.40.0|openshift-pipelines/pipelines-as-code
-BUMP_UPDATES_END


### PR DESCRIPTION
# Changes

This PR cleans up the bump component workflows to prevent temporary files from being committed to the repository.

Changes made:
- Removed `bump-output.txt` from git tracking (it was previously committed)
- Added cleanup step in both bump workflows to remove temporary files before PR creation
- Applies to both `bump-payload-on-main.yaml` and `bump-payload-on-releases.yaml`

The workflows now clean up these temporary files before the `create-pull-request` action runs:
- `bump-output.txt`
- `commit-message.txt`
- `pr-body.txt`

# Submitter Checklist

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) - N/A for workflow changes
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) - N/A for internal workflow changes
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```