### PR TITLE
fix: Prevent CI job skips on PRs with large file counts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,15 +37,21 @@ jobs:
       id: detect
       run: |
         git fetch origin ${{ github.base_ref }}
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | tr ' ' '\n')
 
-        echo -e "Changed files:\n${CHANGED_FILES}"
+        # Store git diff command for reuse
+        GIT_DIFF_CMD="git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
 
-        # If no files are changed at all, then `grep -v` will match even though no change outputs
-        # should be true. Skipping output on an empty set of changes eliminates the false positive
-        if [[ -n "${CHANGED_FILES}" ]]; then
-          NON_DOCS=$(echo "${CHANGED_FILES}" | grep -Eqv '\.md$' && echo 'true' || echo 'false')
-          YAML=$(echo "${CHANGED_FILES}" | grep -Eq '\.ya?ml$' && echo 'true' || echo 'false')
+        # Show changed files for debugging (limit to first 50 for readability)
+        echo "Changed files (first 50):"
+        $GIT_DIFF_CMD | head -50
+        FILE_COUNT=$($GIT_DIFF_CMD | wc -l)
+        echo "Total files changed: $FILE_COUNT"
+
+        # If no files are changed at all, skip detection
+        # Use git diff output directly to avoid bash variable size limits with large PRs
+        if [[ $FILE_COUNT -gt 0 ]]; then
+          NON_DOCS=$($GIT_DIFF_CMD | grep -Eqv '\.md$' && echo 'true' || echo 'false')
+          YAML=$($GIT_DIFF_CMD | grep -Eq '\.ya?ml$' && echo 'true' || echo 'false')
           echo "non-docs=${NON_DOCS}" | tee -a $GITHUB_OUTPUT
           echo "yaml=${YAML}" | tee -a $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
# Changes

Fixes CI job detection failure on PRs with large file counts (1000+ files).

## Problem
PRs like #3146 and #2914 with vendor updates (2000+ changed files) had their CI builds incorrectly skipped. The detection logic stored all filenames in a bash variable which exceeded size limits, causing grep to fail and falsely report `non-docs=false`.

## Solution
- Changed `.github/workflows/ci.yaml` to pipe git diff directly to grep instead of storing output in variables
- Avoids bash variable size limits by using command substitution with direct piping
- Added file count display for better debugging

## Testing
Verified locally with PR #3146 data (2243 files):
- Old logic: `non-docs=false` ❌
- New logic: `non-docs=true` ✅

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) - N/A: CI workflow change only
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) - N/A: Internal CI fix
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```