### PR TITLE
Fix CI SIGPIPE error in categorize changes job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,8 @@ jobs:
         # If no files are changed at all, skip detection
         # Use git diff output directly to avoid bash variable size limits with large PRs
         if [[ $FILE_COUNT -gt 0 ]]; then
-          NON_DOCS=$($GIT_DIFF_CMD | grep -Eqv '\.md$' && echo 'true' || echo 'false')
-          YAML=$($GIT_DIFF_CMD | grep -Eq '\.ya?ml$' && echo 'true' || echo 'false')
+          NON_DOCS=$($GIT_DIFF_CMD | grep -Ev '\.md$' > /dev/null && echo 'true' || echo 'false')
+          YAML=$($GIT_DIFF_CMD | grep -E '\.ya?ml$' > /dev/null && echo 'true' || echo 'false')
           echo "non-docs=${NON_DOCS}" | tee -a $GITHUB_OUTPUT
           echo "yaml=${YAML}" | tee -a $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
# Changes

The CI workflow "categorize changes" job was failing with exit code 141 (SIGPIPE). This occurred when using `grep -q` in a pipe - when grep exits immediately after finding a match, it closes the pipe, causing `git diff` to receive SIGPIPE if it's still writing output.

This fix removes the `-q` flag from grep and redirects output to `/dev/null` instead, allowing `git diff` to complete writing without hitting a broken pipe.

**Changed files:**
- `.github/workflows/ci.yaml` - Updated NON_DOCS and YAML detection logic

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
