### PR TITLE
Fix PAC Controller Cycling and Remove Multiple Versions from kodata

### DIFF
--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -198,7 +198,8 @@ release_yaml_pac() {
     local version=$3
 
     ko_data=${SCRIPT_DIR}/cmd/${TARGET}/operator/kodata
-    dirPath=${ko_data}/tekton-addon/pipelines-as-code/${version}
+    comp_dir=${ko_data}/tekton-addon/pipelines-as-code
+    dirPath=${comp_dir}/${version}
 
     if [[ ${version} == "stable" ||  ${version} == "nightly" ]]; then
       url="https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/${version}/release.yaml"
@@ -216,21 +217,22 @@ release_yaml_pac() {
             echo ""
             return
         fi
-     else
-         rm -rf ${dirPath} || true
-         mkdir -p ${dirPath} || true
-
-         http_response=$(curl -s -o ${dest} -w "%{http_code}" ${url})
-         echo url: ${url}
-
-         if [[ $http_response != "200" ]]; then
-             echo "Error: failed to get $comp yaml, status code: $http_response"
-             exit 1
-         fi
-
-         echo "Info: Added $comp/$fileName:$version release yaml !!"
-         echo ""
      fi
+
+     # Before adding releases, remove existing version directories (same pattern as release_yaml)
+     rm -rf ${comp_dir}/*
+     mkdir -p ${dirPath} || true
+
+     http_response=$(curl -s -o ${dest} -w "%{http_code}" ${url})
+     echo url: ${url}
+
+     if [[ $http_response != "200" ]]; then
+         echo "Error: failed to get $comp yaml, status code: $http_response"
+         exit 1
+     fi
+
+     echo "Info: Added $comp/$fileName:$version release yaml !!"
+     echo ""
 
     runtime=( go java nodejs python generic )
     for run in "${runtime[@]}"


### PR DESCRIPTION
# Changes

This PR addresses a critical bug causing PAC (Pipelines-as-Code) controller pods to continuously cycle through different versions (v0.25.0, v0.27.0, v0.27.2, v0.28.0, v0.36.0, v0.41.1, etc.) and fail to stabilize. The root cause investigation revealed that **all 17 available PAC versions were being embedded into the operator image**, causing the operator to create a TektonInstallerSet with 102 manifests containing 51 duplicate PAC deployments (one per version), all with the same name.

The issue happens only on local dev when historical versions of pac are accumultaed

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
