### PR TITLE
fix pac settings map pointer reconciliation Loop

### DIFF
--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_defaults.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_defaults.go
@@ -41,6 +41,19 @@ func (pac *OpenShiftPipelinesAsCode) SetDefaults(ctx context.Context) {
 	pac.Spec.PACSettings.setPACDefaults(logger)
 }
 
+// settingsEqual compares two Settings maps for equality
+func settingsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || v != bv {
+			return false
+		}
+	}
+	return true
+}
+
 func (set *PACSettings) setPACDefaults(logger *zap.SugaredLogger) {
 	if set.Settings == nil {
 		set.Settings = map[string]string{}
@@ -55,7 +68,11 @@ func (set *PACSettings) setPACDefaults(logger *zap.SugaredLogger) {
 	// Remove tektonhub catalog to only keep artifacthub
 	defaultPacSettings.HubCatalogs.Delete("tektonhub")
 
-	set.Settings = ConvertPacStructToConfigMap(&defaultPacSettings)
+	// Only reassign Settings map if values actually changed
+	newSettings := ConvertPacStructToConfigMap(&defaultPacSettings)
+	if !settingsEqual(set.Settings, newSettings) {
+		set.Settings = newSettings
+	}
 	setAdditionalPACControllerDefault(set.AdditionalPACControllers)
 }
 

--- a/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/pipelinesascode.go
@@ -110,7 +110,7 @@ func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, 
 		updated = true
 	}
 
-	if !reflect.DeepEqual(opacCR.Spec.Settings, config.Spec.Platforms.OpenShift.PipelinesAsCode.Settings) {
+	if !reflect.DeepEqual(opacCR.Spec.PACSettings.Settings, config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings) {
 		opacCR.Spec.PACSettings.Settings = config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Settings
 		updated = true
 	}
@@ -122,11 +122,6 @@ func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, 
 
 	if !reflect.DeepEqual(opacCR.Spec.PACSettings.AdditionalPACControllers, config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.AdditionalPACControllers) {
 		opacCR.Spec.PACSettings.AdditionalPACControllers = config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.AdditionalPACControllers
-		updated = true
-	}
-
-	if !reflect.DeepEqual(opacCR.Spec.PACSettings.Options, config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Options) {
-		opacCR.Spec.PACSettings.Options = config.Spec.Platforms.OpenShift.PipelinesAsCode.PACSettings.Options
 		updated = true
 	}
 


### PR DESCRIPTION
# Changes


- Every reconciliation loop unconditionally reassigned the `Settings` map
- Even if values were identical, the map's memory pointer changed
- Kubernetes detected the pointer change as a modification
- This triggered `resourceVersion` increment on CR update
- Led to continuous reconciliation even when no real changes occurred


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
