### PR TITLE
fix location for windows cli

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
@@ -18,7 +18,7 @@ spec:
       text: Download tkn and tkn-pac for Mac x86_64
     - href: https://testserver.com/tkn/tkn-macos-arm64.tar.gz
       text: Download tkn and tkn-pac for Mac ARM 64
-    - href: https://testserver.com/tkn/tkn-windows-amd64.zip
+    - href: https://testserver.com/tkn/tkn-windows-amd64.tar.gz
       text: Download tkn and tkn-pac for Windows x86_64
-    - href: https://testserver.com/tkn/tkn-windows-arm64.zip
+    - href: https://testserver.com/tkn/tkn-windows-arm64.tar.gz
       text: Download tkn and tkn-pac for Windows ARM 64

--- a/pkg/reconciler/openshift/tektonaddon/transformer.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer.go
@@ -77,8 +77,8 @@ func getlinks(baseURL string) []console.CLIDownloadLink {
 		{"IBM Z", "tkn/tkn-linux-s390x.tar.gz"},
 		{"Mac x86_64", "tkn/tkn-macos-amd64.tar.gz"},
 		{"Mac ARM 64", "tkn/tkn-macos-arm64.tar.gz"},
-		{"Windows x86_64", "tkn/tkn-windows-amd64.zip"},
-		{"Windows ARM 64", "tkn/tkn-windows-arm64.zip"},
+		{"Windows x86_64", "tkn/tkn-windows-amd64.tar.gz"},
+		{"Windows ARM 64", "tkn/tkn-windows-arm64.tar.gz"},
 	}
 	links := []console.CLIDownloadLink{}
 	for _, platformURL := range platformURLs {


### PR DESCRIPTION
# Changes
serve-tkn-cli is the container where the binaries are copied.
Now that the binaries are built via Konflux, the push-artifact-to-cdn pipeline fails when the archive is formatted as a ZIP.
As a result, we moved the archived binaries to a .tar.gz format.
Inside the serve-tkn-cli container, we now include a .tar.gz archive for Windows as well, hence this change.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
