### PR TITLE
fix SRVKP-8901: webhooks are missing namespace owner reference

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -91,10 +91,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 	// If installerSet has not set any owner then CRDs will
 	// not have any owner
 	installerSetOwner := installerSet.GetOwnerReferences()
+	targetNamespace := installerSet.GetAnnotations()[v1alpha1.TargetNamespaceKey]
 	logger.Debug("Transforming manifest with ownership information")
 	installManifests, err = installManifests.Transform(
 		injectOwner(getReference(installerSet)),
 		injectOwnerForCRDsAndNamespace(installerSetOwner),
+		injectNamespaceOwnerForOperatorWebhooks(r.kubeClientSet, targetNamespace),
 	)
 	if err != nil {
 		logger.Errorw("Failed to transform manifest with ownership information", "error", err)

--- a/pkg/reconciler/openshift/namespace/namespace.go
+++ b/pkg/reconciler/openshift/namespace/namespace.go
@@ -244,10 +244,6 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 	webhook := configuredWebhook.DeepCopy()
 
-	// Clear out any previous (bad) OwnerReferences.
-	// See: https://github.com/knative/serving/issues/5845
-	webhook.OwnerReferences = nil
-
 	for i, wh := range webhook.Webhooks {
 		if wh.Name != webhook.Name {
 			continue

--- a/pkg/reconciler/proxy/proxy.go
+++ b/pkg/reconciler/proxy/proxy.go
@@ -155,10 +155,6 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 
 	webhook := configuredWebhook.DeepCopy()
 
-	// Clear out any previous (bad) OwnerReferences.
-	// See: https://github.com/knative/serving/issues/5845
-	webhook.OwnerReferences = nil
-
 	for i, wh := range webhook.Webhooks {
 		if wh.Name != webhook.Name {
 			continue


### PR DESCRIPTION
# Changes
fixes
When openshift pipelines operator is installed, it installs a bunch of webhooks. Almost all of them, except for these 3:
proxy.operator.tekton.dev
validation.pipelinesascode.tekton.dev
namespace.operator.tekton.dev
have owner set to the namespace openshift-pipelines
So if the operator is removed by removing the namespace, e.g. using ArgoCD, all webhooks but these 3 are properly removed.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
