### PR TITLE
[cherry-pick: 8c260eb] Add AddConfiguration transformation in Results

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -109,6 +109,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		updateEnvWithDBSecretName(instance.Spec.ResultsAPIProperties),
 		populateGoogleCreds(instance.Spec.ResultsAPIProperties),
 		common.AddDeploymentRestrictedPSA(),
+		common.AddConfiguration(instance.Spec.Config),
 		common.AddStatefulSetRestrictedPSA(),
 		common.DeploymentImages(resultImgs),
 		common.DeploymentEnvVarKubernetesMinVersion(),


### PR DESCRIPTION
# Changes
This  pr is cherry-pick of 8c260ebf48be63dda6c3e9aa4bb88c304a11e367

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
