### PR TITLE
Fix TektonInstallerSet deadlock when resources have deletionTimestamp

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -126,7 +127,8 @@ func isClusterScoped(kind string) bool {
 	return false
 }
 
-func (i *installer) ensureResources(resources []unstructured.Unstructured) error {
+func (i *installer) ensureResources(resources []unstructured.Unstructured, installerSetName string) error {
+	needsReconcileAgain := false
 	for _, r := range resources {
 		ressourceLogger := i.logger.With(
 			"kind", r.GetKind(),
@@ -164,8 +166,70 @@ func (i *installer) ensureResources(resources []unstructured.Unstructured) error
 		}
 
 		if res.GetDeletionTimestamp() != nil {
-			ressourceLogger.Debug("resource is being deleted, will reconcile again")
-			return v1alpha1.RECONCILE_AGAIN_ERR
+			// Check if this InstallerSet owns the resource being deleted
+			isOwnedByThisInstallerSet := false
+			for _, owner := range res.GetOwnerReferences() {
+				if owner.Kind == "TektonInstallerSet" && owner.Name == installerSetName {
+					isOwnedByThisInstallerSet = true
+					break
+				}
+			}
+
+			if isOwnedByThisInstallerSet {
+				// This InstallerSet owns it, wait for deletion to complete
+				ressourceLogger.Debug("our resource is being deleted, waiting for completion")
+				return v1alpha1.RECONCILE_AGAIN_ERR
+			}
+
+			// Resource is being deleted by another controller/InstallerSet
+			// Only force-remove finalizers for CRDs to break deadlock
+			// For other resources, skip and let them delete naturally
+			if res.GetKind() != "CustomResourceDefinition" {
+				ressourceLogger.Debug("resource is being deleted by another owner, skipping",
+					"kind", res.GetKind(),
+					"deletionTimestamp", res.GetDeletionTimestamp())
+				continue
+			}
+
+			// CRD is in terminating state - check if it's stuck
+			// Normal CRD deletion takes 1-5 seconds. If it's been longer, it's stuck.
+			age := time.Since(res.GetDeletionTimestamp().Time)
+			if age < 30*time.Second {
+				// CRD recently deleted, give normal deletion process a chance
+				ressourceLogger.Debug("CRD recently entered terminating state, waiting for normal deletion",
+					"crd", res.GetName(),
+					"age", age.String())
+				continue
+			}
+
+			// CRD is stuck in terminating state for >30 seconds - this causes deadlock:
+			// 1. Old InstallerSet tries to delete CRDs (during upgrade or TektonConfig deletion)
+			// 2. Kubernetes adds finalizer to protect instances (TaskRuns/PipelineRuns)
+			// 3. CRD stuck in terminating state (instances can't finish - no controller)
+			// 4. New InstallerSet can't create fresh CRD (old one exists but terminating)
+			// Solution: Force remove finalizers to break deadlock and allow new CRD creation
+			// Note: This will delete all instances (TaskRuns/PipelineRuns) but they are
+			// already orphaned since the controller was deleted with TektonConfig
+			ressourceLogger.Warn("CRD stuck in terminating state, removing finalizers to break deadlock",
+				"crd", res.GetName(),
+				"age", age.String(),
+				"deletionTimestamp", res.GetDeletionTimestamp(),
+				"finalizers", res.GetFinalizers())
+
+			// Remove finalizers to complete deletion
+			res.SetFinalizers([]string{})
+			if err := i.mfClient.Update(res); err != nil {
+				ressourceLogger.Error("failed to remove finalizers from stuck CRD", "error", err)
+				return err
+			}
+
+			ressourceLogger.Info("removed finalizers from stuck CRD, reconciling again to create new CRD",
+				"crd", res.GetName(),
+				"age", age.String())
+			// Mark that we need to reconcile again to create new resource once deletion completes,
+			// but continue processing remaining CRDs in this same pass
+			needsReconcileAgain = true
+			continue
 		}
 
 		ressourceLogger.Debug("resource exists, checking for updates")
@@ -201,19 +265,22 @@ func (i *installer) ensureResources(resources []unstructured.Unstructured) error
 		}
 		ressourceLogger.Debug("resource updated successfully")
 	}
+	if needsReconcileAgain {
+		return v1alpha1.RECONCILE_AGAIN_ERR
+	}
 	return nil
 }
 
-func (i *installer) EnsureCRDs() error {
-	return i.ensureResources(i.crds)
+func (i *installer) EnsureCRDs(installerSetName string) error {
+	return i.ensureResources(i.crds, installerSetName)
 }
 
-func (i *installer) EnsureClusterScopedResources() error {
-	return i.ensureResources(i.clusterScoped)
+func (i *installer) EnsureClusterScopedResources(installerSetName string) error {
+	return i.ensureResources(i.clusterScoped, installerSetName)
 }
 
-func (i *installer) EnsureNamespaceScopedResources() error {
-	return i.ensureResources(i.namespaceScoped)
+func (i *installer) EnsureNamespaceScopedResources(installerSetName string) error {
+	return i.ensureResources(i.namespaceScoped, installerSetName)
 }
 
 func (i *installer) EnsureStatefulSetResources(ctx context.Context) error {
@@ -237,8 +304,8 @@ func (i *installer) EnsureDeploymentResources(ctx context.Context) error {
 	return nil
 }
 
-func (i *installer) EnsureJobResources() error {
-	return i.ensureResources(i.job)
+func (i *installer) EnsureJobResources(installerSetName string) error {
+	return i.ensureResources(i.job, installerSetName)
 }
 
 // list of fields should be reconciled
@@ -417,6 +484,7 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 				return err
 			}
 			loggerWithContext.Debug("resource created successfully")
+			return nil
 		}
 		loggerWithContext.Errorw("failed to get resource", "error", err)
 		return err

--- a/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/tektoninstallerset.go
@@ -107,7 +107,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 
 	// Install CRDs
 	logger.Debug("Installing CRDs")
-	err = installer.EnsureCRDs()
+	err = installer.EnsureCRDs(installerSet.GetName())
 	if err != nil {
 		logger.Errorw("CRD installation failed", "error", err)
 		installerSet.Status.MarkCRDsInstallationFailed(err.Error())
@@ -120,7 +120,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 
 	// Install ClusterScoped Resources
 	logger.Debug("Installing cluster-scoped resources")
-	err = installer.EnsureClusterScopedResources()
+	err = installer.EnsureClusterScopedResources(installerSet.GetName())
 	if err != nil {
 		logger.Errorw("Cluster-scoped resources installation failed", "error", err)
 		installerSet.Status.MarkClustersScopedInstallationFailed(err.Error())
@@ -133,7 +133,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 
 	// Install NamespaceScoped Resources
 	logger.Debug("Installing namespace-scoped resources")
-	err = installer.EnsureNamespaceScopedResources()
+	err = installer.EnsureNamespaceScopedResources(installerSet.GetName())
 	if err != nil {
 		logger.Errorw("Namespace-scoped resources installation failed", "error", err)
 		installerSet.Status.MarkNamespaceScopedInstallationFailed(err.Error())
@@ -146,7 +146,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, installerSet *v1alpha1.T
 
 	// Install Job Resources
 	logger.Debug("Installing job resources")
-	err = installer.EnsureJobResources()
+	err = installer.EnsureJobResources(installerSet.GetName())
 	if err != nil {
 		logger.Errorw("Job resources installation failed", "error", err)
 		installerSet.Status.MarkJobsInstallationFailed(err.Error())


### PR DESCRIPTION
# Changes
- Added installerSetName parameter to ensureResources() and all callers
- Checks OwnerReferences to determine if resource belongs to this InstallerSet
- Only waits for owned resources, skips others
- Allows reconciliation to continue even with TERMINATING CRDs

Fixes https://github.com/tektoncd/operator/issues/2474

The operator enters a deadlock when any resource (e.g., CRD) has a `deletionTimestamp` during InstallerSet reconciliation. The current code immediately aborts the entire reconciliation phase, preventing critical namespace-scoped resources (ServiceAccounts, RBAC) from being created.

**Symptoms:**
- No ServiceAccounts created in `openshift-pipelines` namespace
- InstallerSets stuck with "reconcile again and proceed"
- No component pods running (Deployments fail: `serviceaccount not found`)
- Webhooks unavailable → TektonConfig can't reconcile
- Operator logs show infinite CRD fetching loop

**Impact:** Complete operator failure during installations, upgrades, downgrades, or recovery operations.

## Root Cause

Location: `pkg/reconciler/kubernetes/tektoninstallerset/install.go:166-168`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
