### PR TITLE
fix: proxy-webhook selector matches operator pods

### DIFF
--- a/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
+++ b/cmd/kubernetes/operator/kodata/webhook/webhook.yaml
@@ -92,11 +92,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: tekton-operator
+      name: tekton-operator-proxy-webhook
   template:
     metadata:
       labels:
-        name: tekton-operator
+        name: tekton-operator-proxy-webhook
         app: tekton-operator
     spec:
       serviceAccountName: tekton-operators-proxy-webhook
@@ -152,7 +152,7 @@ spec:
       port: 443
       targetPort: 8443
   selector:
-    name: tekton-operator
+    name: tekton-operator-proxy-webhook
 
 ---
 

--- a/cmd/openshift/operator/kodata/webhook/webhook.yaml
+++ b/cmd/openshift/operator/kodata/webhook/webhook.yaml
@@ -99,11 +99,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: tekton-operator
+      name: tekton-operator-proxy-webhook
   template:
     metadata:
       labels:
-        name: tekton-operator
+        name: tekton-operator-proxy-webhook
         app: tekton-operator
     spec:
       securityContext:
@@ -160,7 +160,7 @@ spec:
       port: 443
       targetPort: 8443
   selector:
-    name: tekton-operator
+    name: tekton-operator-proxy-webhook
 
 ---
 

--- a/pkg/reconciler/kubernetes/tektoninstallerset/install.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/install.go
@@ -31,6 +31,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -528,6 +529,18 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 			"expectedHash", expectedHashValue,
 		)
 
+		if selectorChanged, err := deploymentSelectorChanged(expected, existing); err != nil {
+			loggerWithContext.Errorw("failed to compare deployment selectors", "error", err)
+			return err
+		} else if selectorChanged {
+			loggerWithContext.Infow("deployment selector changed, deleting resource before recreate")
+			if err := i.mfClient.Delete(existing); err != nil {
+				loggerWithContext.Errorw("failed to delete deployment with changed selector", "error", err)
+				return v1alpha1.RECONCILE_AGAIN_ERR
+			}
+			return v1alpha1.RECONCILE_AGAIN_ERR
+		}
+
 		err = i.copyResourceFields(expected, existing, reconcileFields...)
 		if err != nil {
 			loggerWithContext.Errorw("failed to copy resource fields", "error", err)
@@ -545,6 +558,24 @@ func (i *installer) ensureResource(ctx context.Context, expected *unstructured.U
 	}
 	loggerWithContext.Debug("no changes detected, resource is up-to-date")
 	return nil
+}
+
+func deploymentSelectorChanged(expected, existing *unstructured.Unstructured) (bool, error) {
+	if expected.GetKind() != "Deployment" {
+		return false, nil
+	}
+
+	expectedDeployment := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(expected.Object, expectedDeployment); err != nil {
+		return false, err
+	}
+
+	existingDeployment := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, existingDeployment); err != nil {
+		return false, err
+	}
+
+	return !equality.Semantic.DeepEqual(expectedDeployment.Spec.Selector, existingDeployment.Spec.Selector), nil
 }
 
 func (i *installer) removeExtraKeyInMap(src, dst map[string]string) map[string]string {


### PR DESCRIPTION
# Changes

Fixes #3227

Both the `tekton-operator` and `tekton-operator-proxy-webhook` Deployments
label their Pods with `name: tekton-operator`. The
`tekton-operator-proxy-webhook` Service uses this same label as its only
selector, so it inadvertently load-balances traffic across both Deployments.
Because `tekton-operator` pods do not serve on port 8443, ~50% of admission
webhook requests fail with `connection refused`. Since the
MutatingWebhookConfiguration has `failurePolicy: Fail`, each failure
immediately rejects TaskRun Pod creation.

**Changes:**

- `cmd/kubernetes/operator/kodata/webhook/webhook.yaml`: rename the
  proxy-webhook Deployment's `matchLabels` selector and pod template label
  from `name: tekton-operator` to `name: tekton-operator-proxy-webhook`;
  update the Service `selector` to match.
- `cmd/openshift/operator/kodata/webhook/webhook.yaml`: same change for the
  OpenShift manifest.

The existing `app: tekton-operator` label is preserved on both Deployments.
No other resources are affected.

**Alternative considered:** adding a set-based (`NotIn`) expression to the
Service selector to exclude `tekton-operator` pods. This was not viable
because Kubernetes Services only support equality-based (`matchLabels`)
selectors.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

> **Note on tests:** This bug only manifests at the Service routing layer
> (i.e., ~50% of requests land on a pod with no server). There is no
> in-tree unit or integration test that exercises which pods a Service
> selects. A targeted e2e test verifying that the proxy-webhook Service
> endpoints do not include `tekton-operator` pods would be a good addition,
> but is left for a follow-up.

# Release Notes

```release-note
Fix: the tekton-operator-proxy-webhook Service selector incorrectly matched
tekton-operator pods in addition to proxy-webhook pods, causing ~50% of
admission webhook requests to fail with "connection refused" and TaskRun Pod
creation to be rejected. Users on v0.78.1 can work around this until upgrading
by adding `pod-template-hash: <webhook-pod-hash>` to the Service selector.
```
