### PR TITLE
fix(scheduler): make multi-cluster-role case-insensitive

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonscheduler_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"knative.dev/pkg/apis"
 )
@@ -43,9 +44,9 @@ func (mcc *MultiClusterConfig) validate() (errs *apis.FieldError) {
 	if mcc.MultiClusterDisabled && mcc.MultiClusterRole != "" {
 		errs = errs.Also(apis.ErrInvalidValue("MultiClusterConfig", "multicluster-role",
 			"multicluster-role should be blank when MultiClusterConfig.MultiClusterDisabled is true"))
-	} else if !mcc.MultiClusterDisabled && !(mcc.MultiClusterRole == MultiClusterRoleHub || mcc.MultiClusterRole == MultiClusterRoleSpoke) {
+	} else if !mcc.MultiClusterDisabled && !(strings.EqualFold(string(mcc.MultiClusterRole), string(MultiClusterRoleHub)) || strings.EqualFold(string(mcc.MultiClusterRole), string(MultiClusterRoleSpoke))) {
 		errs = errs.Also(apis.ErrInvalidValue("MultiClusterConfig", "multicluster-role",
-			"multicluster-role should be 'Hub' or 'Spoke' when MultiClusterConfig.MultiClusterDisabled is false"))
+			"multicluster-role should be 'Hub' or 'Spoke' (case-insensitive) when MultiClusterConfig.MultiClusterDisabled is false"))
 	}
 	return errs
 }

--- a/pkg/reconciler/shared/tektonconfig/result/result.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result.go
@@ -171,7 +171,7 @@ func GetTektonResultCR(config *v1alpha1.TektonConfig, operatorVersion string) *v
 	// For Hub clusters (multicluster enabled AND role is Hub), set replicas to 0
 	// for watcher and retention-policy-agent deployments
 	if !config.Spec.Scheduler.MultiClusterDisabled &&
-		config.Spec.Scheduler.MultiClusterRole == v1alpha1.MultiClusterRoleHub {
+		strings.EqualFold(string(config.Spec.Scheduler.MultiClusterRole), string(v1alpha1.MultiClusterRoleHub)) {
 		result = disableWatcherAndRetentionAgentOnHubCluster(result)
 	}
 

--- a/pkg/reconciler/shared/tektonconfig/scheduler/scheduler.go
+++ b/pkg/reconciler/shared/tektonconfig/scheduler/scheduler.go
@@ -39,7 +39,7 @@ func EnsureTektonSchedulerExists(ctx context.Context, clients op.TektonScheduler
 
 	// Update MultiKueueOverride
 	// If MultiCluster is enabled and MultiClusterRole=Hub then MultiKueueOverride should be true
-	newScheduler.Spec.Config.MultiKueueOverride = !newScheduler.Spec.MultiClusterDisabled && newScheduler.Spec.MultiClusterRole == v1alpha1.MultiClusterRoleHub
+	newScheduler.Spec.Config.MultiKueueOverride = !newScheduler.Spec.MultiClusterDisabled && strings.EqualFold(string(newScheduler.Spec.MultiClusterRole), string(v1alpha1.MultiClusterRoleHub))
 	TektonScheduler, err := GetTektonScheduler(ctx, clients, v1alpha1.TektonSchedulerResourceName)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {

--- a/pkg/reconciler/shared/tektonconfig/syncerservice/syncerservice.go
+++ b/pkg/reconciler/shared/tektonconfig/syncerservice/syncerservice.go
@@ -38,7 +38,7 @@ func IsSyncerServiceEnabled(scheduler *v1alpha1.Scheduler) bool {
 		return false
 	}
 	return !scheduler.MultiClusterDisabled &&
-		scheduler.MultiClusterRole == v1alpha1.MultiClusterRoleHub
+		strings.EqualFold(string(scheduler.MultiClusterRole), string(v1alpha1.MultiClusterRoleHub))
 }
 
 // EnsureSyncerServiceExists ensures the SyncerService CR exists if conditions are met


### PR DESCRIPTION
Users can now specify multi-cluster-role values in any case (hub/Hub/HUB, spoke/Spoke/SPOKE) instead of requiring exact capitalization. This improves usability and prevents configuration errors when MultiKueueOverride, SyncerService, or Result components fail to deploy due to case mismatches.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
