### PR TITLE
Enable authorization for Services in Console Plugin

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -152,6 +152,7 @@ spec:
   proxy:
     - type: Service
       alias: tekton-results-api-service
+      authorize: true
       endpoint:
         type: Service
         service:
@@ -160,6 +161,7 @@ spec:
           port: 8080
     - type: Service
       alias: multicluster-proxy
+      authorize: true
       endpoint:
         type: Service
         service:


### PR DESCRIPTION
Added authorization field for tekton-results-api-service and multicluster-proxy.

This ensures that token is passed to console plugin

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
