### PR TITLE
proxy-aae: override WORKERS_SECRET_NAMESPACE for OpenShift

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -451,6 +451,26 @@ scheduler:
 
 See [TektonMulticlusterProxyAAE](./TektonMulticlusterProxyAAE.md) for details on the proxy component and its requirements.
 
+#### OpenShift: proxy-aae Kueue namespace
+
+The proxy-aae deployment reads `WORKERS_SECRET_NAMESPACE` to locate the Kueue operator namespace. The Kubernetes default is `kueue-system`; on OpenShift the operator automatically sets this to `openshift-kueue-operator`. If Kueue is installed in a non-default namespace, override `WORKERS_SECRET_NAMESPACE` via `spec.multiclusterProxyAAE.options` in TektonConfig:
+
+```yaml
+spec:
+  multiclusterProxyAAE:
+    options:
+      deployments:
+        proxy-aae:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: proxy-aae
+                  env:
+                  - name: WORKERS_SECRET_NAMESPACE
+                    value: my-kueue-namespace
+```
+
 ### Addon
 
 TektonAddon install some resources along with Tekton Pipelines on the cluster. This provides few PipelineTemplates, ResolverTasks, ResolverStepActions and CommunityResolverTasks.

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -116,6 +116,9 @@ type TektonConfigSpec struct {
 	// Dashboard holds the customizable options for dashboards component
 	// +optional
 	Dashboard Dashboard `json:"dashboard,omitempty"`
+	// MulticlusterProxyAAE holds the customizable options for the multicluster-proxy-aae component
+	// +optional
+	MulticlusterProxyAAE MulticlusterProxyAAEOptions `json:"multiclusterProxyAAE,omitempty"`
 	// Params is the list of params passed for all platforms
 	// +optional
 	Params []Param `json:"params,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -126,6 +126,7 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(tc.Spec.Chain.Options.validate("spec.chain.options"))
 	errs = errs.Also(tc.Spec.Trigger.Options.validate("spec.trigger.options"))
 	errs = errs.Also(tc.Spec.Result.Options.validate("spec.result.options"))
+	errs = errs.Also(tc.Spec.MulticlusterProxyAAE.Options.validate("spec.multiclusterProxyAAE.options"))
 
 	return errs.Also(tc.Spec.Trigger.TriggersProperties.validate("spec.trigger"))
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1816,6 +1816,7 @@ func (in *TektonConfigSpec) DeepCopyInto(out *TektonConfigSpec) {
 	in.Chain.DeepCopyInto(&out.Chain)
 	in.Result.DeepCopyInto(&out.Result)
 	in.Dashboard.DeepCopyInto(&out.Dashboard)
+	in.MulticlusterProxyAAE.DeepCopyInto(&out.MulticlusterProxyAAE)
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
 		*out = make([]Param, len(*in))

--- a/pkg/reconciler/common/transformer_inject_envvar.go
+++ b/pkg/reconciler/common/transformer_inject_envvar.go
@@ -27,6 +27,14 @@ import (
 	"knative.dev/pkg/version"
 )
 
+// DeploymentEnvVars returns a transformer that injects or replaces the given
+// environment variables in every container of every Deployment in the manifest.
+// If an env var with the same name already exists it is overwritten; otherwise
+// it is appended.
+func DeploymentEnvVars(envVars []corev1.EnvVar) mf.Transformer {
+	return deploymentEnvVars(envVars)
+}
+
 func DeploymentEnvVarKubernetesMinVersion() mf.Transformer {
 	var envVars []corev1.EnvVar
 	if minVersion, exists := os.LookupEnv(version.KubernetesMinVersionKey); exists {

--- a/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension.go
+++ b/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	mf "github.com/manifestival/manifestival"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
@@ -35,6 +37,12 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 	return []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
+		common.DeploymentEnvVars([]corev1.EnvVar{
+			{
+				Name:  "WORKERS_SECRET_NAMESPACE",
+				Value: "openshift-kueue-operator",
+			},
+		}),
 	}
 }
 

--- a/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension_test.go
+++ b/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonmulticlusterproxyaae
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestOpenShiftExtensionTransformers(t *testing.T) {
+	t.Run("sets WORKERS_SECRET_NAMESPACE to openshift-kueue-operator", func(t *testing.T) {
+		manifest := loadTestManifest(t)
+		cr := &v1alpha1.TektonMulticlusterProxyAAE{}
+
+		transformers := openshiftExtension{}.Transformers(cr)
+		newManifest, err := manifest.Transform(transformers...)
+		if err != nil {
+			t.Fatalf("unexpected error applying transformers: %v", err)
+		}
+
+		assertDeploymentEnvVar(t, newManifest, "WORKERS_SECRET_NAMESPACE", "openshift-kueue-operator")
+	})
+
+	// spec.options.deployments allows users to override env vars set by the extension.
+	// Since ExecuteAdditionalOptionsTransformer runs after the extension transformers,
+	// the options value takes precedence.
+	t.Run("spec.options can override WORKERS_SECRET_NAMESPACE", func(t *testing.T) {
+		manifest := loadTestManifest(t)
+		cr := &v1alpha1.TektonMulticlusterProxyAAE{
+			Spec: v1alpha1.TektonMulticlusterProxyAAESpec{
+				MulticlusterProxyAAEOptions: v1alpha1.MulticlusterProxyAAEOptions{
+					Options: v1alpha1.AdditionalOptions{
+						Deployments: map[string]appsv1.Deployment{
+							"proxy-aae": {
+								Spec: appsv1.DeploymentSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name: "proxy-aae",
+													Env: []corev1.EnvVar{
+														{
+															Name:  "WORKERS_SECRET_NAMESPACE",
+															Value: "custom-namespace",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Apply extension transformers first — sets openshift-kueue-operator.
+		transformers := openshiftExtension{}.Transformers(cr)
+		newManifest, err := manifest.Transform(transformers...)
+		if err != nil {
+			t.Fatalf("unexpected error applying transformers: %v", err)
+		}
+
+		// Apply options transformer — overrides with the user-supplied value.
+		if err := common.ExecuteAdditionalOptionsTransformer(
+			context.Background(), &newManifest,
+			cr.Spec.GetTargetNamespace(), cr.Spec.Options,
+		); err != nil {
+			t.Fatalf("unexpected error from options transformer: %v", err)
+		}
+
+		assertDeploymentEnvVar(t, newManifest, "WORKERS_SECRET_NAMESPACE", "custom-namespace")
+	})
+}
+
+func loadTestManifest(t *testing.T) mf.Manifest {
+	t.Helper()
+	manifest, err := mf.ManifestFrom(mf.Recursive(path.Join("testdata", "proxy-aae-deployment.yaml")))
+	if err != nil {
+		t.Fatalf("failed to load test manifest: %v", err)
+	}
+	return manifest
+}
+
+func assertDeploymentEnvVar(t *testing.T, manifest mf.Manifest, envName, expectedValue string) {
+	t.Helper()
+	for _, resource := range manifest.Resources() {
+		if resource.GetKind() != "Deployment" {
+			continue
+		}
+
+		d := &appsv1.Deployment{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, d); err != nil {
+			t.Fatalf("failed to convert resource to Deployment: %v", err)
+		}
+
+		for _, container := range d.Spec.Template.Spec.Containers {
+			for _, env := range container.Env {
+				if env.Name == envName {
+					if env.Value != expectedValue {
+						t.Errorf("deployment %q container %q: env %q = %q, want %q",
+							d.Name, container.Name, envName, env.Value, expectedValue)
+					}
+					return
+				}
+			}
+		}
+		t.Errorf("deployment %q: env var %q not found in any container", d.Name, envName)
+	}
+}

--- a/pkg/reconciler/openshift/tektonmulticlusterproxyaae/testdata/proxy-aae-deployment.yaml
+++ b/pkg/reconciler/openshift/tektonmulticlusterproxyaae/testdata/proxy-aae-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-aae
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-aae
+  template:
+    metadata:
+      labels:
+        app: proxy-aae
+    spec:
+      containers:
+      - name: proxy-aae
+        image: proxy-aae:latest
+        env:
+        - name: WORKERS_SECRET_NAMESPACE
+          value: "kueue-system"

--- a/pkg/reconciler/shared/tektonconfig/multiclusterproxyaae/multiclusterproxyaae.go
+++ b/pkg/reconciler/shared/tektonconfig/multiclusterproxyaae/multiclusterproxyaae.go
@@ -118,6 +118,7 @@ func GetTektonMulticlusterProxyAAECR(config *v1alpha1.TektonConfig, operatorVers
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
+			MulticlusterProxyAAEOptions: config.Spec.MulticlusterProxyAAE,
 		},
 	}
 }


### PR DESCRIPTION
On OpenShift, the kueue operator runs in the openshift-kueue-operator namespace rather than the upstream default kueue-system. Add an OpenShift transform in the proxy-aae extension to replace the WORKERS_SECRET_NAMESPACE env var accordingly. Export DeploymentEnvVars in the common package to make the transformer reusable. Add tests covering both the default transform and the ability for spec.options to override the value.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
