### PR TITLE
Downgrade repetitive Info-level logs to Debug level to reduce operato…

### DIFF
--- a/pkg/common/scc.go
+++ b/pkg/common/scc.go
@@ -66,7 +66,7 @@ func GetSCCRestrictiveList(ctx context.Context, securityClient security.Interfac
 	for _, sortedSCC := range sccPointerList {
 		sccLog = fmt.Sprintf("%s %s", sccLog, sortedSCC.Name)
 	}
-	logger.Info(sccLog)
+	logger.Debug(sccLog)
 	return sccPointerList, nil
 }
 

--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -228,7 +228,7 @@ func (r *rbac) ensurePreRequisites(ctx context.Context) error {
 		// Should not really happen due to defaulting, but okay...
 		return fmt.Errorf("tektonConfig.Spec.Platforms.OpenShift.SCC.Default cannot be empty")
 	}
-	logger.Infof("default SCC set to: %s", defaultSCC)
+	logger.Debugf("default SCC set to: %s", defaultSCC)
 	if err := common.VerifySCCExists(ctx, defaultSCC, r.securityClientSet); err != nil {
 		return fmt.Errorf("failed to verify scc %s exists, %w", defaultSCC, err)
 	}
@@ -253,9 +253,9 @@ func (r *rbac) ensurePreRequisites(ctx context.Context) error {
 		if !isPriority {
 			return fmt.Errorf("maxAllowed SCC: %s must be less restrictive than the default SCC: %s", maxAllowedSCC, defaultSCC)
 		}
-		logger.Infof("maxAllowed SCC set to: %s", maxAllowedSCC)
+		logger.Debugf("maxAllowed SCC set to: %s", maxAllowedSCC)
 	} else {
-		logger.Info("No maxAllowed SCC set in TektonConfig")
+		logger.Debug("No maxAllowed SCC set in TektonConfig")
 	}
 
 	// Maintaining a separate cluster role for the scc declaration.
@@ -546,14 +546,14 @@ func (r *rbac) createResources(ctx context.Context) error {
 
 	// Early return if no namespaces need reconciliation for either feature
 	if len(namespacesToReconcile.RBACNamespaces) == 0 && len(namespacesToReconcile.CANamespaces) == 0 {
-		logger.Info("No namespaces need reconciliation for either RBAC or CA bundles")
+		logger.Debug("No namespaces need reconciliation for either RBAC or CA bundles")
 		return nil
 	}
 
 	// Step 4: Handle RBAC if enabled
 	if createRBACResource {
 		if len(namespacesToReconcile.RBACNamespaces) == 0 {
-			logger.Info("No namespaces need RBAC reconciliation")
+			logger.Debug("No namespaces need RBAC reconciliation")
 		} else {
 			logger.Debugf("Found %d namespaces to be reconciled for RBAC", len(namespacesToReconcile.RBACNamespaces))
 
@@ -597,7 +597,7 @@ func (r *rbac) createResources(ctx context.Context) error {
 	// Step 5: Handle CA bundles if enabled
 	if createCABundles {
 		if len(namespacesToReconcile.CANamespaces) == 0 {
-			logger.Info("No namespaces need CA bundle reconciliation")
+			logger.Debug("No namespaces need CA bundle reconciliation")
 		} else {
 			logger.Debugf("Found %d namespaces to be reconciled for CA bundles", len(namespacesToReconcile.CANamespaces))
 
@@ -843,7 +843,7 @@ func (r *rbac) ensureSCCRoleInNamespace(ctx context.Context, namespace string, s
 func (r *rbac) ensurePipelinesSCClusterRole(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("finding cluster role:", pipelinesSCCClusterRole)
+	logger.Debug("finding cluster role:", pipelinesSCCClusterRole)
 
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
…r log noise during steady-state operation.

# Changes
 "No namespaces need reconciliation for either RBAC or CA bundles"
  (occurred 4,687 times in 42.5h in customer logs)
- "No namespaces need RBAC reconciliation"
- "No namespaces need CA bundle reconciliation"
- "default SCC set to: X"
- "maxAllowed SCC set to: X"
- "No maxAllowed SCC set in TektonConfig"
- "finding cluster role: X"
- "SCCs sorted from most restrictive to least restrictive..."

These logs are routine operational checks that don't indicate issues
and should only appear at Debug level. Info level is reserved for
significant events and state changes.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
