### PR TITLE
fix: propagate TektonConfig config to TektonResult CR

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/result/result.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result.go
@@ -140,6 +140,11 @@ func UpdateResult(ctx context.Context, old *v1alpha1.TektonResult, new *v1alpha1
 		updated = true
 	}
 
+	if !reflect.DeepEqual(old.Spec.Config, new.Spec.Config) {
+		old.Spec.Config = new.Spec.Config
+		updated = true
+	}
+
 	if old.ObjectMeta.OwnerReferences == nil {
 		old.ObjectMeta.OwnerReferences = new.ObjectMeta.OwnerReferences
 		updated = true
@@ -188,6 +193,7 @@ func GetTektonResultCR(config *v1alpha1.TektonConfig, operatorVersion string) *v
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
 			Result: result,
+			Config: config.Spec.Config,
 		},
 	}
 }


### PR DESCRIPTION
Copy  the spec.config (nodeSelector, tolerations, priorityClassName) from TektonConfig into the TektonResult CR in GetTektonResultCR and keep it in sync in UpdateResult, so Results pods are scheduled according to TektonConfig config's configuration

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Copy the spec.config (nodeSelector, tolerations, priorityClassName) from TektonConfig into the TektonResult CR  and keep it in sync so Results pods are scheduled according to TektonConfig config's configuration
```
