### PR TITLE
Move inactive approvers to alumni

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,8 @@
 
 approvers:
 - anithapriyanatarajan
-- concaf
-- jkandasa
 - jkhelil
 - mbpavan
-- piyush-garg
 - PuneetPunamiya
 - savitaashture
 - vdemeester
@@ -18,7 +15,6 @@ reviewers:
 - khrm
 - l-qing
 - mbpavan
-- piyush-garg
 - pramodbindal
 - pratap0007
 - PuneetPunamiya
@@ -29,3 +25,6 @@ reviewers:
 # - pradeepitm12
 # - sm43
 # - vincent-pli
+# - concaf
+# - jkandasa
+# - piyush-garg


### PR DESCRIPTION
# Changes

Move concaf, jkandasa, and piyush-garg to alumni status. Also remove piyush-garg from reviewers.

- **concaf**: last activity Nov 2025, zero devstats contributions in last year (665 in last 5 years)
- **jkandasa**: only 13 devstats operator contributions in last year (547 in last 2 years — rapidly declining). Zero PRs authored, zero reviews.
- **piyush-garg**: zero operator activity in 12 months (976 contributions org-wide in last 2 years — dropped off completely)

Per the [contributor ladder inactivity policy](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity), >4 months of no contributions warrants moving to emeritus.

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```