### PR TITLE
Update Hub repo org name and openshift-pipelines/hub version

### DIFF
--- a/components.nightly.yaml
+++ b/components.nightly.yaml
@@ -22,7 +22,7 @@ manual-approval-gate:
   github: openshift-pipelines/manual-approval-gate
   version: v0.3.0
 hub:
-  github: tektoncd/hub
+  github: openshift-pipelines/hub
   version: v1.18.0
 pipelines-as-code:
   github: openshift-pipelines/pipelines-as-code

--- a/components.yaml
+++ b/components.yaml
@@ -5,8 +5,8 @@ dashboard:
   github: tektoncd/dashboard
   version: v0.63.1
 hub:
-  github: tektoncd/hub
-  version: v1.23.6
+  github: openshift-pipelines/hub
+  version: v1.23.8
 manual-approval-gate:
   github: openshift-pipelines/manual-approval-gate
   version: v0.7.0

--- a/docs/TektonHub.md
+++ b/docs/TektonHub.md
@@ -118,7 +118,7 @@ To install Tekton Hub on your cluster follow steps as given below:
         - `GHE_URL=<github enterprise url(leave it blank if not using github enterprise>`
         - `GLE_URL=<gitlab enterprise url(leave it blank if not using gitlab enterprise>`
 
-   > _Note 1_: For more details please refer to [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md#create-git-oauth-applications)
+   > _Note 1_: For more details please refer to [here](https://github.com/openshift-pipelines/hub/blob/main/docs/DEPLOYMENT.md#create-git-oauth-applications)
 
 3. Once the secrets are created now we need to understand how TektonHub CR looks.
 
@@ -181,4 +181,4 @@ To install Tekton Hub on your cluster follow steps as given below:
     hub    v1.6.0    True             https://api.route.url   https://ui.route.url
     ```
 
-[hub]: https://github.com/tektoncd/hub
+[hub]: https://github.com/openshift-pipelines/hub

--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -305,7 +305,7 @@ release_yaml_hub() {
   ko_data=${SCRIPT_DIR}/cmd/${TARGET}/operator/kodata
   if [ ${version} == "latest" ]
   then
-    version=$(curl -sL https://api.github.com/repos/tektoncd/hub/releases | jq -r ".[].tag_name" | sort -Vr | head -n1)
+    version=$(curl -sL https://api.github.com/repos/openshift-pipelines/hub/releases | jq -r ".[].tag_name" | sort -Vr | head -n1)
     dirPath=${ko_data}/tekton-hub/0.0.0-latest
   else
     dirPath=${ko_data}/tekton-hub/${version}
@@ -336,7 +336,7 @@ release_yaml_hub() {
 
     [[ ${component} == "api" ]] || [[ ${component} == "ui" ]] && fileName=${component}-${TARGET}.yaml
 
-    url="https://github.com/tektoncd/hub/releases/download/${version}/${fileName}"
+    url="https://github.com/openshift-pipelines/hub/releases/download/${version}/${fileName}"
     echo $url
     http_response=$(curl -s -L -o ${destinationFile} -w "%{http_code}" ${url})
     echo url: ${url}

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -334,7 +334,7 @@ spec:
     - Tekton Triggers: v0.34.0
     - Pipelines as Code: v0.39.5
     - Tekton Chains: v0.26.2
-    - Tekton Hub (tech-preview): v1.23.6
+    - Tekton Hub (tech-preview): v1.23.8
     - Tekton Results: v0.17.2
     - Manual Approval Gate (tech-preview): v0.7.0
     - Tekton Pruner: v0.3.5


### PR DESCRIPTION
Upstream Hub is archived and forked to openshift-pipelines org
and this patch updates Hub org name and also updates Hub 
version to latest patch version.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
