### PR TITLE
Fix: Syncer Service Transformer

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -55,7 +55,7 @@ const (
 	PrunerImagePrefix               = "IMAGE_PRUNER_"
 	SchedulerImagePrefix            = "IMAGE_SCHEDULER_"
 	MulticlusterProxyAAEImagePrefix = "IMAGE_MULTICLUSTERPROXYAAE_"
-	SyncerServiceImagePrefix        = "IMAGE_SYNCER_SERVICE_"
+	SyncerServiceImagePrefix        = "IMAGE_SYNCER_SERVICE_WORKLOAD_"
 	ResultsImagePrefix              = "IMAGE_RESULTS_"
 	HubImagePrefix                  = "IMAGE_HUB_"
 	DashboardImagePrefix            = "IMAGE_DASHBOARD_"

--- a/pkg/reconciler/openshift/const.go
+++ b/pkg/reconciler/openshift/const.go
@@ -1,6 +1,7 @@
 package openshift
 
 const (
+	KueueNameSpace                  = "openshift-kueue-operator"
 	OperandOpenShiftPipelinesAddons = "openshift-pipelines-addons"
 	OperandOpenShiftPipelineAsCode  = "openshift-pipeline-as-code"
 	// NamespaceSCCAnnotation is used to set SCC for a given namespace

--- a/pkg/reconciler/openshift/syncerservice/extension.go
+++ b/pkg/reconciler/openshift/syncerservice/extension.go
@@ -22,7 +22,9 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -36,6 +38,12 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundlesToDeployment,
+		common.DeploymentEnvVars([]corev1.EnvVar{
+			{
+				Name:  "KUEUE_NAMESPACE",
+				Value: openshift.KueueNameSpace,
+			},
+		}),
 	}
 }
 

--- a/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension.go
+++ b/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -40,7 +41,7 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		common.DeploymentEnvVars([]corev1.EnvVar{
 			{
 				Name:  "WORKERS_SECRET_NAMESPACE",
-				Value: "openshift-kueue-operator",
+				Value: openshift.KueueNameSpace,
 			},
 		}),
 	}

--- a/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension_test.go
+++ b/pkg/reconciler/openshift/tektonmulticlusterproxyaae/extension_test.go
@@ -24,6 +24,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/openshift"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,7 @@ func TestOpenShiftExtensionTransformers(t *testing.T) {
 			t.Fatalf("unexpected error applying transformers: %v", err)
 		}
 
-		assertDeploymentEnvVar(t, newManifest, "WORKERS_SECRET_NAMESPACE", "openshift-kueue-operator")
+		assertDeploymentEnvVar(t, newManifest, "WORKERS_SECRET_NAMESPACE", openshift.KueueNameSpace)
 	})
 
 	// spec.options.deployments allows users to override env vars set by the extension.


### PR DESCRIPTION
1. Default Kueue Namespace on openshiftr must be openshift-kueue-operator not kueue-system 
2. update the image prefix  as container name in deployment is controller not workload-controller

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
