### PR TITLE
feat: Generate OpenAPI schemas for all CRDs using controller-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ $(BIN)/kustomize: | $(BIN) ; $(info $(M) getting kustomize)
 	@curl -sSfL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
 	@mv ./kustomize $(BIN)/kustomize
 
+CONTROLLER_GEN = $(or ${CONTROLLER_GEN_BIN},$(BIN)/controller-gen)
+$(BIN)/controller-gen: | $(BIN) ; $(info $(M) getting controller-gen)
+	$Q GOBIN=$(BIN) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
+
 GOLANGCILINT = $(or ${GOLANGCILINT_BIN},${GOLANGCILINT_BIN},$(BIN)/golangci-lint)
 $(BIN)/golangci-lint: | $(BIN) ; $(info $(M) getting golangci-lint $(GOLANGCI_VERSION))
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) $(GOLANGCI_VERSION)
@@ -116,6 +120,15 @@ resolve: | $(KO) $(KUSTOMIZE) get-releases ; $(info $(M) ko resolve on $(TARGET)
 .PHONY: generated
 generated: | vendor ; $(info $(M) update generated files) ## Update generated files
 	$Q ./hack/update-codegen.sh
+
+##@ CRD Generation
+.PHONY: generate-crds
+generate-crds: | $(CONTROLLER_GEN) ; $(info $(M) generating CRDs from Go types…) ## Generate CRD manifests from Go types
+	$Q $(CONTROLLER_GEN) crd:allowDangerousTypes=true paths="./pkg/apis/operator/v1alpha1/..." output:crd:artifacts:config=config/base/generated-crds
+
+.PHONY: sync-helm-crds
+sync-helm-crds: generate-crds ; $(info $(M) syncing CRDs to config and Helm chart…) ## Sync generated CRDs to config/ and Helm chart
+	$Q ./hack/sync-helm-crds.sh
 
 .PHONY: vendor
 vendor: ; $(info $(M) update vendor folder)  ## Update vendor folder

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
   labels:
     version: "devel"
@@ -13,81 +15,401 @@ spec:
     kind: ManualApprovalGate
     listKind: ManualApprovalGateList
     plural: manualapprovalgates
-    singular: manualapprovalgate
     shortNames:
-      - mag
-  preserveUnknownFields: false
+    - mag
+    singular: manualapprovalgate
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: ".status.conditions[?(@.type==\"Ready\")].message"
-          name: Reason
-          type: string
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: Schema for the ManualApprovalGate API
-          x-kubernetes-preserve-unknown-fields: true
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManualApprovalGate is the Schema for the ManualApprovalGate API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: ManualApprovalGateStatus defines the observed state of ManualApprovalGate
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for ManualApprovalGate
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: openshiftpipelinesascodes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode
     listKind: OpenShiftPipelinesAsCodeList
     plural: openshiftpipelinesascodes
-    singular: openshiftpipelinesascode
     shortNames:
-      - opac
-      - pac
-  preserveUnknownFields: false
+    - opac
+    - pac
+    singular: openshiftpipelinesascode
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the OpenShiftPipelinesAsCode API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenShiftPipelinesAsCode is the Schema for the OpenShiftPipelinesAsCode
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenShiftPipelinesAsCodeSpec defines the desired state of
+              OpenShiftPipelinesAsCode
+            properties:
+              additionalPACControllers:
+                additionalProperties:
+                  description: AdditionalPACControllerConfig contains config for additionalPACControllers
+                  properties:
+                    configMapName:
+                      description: Name of the additional controller configMap
+                      type: string
+                    enable:
+                      description: Enable or disable this additional pipelines as
+                        code instance by changing this bool
+                      type: boolean
+                    secretName:
+                      description: Name of the additional controller Secret
+                      type: string
+                    settings:
+                      additionalProperties:
+                        type: string
+                      description: Setting will contains the configMap data
+                      type: object
+                  type: object
+                description: AdditionalPACControllers allows to deploy additional
+                  PAC controller
+                type: object
+              config:
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              settings:
+                additionalProperties:
+                  type: string
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: OpenShiftPipelinesAsCodeStatus defines the observed state
+              of OpenShiftPipelinesAsCode
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -95,37 +417,487 @@ spec:
     listKind: TektonChainList
     plural: tektonchains
     singular: tektonchain
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonChains API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonChain is the Schema for the tektonchain API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonChainSpec defines the desired state of TektonChain
+            properties:
+              artifacts.oci.format:
+                description: oci artifacts config
+                type: string
+              artifacts.oci.signer:
+                type: string
+              artifacts.oci.storage:
+                type: string
+              artifacts.pipelinerun.enable-deep-inspection:
+                type: string
+              artifacts.pipelinerun.format:
+                description: pipelinerun artifacts config
+                type: string
+              artifacts.pipelinerun.signer:
+                type: string
+              artifacts.pipelinerun.storage:
+                type: string
+              artifacts.taskrun.format:
+                description: taskrun artifacts config
+                type: string
+              artifacts.taskrun.signer:
+                type: string
+              artifacts.taskrun.storage:
+                type: string
+              builddefinition.buildtype:
+                type: string
+              builder.id:
+                description: builder config
+                type: string
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonChain
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              controllerEnvs:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              disabled:
+                description: enable or disable chains feature
+                type: boolean
+              generateSigningSecret:
+                description: generate signing key
+                type: boolean
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              signers.kms.auth.address:
+                type: string
+              signers.kms.auth.oidc.path:
+                type: string
+              signers.kms.auth.oidc.role:
+                type: string
+              signers.kms.auth.spire.audience:
+                type: string
+              signers.kms.auth.spire.sock:
+                type: string
+              signers.kms.auth.token:
+                type: string
+              signers.kms.auth.token-path:
+                type: string
+              signers.kms.kmsref:
+                description: kms signer config
+                type: string
+              signers.x509.fulcio.address:
+                type: string
+              signers.x509.fulcio.enabled:
+                description: x509 signer config
+                type: boolean
+              signers.x509.fulcio.issuer:
+                type: string
+              signers.x509.fulcio.provider:
+                type: string
+              signers.x509.identity.token.file:
+                type: string
+              signers.x509.tuf.mirror.url:
+                type: string
+              storage.docdb.mongo-server-url:
+                type: string
+              storage.docdb.mongo-server-url-dir:
+                type: string
+              storage.docdb.url:
+                type: string
+              storage.gcs.bucket:
+                description: storage configs
+                type: string
+              storage.grafeas.notehint:
+                type: string
+              storage.grafeas.noteid:
+                type: string
+              storage.grafeas.projectid:
+                type: string
+              storage.oci.repository:
+                type: string
+              storage.oci.repository.insecure:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              transparency.enabled:
+                type: string
+              transparency.url:
+                type: string
+            required:
+            - disabled
+            - options
+            type: object
+          status:
+            description: TektonChainStatus defines the observed state of TektonChain
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonChain
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -133,37 +905,1438 @@ spec:
     listKind: TektonConfigList
     plural: tektonconfigs
     singular: tektonconfig
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonconfigs API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonConfig is the Schema for the TektonConfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonConfigSpec defines the desired state of TektonConfig
+            properties:
+              addon:
+                description: Addon holds the addons config
+                properties:
+                  enablePipelinesAsCode:
+                    description: |-
+                      Deprecated, will be removed in further release
+                      EnablePAC field defines whether to install PAC
+                    type: boolean
+                  params:
+                    description: Params is the list of params passed for Addon customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              chain:
+                description: Chain holds the customizable option for chains component
+                properties:
+                  artifacts.oci.format:
+                    description: oci artifacts config
+                    type: string
+                  artifacts.oci.signer:
+                    type: string
+                  artifacts.oci.storage:
+                    type: string
+                  artifacts.pipelinerun.enable-deep-inspection:
+                    type: string
+                  artifacts.pipelinerun.format:
+                    description: pipelinerun artifacts config
+                    type: string
+                  artifacts.pipelinerun.signer:
+                    type: string
+                  artifacts.pipelinerun.storage:
+                    type: string
+                  artifacts.taskrun.format:
+                    description: taskrun artifacts config
+                    type: string
+                  artifacts.taskrun.signer:
+                    type: string
+                  artifacts.taskrun.storage:
+                    type: string
+                  builddefinition.buildtype:
+                    type: string
+                  builder.id:
+                    description: builder config
+                    type: string
+                  controllerEnvs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  disabled:
+                    description: enable or disable chains feature
+                    type: boolean
+                  generateSigningSecret:
+                    description: generate signing key
+                    type: boolean
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  signers.kms.auth.address:
+                    type: string
+                  signers.kms.auth.oidc.path:
+                    type: string
+                  signers.kms.auth.oidc.role:
+                    type: string
+                  signers.kms.auth.spire.audience:
+                    type: string
+                  signers.kms.auth.spire.sock:
+                    type: string
+                  signers.kms.auth.token:
+                    type: string
+                  signers.kms.auth.token-path:
+                    type: string
+                  signers.kms.kmsref:
+                    description: kms signer config
+                    type: string
+                  signers.x509.fulcio.address:
+                    type: string
+                  signers.x509.fulcio.enabled:
+                    description: x509 signer config
+                    type: boolean
+                  signers.x509.fulcio.issuer:
+                    type: string
+                  signers.x509.fulcio.provider:
+                    type: string
+                  signers.x509.identity.token.file:
+                    type: string
+                  signers.x509.tuf.mirror.url:
+                    type: string
+                  storage.docdb.mongo-server-url:
+                    type: string
+                  storage.docdb.mongo-server-url-dir:
+                    type: string
+                  storage.docdb.url:
+                    type: string
+                  storage.gcs.bucket:
+                    description: storage configs
+                    type: string
+                  storage.grafeas.notehint:
+                    type: string
+                  storage.grafeas.noteid:
+                    type: string
+                  storage.grafeas.projectid:
+                    type: string
+                  storage.oci.repository:
+                    type: string
+                  storage.oci.repository.insecure:
+                    type: boolean
+                  transparency.enabled:
+                    type: string
+                  transparency.url:
+                    type: string
+                required:
+                - disabled
+                - options
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonConfig
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              dashboard:
+                description: Dashboard holds the customizable options for dashboards
+                  component
+                properties:
+                  external-logs:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  readonly:
+                    description: Readonly when set to true configures the Tekton dashboard
+                      in read-only mode
+                    type: boolean
+                required:
+                - options
+                - readonly
+                type: object
+              hub:
+                description: Hub holds the hub config
+                properties:
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: Params is the list of params passed for Hub customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - options
+                type: object
+              multiclusterProxyAAE:
+                description: MulticlusterProxyAAE holds the customizable options for
+                  the multicluster-proxy-aae component
+                properties:
+                  options:
+                    description: options holds additional fields and these fields
+                      will be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - options
+                type: object
+              params:
+                description: Params is the list of params passed for all platforms
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              pipeline:
+                description: Pipeline holds the customizable option for pipeline component
+                properties:
+                  await-sidecar-readiness:
+                    type: boolean
+                  bundles-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  cluster-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  coschedule:
+                    type: string
+                  default-affinity-assistant-pod-template:
+                    type: string
+                  default-cloud-events-sink:
+                    type: string
+                  default-forbidden-env:
+                    type: string
+                  default-managed-by-label-value:
+                    type: string
+                  default-max-matrix-combinations-count:
+                    type: string
+                  default-pod-template:
+                    type: string
+                  default-resolver-type:
+                    type: string
+                  default-service-account:
+                    type: string
+                  default-task-run-workspace-binding:
+                    type: string
+                  default-timeout-minutes:
+                    type: integer
+                  disable-affinity-assistant:
+                    description: |-
+                      Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                      This field is removed from pipeline component.
+                      Keeping here to maintain API compatibility during upgrades.
+                    type: boolean
+                  disable-creds-init:
+                    type: boolean
+                  disable-inline-spec:
+                    type: string
+                  embedded-status:
+                    type: string
+                  enable-api-fields:
+                    type: string
+                  enable-bundles-resolver:
+                    type: boolean
+                  enable-cel-in-whenexpression:
+                    type: boolean
+                  enable-cluster-resolver:
+                    type: boolean
+                  enable-custom-tasks:
+                    type: boolean
+                  enable-git-resolver:
+                    type: boolean
+                  enable-hub-resolver:
+                    type: boolean
+                  enable-param-enum:
+                    type: boolean
+                  enable-provenance-in-status:
+                    type: boolean
+                  enable-step-actions:
+                    type: boolean
+                  enable-tekton-oci-bundles:
+                    description: |-
+                      not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                      this field is removed from pipeline component
+                      keeping here to maintain the API compatibility
+                    type: boolean
+                  enforce-nonfalsifiability:
+                    type: string
+                  git-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  hub-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  keep-pod-on-cancel:
+                    type: boolean
+                  max-result-size:
+                    format: int32
+                    type: integer
+                  metrics.count.enable-reason:
+                    type: boolean
+                  metrics.pipelinerun.duration-type:
+                    type: string
+                  metrics.pipelinerun.level:
+                    type: string
+                  metrics.taskrun.duration-type:
+                    type: string
+                  metrics.taskrun.level:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: The params to customize different components of Pipelines
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  require-git-ssh-secret-known-hosts:
+                    type: boolean
+                  results-from:
+                    type: string
+                  running-in-environment-with-injected-sidecars:
+                    type: boolean
+                  scope-when-expressions-to-task:
+                    description: ScopeWhenExpressionsToTask is deprecated and never
+                      used.
+                    type: boolean
+                  send-cloudevents-for-runs:
+                    type: boolean
+                  set-security-context:
+                    type: boolean
+                  traces.credentialsSecret:
+                    description: CredentialsSecret is the name of the secret containing
+                      credentials for the tracing endpoint
+                    type: string
+                  traces.enabled:
+                    description: Enabled controls whether tracing is enabled or not
+                    type: boolean
+                  traces.endpoint:
+                    description: Endpoint is the URL for the OpenTelemetry trace collector
+                    type: string
+                  trusted-resources-verification-no-match-policy:
+                    type: string
+                  verification-mode:
+                    type: string
+                required:
+                - options
+                type: object
+              platforms:
+                description: Platforms allows configuring platform specific configurations
+                properties:
+                  kubernetes:
+                    description: Kubernetes allows configuring kubernetes specific
+                      components and configurations
+                    properties:
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - options
+                        type: object
+                    type: object
+                  openshift:
+                    description: OpenShift allows configuring openshift specific components
+                      and configurations
+                    properties:
+                      enableCentralTLSConfig:
+                        description: |-
+                          EnableCentralTLSConfig enables TLS configuration inheritance from
+                          the cluster's APIServer TLS security profile. When enabled, TLS settings
+                          (minimum version, cipher suites, curve preferences) are automatically
+                          derived from the cluster-wide security policy and injected into Tekton
+                          component containers that support TLS configuration.
+                          If the APIServer does not have a TLS profile configured, user-specified
+                          TLS settings in component configurations will be used as fallback.
+                          Default: false (opt-in)
+                        type: boolean
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - options
+                        type: object
+                      scc:
+                        description: SCC allows configuring security context constraints
+                          used by workloads
+                        properties:
+                          default:
+                            description: |-
+                              Default contains the default SCC that will be attached to the service
+                              account used for workloads (`pipeline` SA by default) and defined in
+                              PipelineProperties.OptionalPipelineProperties.DefaultServiceAccount
+                            type: string
+                          maxAllowed:
+                            description: |-
+                              MaxAllowed specifies the highest SCC that can be requested for in a
+                              namespace or in the Default field.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              profile:
+                type: string
+              pruner:
+                description: Pruner holds the prune config
+                properties:
+                  disabled:
+                    description: enable or disable pruner feature
+                    type: boolean
+                  keep:
+                    description: |-
+                      The number of resource to keep
+                      You dont want to delete all the pipelinerun/taskrun's by a cron
+                    type: integer
+                  keep-since:
+                    description: |-
+                      KeepSince keeps the resources younger than the specified value
+                      Its value is taken in minutes
+                    type: integer
+                  prune-per-resource:
+                    description: apply the prune job to the individual resources
+                    type: boolean
+                  resources:
+                    description: The resources which need to be pruned
+                    items:
+                      type: string
+                    type: array
+                  schedule:
+                    description: How frequent pruning should happen
+                    type: string
+                  startingDeadlineSeconds:
+                    description: |-
+                      Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
+                      Missed jobs executions will be counted as failed ones.
+                    format: int64
+                    type: integer
+                required:
+                - disabled
+                type: object
+              result:
+                description: Result holds the customize option for results component
+                properties:
+                  auth_disable:
+                    type: boolean
+                  auth_impersonate:
+                    type: boolean
+                  db_enable_auto_migration:
+                    type: boolean
+                  db_host:
+                    type: string
+                  db_name:
+                    type: string
+                  db_port:
+                    format: int64
+                    type: integer
+                  db_secret_name:
+                    type: string
+                  db_secret_password_key:
+                    type: string
+                  db_secret_user_key:
+                    type: string
+                  db_sslmode:
+                    type: string
+                  db_sslrootcert:
+                    type: string
+                  disabled:
+                    description: enable or disable Result Component
+                    type: boolean
+                  gcs_bucket_name:
+                    type: string
+                  gcs_creds_secret_key:
+                    type: string
+                  gcs_creds_secret_name:
+                    type: string
+                  is_external_db:
+                    type: boolean
+                  log_level:
+                    type: string
+                  logging_plugin_api_url:
+                    type: string
+                  logging_plugin_ca_cert:
+                    type: string
+                  logging_plugin_forwarder_delay_duration:
+                    type: integer
+                  logging_plugin_multipart_regex:
+                    type: string
+                  logging_plugin_namespace_key:
+                    type: string
+                  logging_plugin_proxy_path:
+                    type: string
+                  logging_plugin_query_limit:
+                    type: integer
+                  logging_plugin_query_params:
+                    type: string
+                  logging_plugin_static_labels:
+                    type: string
+                  logging_plugin_tls_verification_disable:
+                    type: boolean
+                  logging_plugin_token_path:
+                    type: string
+                  logging_pvc_name:
+                    type: string
+                  logs_api:
+                    type: boolean
+                  logs_buffer_size:
+                    format: int64
+                    type: integer
+                  logs_path:
+                    type: string
+                  logs_type:
+                    type: string
+                  loki_stack_name:
+                    type: string
+                  loki_stack_namespace:
+                    type: string
+                  options:
+                    description: Options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  prometheus_histogram:
+                    type: boolean
+                  prometheus_port:
+                    format: int64
+                    type: integer
+                  route_enabled:
+                    description: Route configuration for Results API service exposure
+                    type: boolean
+                  route_host:
+                    type: string
+                  route_path:
+                    type: string
+                  route_tls_termination:
+                    type: string
+                  secret_name:
+                    description: |-
+                      name of the secret used to get S3 credentials and
+                      pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                    type: string
+                  server_port:
+                    format: int64
+                    type: integer
+                  storage_emulator_host:
+                    type: string
+                  tls_hostname_override:
+                    type: string
+                required:
+                - disabled
+                - is_external_db
+                - options
+                type: object
+              scheduler:
+                description: To enable Pipeline Scheduling on Single Cluster or Multiple
+                  Clusters
+                properties:
+                  config.yaml:
+                    description: |-
+                      This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                      match the key here
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    description: enable or disable TektonScheduler Component
+                    type: boolean
+                  multi-cluster-disabled:
+                    type: boolean
+                  multi-cluster-role:
+                    description: |-
+                      MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                      can be one of Hub or Spoke
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - config.yaml
+                - disabled
+                - multi-cluster-disabled
+                - multi-cluster-role
+                - options
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              targetNamespaceMetadata:
+                description: holds target namespace metadata
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              tektonpruner:
+                description: New EventBasedPruner which provides more granular control
+                  over TaskRun and PipelineRuns
+                properties:
+                  disabled:
+                    description: enable or disable TektonPruner Component
+                    type: boolean
+                  global-config:
+                    x-kubernetes-preserve-unknown-fields: true
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - global-config
+                - options
+                type: object
+              trigger:
+                description: Trigger holds the customizable option for triggers component
+                properties:
+                  default-service-account:
+                    type: string
+                  disabled:
+                    description: enable or disable Trigger Component
+                    type: boolean
+                  enable-api-fields:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - options
+                type: object
+            type: object
+          status:
+            description: TektonConfigStatus defines the observed state of TektonConfig
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              profile:
+                description: The profile installed
+                type: string
+              tektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektondashboards.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -171,37 +2344,218 @@ spec:
     listKind: TektonDashboardList
     plural: tektondashboards
     singular: tektondashboard
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektondashboards API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonDashboard is the Schema for the tektondashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonDashboardSpec defines the desired state of TektonDashboard
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonDashboard
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              external-logs:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              readonly:
+                description: Readonly when set to true configures the Tekton dashboard
+                  in read-only mode
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            - readonly
+            type: object
+          status:
+            description: TektonDashboardStatus defines the observed state of TektonDashboard
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonDashboard
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonhubs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -209,43 +2563,260 @@ spec:
     listKind: TektonHubList
     plural: tektonhubs
     singular: tektonhub
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-        - jsonPath: .status.apiUrl
-          name: ApiUrl
-          type: string
-        - jsonPath: .status.uiUrl
-          name: UiUrl
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonhubs API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    - jsonPath: .status.apiUrl
+      name: ApiUrl
+      type: string
+    - jsonPath: .status.uiUrl
+      name: UiUrl
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonHub is the Schema for the tektonhub API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              api:
+                properties:
+                  catalogRefreshInterval:
+                    type: string
+                  hubConfigUrl:
+                    description: Deprecated, will be removed in further release
+                    type: string
+                  routeHostUrl:
+                    type: string
+                  secret:
+                    type: string
+                type: object
+              catalogs:
+                items:
+                  properties:
+                    contextDir:
+                      type: string
+                    name:
+                      type: string
+                    org:
+                      type: string
+                    provider:
+                      type: string
+                    revision:
+                      type: string
+                    sshUrl:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              categories:
+                items:
+                  type: string
+                type: array
+              customLogo:
+                description: The Base64 Encode data and mediaType of the Custom Logo
+                properties:
+                  base64Data:
+                    type: string
+                  mediaType:
+                    type: string
+                type: object
+              db:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              default:
+                properties:
+                  scopes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: Params is the list of params passed for Hub customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              scopes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    users:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonHubStatus defines the observed state of TektonHub
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              apiUrl:
+                description: The URL route for API which needs to be exposed
+                type: string
+              authUrl:
+                description: The URL route for Auth server
+                type: string
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              hubInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              manifests:
+                description: The url links of the manifests, separated by comma
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              uiUrl:
+                description: The URL route for UI which needs to be exposed
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -253,34 +2824,114 @@ spec:
     listKind: TektonInstallerSetList
     plural: tektoninstallersets
     singular: tektoninstallerset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektoninstallerset API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
+            properties:
+              manifests:
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -288,37 +2939,382 @@ spec:
     listKind: TektonPipelineList
     plural: tektonpipelines
     singular: tektonpipeline
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonpipelines API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPipeline is the Schema for the tektonpipelines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
+            properties:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                format: int32
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                type: boolean
+              set-security-context:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -326,37 +3322,344 @@ spec:
     listKind: TektonResultList
     plural: tektonresults
     singular: tektonresult
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonResults API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonResult is the Schema for the tektonresults API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonResultSpec defines the desired state of TektonResult
+            properties:
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                format: int64
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                format: int64
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                format: int64
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                format: int64
+                type: integer
+              storage_emulator_host:
+                type: string
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              tls_hostname_override:
+                type: string
+            required:
+            - disabled
+            - is_external_db
+            - options
+            type: object
+          status:
+            description: TektonResultStatus defines the observed state of TektonResult
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -364,37 +3667,219 @@ spec:
     listKind: TektonTriggerList
     plural: tektontriggers
     singular: tektontrigger
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektontriggers API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonTrigger is the Schema for the tektontriggers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
+              disabled:
+                description: enable or disable Trigger Component
+                type: boolean
+              enable-api-fields:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - options
+            type: object
+          status:
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -402,37 +3887,217 @@ spec:
     listKind: TektonPrunerList
     plural: tektonpruners
     singular: tektonpruner
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonPruner API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPruner is the Schema for the TektonPruner API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              disabled:
+                description: enable or disable TektonPruner Component
+                type: boolean
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - global-config
+            - options
+            type: object
+          status:
+            description: TektonPrunerStatus defines the observed state of TektonPruner
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -440,37 +4105,177 @@ spec:
     listKind: TektonSchedulerList
     plural: tektonschedulers
     singular: tektonscheduler
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonschedulers API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonScheduler is the Schema for the TektonScheduler API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config.yaml:
+                description: |-
+                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                  match the key here
+                x-kubernetes-preserve-unknown-fields: true
+              disabled:
+                description: enable or disable TektonScheduler Component
+                type: boolean
+              multi-cluster-disabled:
+                type: boolean
+              multi-cluster-role:
+                description: |-
+                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                  can be one of Hub or Spoke
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - config.yaml
+            - disabled
+            - multi-cluster-disabled
+            - multi-cluster-role
+            - options
+            type: object
+          status:
+            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tekton-scheduler:
+                description: The current installer set name for TektonScheduler
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -478,38 +4283,160 @@ spec:
     listKind: TektonMulticlusterProxyAAEList
     plural: tektonmulticlusterproxyaaes
     singular: tektonmulticlusterproxyaae
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            TektonMulticlusterProxyAAE configures the Proxy AAE (Aggregated API Extension).
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additional fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -517,27 +4444,197 @@ spec:
     listKind: SyncerServiceList
     plural: syncerservices
     singular: syncerservice
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the SyncerService API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SyncerService is the Schema for the syncerservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: SyncerServiceStatus defines the observed state of SyncerService
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end -}}

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
   labels:
     version: "devel"
@@ -13,40 +15,161 @@ spec:
     kind: ManualApprovalGate
     listKind: ManualApprovalGateList
     plural: manualapprovalgates
-    singular: manualapprovalgate
     shortNames:
-      - mag
-  preserveUnknownFields: false
+    - mag
+    singular: manualapprovalgate
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: { }
-      additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: ".status.conditions[?(@.type==\"Ready\")].message"
-          name: Reason
-          type: string
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: Schema for the ManualApprovalGate API
-          x-kubernetes-preserve-unknown-fields: true
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManualApprovalGate is the Schema for the ManualApprovalGate API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: ManualApprovalGateStatus defines the observed state of ManualApprovalGate
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for ManualApprovalGate
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: openshiftpipelinesascodes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -54,40 +177,239 @@ spec:
     listKind: OpenShiftPipelinesAsCodeList
     plural: openshiftpipelinesascodes
     shortNames:
-      - opac
-      - pac
+    - opac
+    - pac
     singular: openshiftpipelinesascode
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the OpenShiftPipelinesAsCode API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenShiftPipelinesAsCode is the Schema for the OpenShiftPipelinesAsCode
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenShiftPipelinesAsCodeSpec defines the desired state of
+              OpenShiftPipelinesAsCode
+            properties:
+              additionalPACControllers:
+                additionalProperties:
+                  description: AdditionalPACControllerConfig contains config for additionalPACControllers
+                  properties:
+                    configMapName:
+                      description: Name of the additional controller configMap
+                      type: string
+                    enable:
+                      description: Enable or disable this additional pipelines as
+                        code instance by changing this bool
+                      type: boolean
+                    secretName:
+                      description: Name of the additional controller Secret
+                      type: string
+                    settings:
+                      additionalProperties:
+                        type: string
+                      description: Setting will contains the configMap data
+                      type: object
+                  type: object
+                description: AdditionalPACControllers allows to deploy additional
+                  PAC controller
+                type: object
+              config:
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              settings:
+                additionalProperties:
+                  type: string
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: OpenShiftPipelinesAsCodeStatus defines the observed state
+              of OpenShiftPipelinesAsCode
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonaddons.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -95,37 +417,195 @@ spec:
     listKind: TektonAddonList
     plural: tektonaddons
     singular: tektonaddon
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonaddons API. Supported on OpenShift only.
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonAddon is the Schema for the tektonaddons API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonAddonSpec defines the desired state of TektonAddon
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by Addon
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              enablePipelinesAsCode:
+                description: |-
+                  Deprecated, will be removed in further release
+                  EnablePAC field defines whether to install PAC
+                type: boolean
+              params:
+                description: Params is the list of params passed for Addon customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: TektonAddonStatus defines the observed state of TektonAddon
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              installerSets:
+                additionalProperties:
+                  type: string
+                description: TektonInstallerSet created to install addons
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -133,37 +613,487 @@ spec:
     listKind: TektonChainList
     plural: tektonchains
     singular: tektonchain
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonChains API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonChain is the Schema for the tektonchain API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonChainSpec defines the desired state of TektonChain
+            properties:
+              artifacts.oci.format:
+                description: oci artifacts config
+                type: string
+              artifacts.oci.signer:
+                type: string
+              artifacts.oci.storage:
+                type: string
+              artifacts.pipelinerun.enable-deep-inspection:
+                type: string
+              artifacts.pipelinerun.format:
+                description: pipelinerun artifacts config
+                type: string
+              artifacts.pipelinerun.signer:
+                type: string
+              artifacts.pipelinerun.storage:
+                type: string
+              artifacts.taskrun.format:
+                description: taskrun artifacts config
+                type: string
+              artifacts.taskrun.signer:
+                type: string
+              artifacts.taskrun.storage:
+                type: string
+              builddefinition.buildtype:
+                type: string
+              builder.id:
+                description: builder config
+                type: string
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonChain
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              controllerEnvs:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              disabled:
+                description: enable or disable chains feature
+                type: boolean
+              generateSigningSecret:
+                description: generate signing key
+                type: boolean
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              signers.kms.auth.address:
+                type: string
+              signers.kms.auth.oidc.path:
+                type: string
+              signers.kms.auth.oidc.role:
+                type: string
+              signers.kms.auth.spire.audience:
+                type: string
+              signers.kms.auth.spire.sock:
+                type: string
+              signers.kms.auth.token:
+                type: string
+              signers.kms.auth.token-path:
+                type: string
+              signers.kms.kmsref:
+                description: kms signer config
+                type: string
+              signers.x509.fulcio.address:
+                type: string
+              signers.x509.fulcio.enabled:
+                description: x509 signer config
+                type: boolean
+              signers.x509.fulcio.issuer:
+                type: string
+              signers.x509.fulcio.provider:
+                type: string
+              signers.x509.identity.token.file:
+                type: string
+              signers.x509.tuf.mirror.url:
+                type: string
+              storage.docdb.mongo-server-url:
+                type: string
+              storage.docdb.mongo-server-url-dir:
+                type: string
+              storage.docdb.url:
+                type: string
+              storage.gcs.bucket:
+                description: storage configs
+                type: string
+              storage.grafeas.notehint:
+                type: string
+              storage.grafeas.noteid:
+                type: string
+              storage.grafeas.projectid:
+                type: string
+              storage.oci.repository:
+                type: string
+              storage.oci.repository.insecure:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              transparency.enabled:
+                type: string
+              transparency.url:
+                type: string
+            required:
+            - disabled
+            - options
+            type: object
+          status:
+            description: TektonChainStatus defines the observed state of TektonChain
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonChain
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -171,37 +1101,1438 @@ spec:
     listKind: TektonConfigList
     plural: tektonconfigs
     singular: tektonconfig
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonconfigs API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonConfig is the Schema for the TektonConfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonConfigSpec defines the desired state of TektonConfig
+            properties:
+              addon:
+                description: Addon holds the addons config
+                properties:
+                  enablePipelinesAsCode:
+                    description: |-
+                      Deprecated, will be removed in further release
+                      EnablePAC field defines whether to install PAC
+                    type: boolean
+                  params:
+                    description: Params is the list of params passed for Addon customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              chain:
+                description: Chain holds the customizable option for chains component
+                properties:
+                  artifacts.oci.format:
+                    description: oci artifacts config
+                    type: string
+                  artifacts.oci.signer:
+                    type: string
+                  artifacts.oci.storage:
+                    type: string
+                  artifacts.pipelinerun.enable-deep-inspection:
+                    type: string
+                  artifacts.pipelinerun.format:
+                    description: pipelinerun artifacts config
+                    type: string
+                  artifacts.pipelinerun.signer:
+                    type: string
+                  artifacts.pipelinerun.storage:
+                    type: string
+                  artifacts.taskrun.format:
+                    description: taskrun artifacts config
+                    type: string
+                  artifacts.taskrun.signer:
+                    type: string
+                  artifacts.taskrun.storage:
+                    type: string
+                  builddefinition.buildtype:
+                    type: string
+                  builder.id:
+                    description: builder config
+                    type: string
+                  controllerEnvs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  disabled:
+                    description: enable or disable chains feature
+                    type: boolean
+                  generateSigningSecret:
+                    description: generate signing key
+                    type: boolean
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  signers.kms.auth.address:
+                    type: string
+                  signers.kms.auth.oidc.path:
+                    type: string
+                  signers.kms.auth.oidc.role:
+                    type: string
+                  signers.kms.auth.spire.audience:
+                    type: string
+                  signers.kms.auth.spire.sock:
+                    type: string
+                  signers.kms.auth.token:
+                    type: string
+                  signers.kms.auth.token-path:
+                    type: string
+                  signers.kms.kmsref:
+                    description: kms signer config
+                    type: string
+                  signers.x509.fulcio.address:
+                    type: string
+                  signers.x509.fulcio.enabled:
+                    description: x509 signer config
+                    type: boolean
+                  signers.x509.fulcio.issuer:
+                    type: string
+                  signers.x509.fulcio.provider:
+                    type: string
+                  signers.x509.identity.token.file:
+                    type: string
+                  signers.x509.tuf.mirror.url:
+                    type: string
+                  storage.docdb.mongo-server-url:
+                    type: string
+                  storage.docdb.mongo-server-url-dir:
+                    type: string
+                  storage.docdb.url:
+                    type: string
+                  storage.gcs.bucket:
+                    description: storage configs
+                    type: string
+                  storage.grafeas.notehint:
+                    type: string
+                  storage.grafeas.noteid:
+                    type: string
+                  storage.grafeas.projectid:
+                    type: string
+                  storage.oci.repository:
+                    type: string
+                  storage.oci.repository.insecure:
+                    type: boolean
+                  transparency.enabled:
+                    type: string
+                  transparency.url:
+                    type: string
+                required:
+                - disabled
+                - options
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonConfig
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              dashboard:
+                description: Dashboard holds the customizable options for dashboards
+                  component
+                properties:
+                  external-logs:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  readonly:
+                    description: Readonly when set to true configures the Tekton dashboard
+                      in read-only mode
+                    type: boolean
+                required:
+                - options
+                - readonly
+                type: object
+              hub:
+                description: Hub holds the hub config
+                properties:
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: Params is the list of params passed for Hub customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - options
+                type: object
+              multiclusterProxyAAE:
+                description: MulticlusterProxyAAE holds the customizable options for
+                  the multicluster-proxy-aae component
+                properties:
+                  options:
+                    description: options holds additional fields and these fields
+                      will be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - options
+                type: object
+              params:
+                description: Params is the list of params passed for all platforms
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              pipeline:
+                description: Pipeline holds the customizable option for pipeline component
+                properties:
+                  await-sidecar-readiness:
+                    type: boolean
+                  bundles-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  cluster-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  coschedule:
+                    type: string
+                  default-affinity-assistant-pod-template:
+                    type: string
+                  default-cloud-events-sink:
+                    type: string
+                  default-forbidden-env:
+                    type: string
+                  default-managed-by-label-value:
+                    type: string
+                  default-max-matrix-combinations-count:
+                    type: string
+                  default-pod-template:
+                    type: string
+                  default-resolver-type:
+                    type: string
+                  default-service-account:
+                    type: string
+                  default-task-run-workspace-binding:
+                    type: string
+                  default-timeout-minutes:
+                    type: integer
+                  disable-affinity-assistant:
+                    description: |-
+                      Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                      This field is removed from pipeline component.
+                      Keeping here to maintain API compatibility during upgrades.
+                    type: boolean
+                  disable-creds-init:
+                    type: boolean
+                  disable-inline-spec:
+                    type: string
+                  embedded-status:
+                    type: string
+                  enable-api-fields:
+                    type: string
+                  enable-bundles-resolver:
+                    type: boolean
+                  enable-cel-in-whenexpression:
+                    type: boolean
+                  enable-cluster-resolver:
+                    type: boolean
+                  enable-custom-tasks:
+                    type: boolean
+                  enable-git-resolver:
+                    type: boolean
+                  enable-hub-resolver:
+                    type: boolean
+                  enable-param-enum:
+                    type: boolean
+                  enable-provenance-in-status:
+                    type: boolean
+                  enable-step-actions:
+                    type: boolean
+                  enable-tekton-oci-bundles:
+                    description: |-
+                      not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                      this field is removed from pipeline component
+                      keeping here to maintain the API compatibility
+                    type: boolean
+                  enforce-nonfalsifiability:
+                    type: string
+                  git-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  hub-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  keep-pod-on-cancel:
+                    type: boolean
+                  max-result-size:
+                    format: int32
+                    type: integer
+                  metrics.count.enable-reason:
+                    type: boolean
+                  metrics.pipelinerun.duration-type:
+                    type: string
+                  metrics.pipelinerun.level:
+                    type: string
+                  metrics.taskrun.duration-type:
+                    type: string
+                  metrics.taskrun.level:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: The params to customize different components of Pipelines
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  require-git-ssh-secret-known-hosts:
+                    type: boolean
+                  results-from:
+                    type: string
+                  running-in-environment-with-injected-sidecars:
+                    type: boolean
+                  scope-when-expressions-to-task:
+                    description: ScopeWhenExpressionsToTask is deprecated and never
+                      used.
+                    type: boolean
+                  send-cloudevents-for-runs:
+                    type: boolean
+                  set-security-context:
+                    type: boolean
+                  traces.credentialsSecret:
+                    description: CredentialsSecret is the name of the secret containing
+                      credentials for the tracing endpoint
+                    type: string
+                  traces.enabled:
+                    description: Enabled controls whether tracing is enabled or not
+                    type: boolean
+                  traces.endpoint:
+                    description: Endpoint is the URL for the OpenTelemetry trace collector
+                    type: string
+                  trusted-resources-verification-no-match-policy:
+                    type: string
+                  verification-mode:
+                    type: string
+                required:
+                - options
+                type: object
+              platforms:
+                description: Platforms allows configuring platform specific configurations
+                properties:
+                  kubernetes:
+                    description: Kubernetes allows configuring kubernetes specific
+                      components and configurations
+                    properties:
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - options
+                        type: object
+                    type: object
+                  openshift:
+                    description: OpenShift allows configuring openshift specific components
+                      and configurations
+                    properties:
+                      enableCentralTLSConfig:
+                        description: |-
+                          EnableCentralTLSConfig enables TLS configuration inheritance from
+                          the cluster's APIServer TLS security profile. When enabled, TLS settings
+                          (minimum version, cipher suites, curve preferences) are automatically
+                          derived from the cluster-wide security policy and injected into Tekton
+                          component containers that support TLS configuration.
+                          If the APIServer does not have a TLS profile configured, user-specified
+                          TLS settings in component configurations will be used as fallback.
+                          Default: false (opt-in)
+                        type: boolean
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - options
+                        type: object
+                      scc:
+                        description: SCC allows configuring security context constraints
+                          used by workloads
+                        properties:
+                          default:
+                            description: |-
+                              Default contains the default SCC that will be attached to the service
+                              account used for workloads (`pipeline` SA by default) and defined in
+                              PipelineProperties.OptionalPipelineProperties.DefaultServiceAccount
+                            type: string
+                          maxAllowed:
+                            description: |-
+                              MaxAllowed specifies the highest SCC that can be requested for in a
+                              namespace or in the Default field.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              profile:
+                type: string
+              pruner:
+                description: Pruner holds the prune config
+                properties:
+                  disabled:
+                    description: enable or disable pruner feature
+                    type: boolean
+                  keep:
+                    description: |-
+                      The number of resource to keep
+                      You dont want to delete all the pipelinerun/taskrun's by a cron
+                    type: integer
+                  keep-since:
+                    description: |-
+                      KeepSince keeps the resources younger than the specified value
+                      Its value is taken in minutes
+                    type: integer
+                  prune-per-resource:
+                    description: apply the prune job to the individual resources
+                    type: boolean
+                  resources:
+                    description: The resources which need to be pruned
+                    items:
+                      type: string
+                    type: array
+                  schedule:
+                    description: How frequent pruning should happen
+                    type: string
+                  startingDeadlineSeconds:
+                    description: |-
+                      Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
+                      Missed jobs executions will be counted as failed ones.
+                    format: int64
+                    type: integer
+                required:
+                - disabled
+                type: object
+              result:
+                description: Result holds the customize option for results component
+                properties:
+                  auth_disable:
+                    type: boolean
+                  auth_impersonate:
+                    type: boolean
+                  db_enable_auto_migration:
+                    type: boolean
+                  db_host:
+                    type: string
+                  db_name:
+                    type: string
+                  db_port:
+                    format: int64
+                    type: integer
+                  db_secret_name:
+                    type: string
+                  db_secret_password_key:
+                    type: string
+                  db_secret_user_key:
+                    type: string
+                  db_sslmode:
+                    type: string
+                  db_sslrootcert:
+                    type: string
+                  disabled:
+                    description: enable or disable Result Component
+                    type: boolean
+                  gcs_bucket_name:
+                    type: string
+                  gcs_creds_secret_key:
+                    type: string
+                  gcs_creds_secret_name:
+                    type: string
+                  is_external_db:
+                    type: boolean
+                  log_level:
+                    type: string
+                  logging_plugin_api_url:
+                    type: string
+                  logging_plugin_ca_cert:
+                    type: string
+                  logging_plugin_forwarder_delay_duration:
+                    type: integer
+                  logging_plugin_multipart_regex:
+                    type: string
+                  logging_plugin_namespace_key:
+                    type: string
+                  logging_plugin_proxy_path:
+                    type: string
+                  logging_plugin_query_limit:
+                    type: integer
+                  logging_plugin_query_params:
+                    type: string
+                  logging_plugin_static_labels:
+                    type: string
+                  logging_plugin_tls_verification_disable:
+                    type: boolean
+                  logging_plugin_token_path:
+                    type: string
+                  logging_pvc_name:
+                    type: string
+                  logs_api:
+                    type: boolean
+                  logs_buffer_size:
+                    format: int64
+                    type: integer
+                  logs_path:
+                    type: string
+                  logs_type:
+                    type: string
+                  loki_stack_name:
+                    type: string
+                  loki_stack_namespace:
+                    type: string
+                  options:
+                    description: Options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        format: int32
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  prometheus_histogram:
+                    type: boolean
+                  prometheus_port:
+                    format: int64
+                    type: integer
+                  route_enabled:
+                    description: Route configuration for Results API service exposure
+                    type: boolean
+                  route_host:
+                    type: string
+                  route_path:
+                    type: string
+                  route_tls_termination:
+                    type: string
+                  secret_name:
+                    description: |-
+                      name of the secret used to get S3 credentials and
+                      pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                    type: string
+                  server_port:
+                    format: int64
+                    type: integer
+                  storage_emulator_host:
+                    type: string
+                  tls_hostname_override:
+                    type: string
+                required:
+                - disabled
+                - is_external_db
+                - options
+                type: object
+              scheduler:
+                description: To enable Pipeline Scheduling on Single Cluster or Multiple
+                  Clusters
+                properties:
+                  config.yaml:
+                    description: |-
+                      This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                      match the key here
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    description: enable or disable TektonScheduler Component
+                    type: boolean
+                  multi-cluster-disabled:
+                    type: boolean
+                  multi-cluster-role:
+                    description: |-
+                      MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                      can be one of Hub or Spoke
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - config.yaml
+                - disabled
+                - multi-cluster-disabled
+                - multi-cluster-role
+                - options
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              targetNamespaceMetadata:
+                description: holds target namespace metadata
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              tektonpruner:
+                description: New EventBasedPruner which provides more granular control
+                  over TaskRun and PipelineRuns
+                properties:
+                  disabled:
+                    description: enable or disable TektonPruner Component
+                    type: boolean
+                  global-config:
+                    x-kubernetes-preserve-unknown-fields: true
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - global-config
+                - options
+                type: object
+              trigger:
+                description: Trigger holds the customizable option for triggers component
+                properties:
+                  default-service-account:
+                    type: string
+                  disabled:
+                    description: enable or disable Trigger Component
+                    type: boolean
+                  enable-api-fields:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - options
+                type: object
+            type: object
+          status:
+            description: TektonConfigStatus defines the observed state of TektonConfig
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              profile:
+                description: The profile installed
+                type: string
+              tektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonhubs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -209,43 +2540,260 @@ spec:
     listKind: TektonHubList
     plural: tektonhubs
     singular: tektonhub
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-        - jsonPath: .status.apiUrl
-          name: ApiUrl
-          type: string
-        - jsonPath: .status.uiUrl
-          name: UiUrl
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonhubs API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    - jsonPath: .status.apiUrl
+      name: ApiUrl
+      type: string
+    - jsonPath: .status.uiUrl
+      name: UiUrl
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonHub is the Schema for the tektonhub API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              api:
+                properties:
+                  catalogRefreshInterval:
+                    type: string
+                  hubConfigUrl:
+                    description: Deprecated, will be removed in further release
+                    type: string
+                  routeHostUrl:
+                    type: string
+                  secret:
+                    type: string
+                type: object
+              catalogs:
+                items:
+                  properties:
+                    contextDir:
+                      type: string
+                    name:
+                      type: string
+                    org:
+                      type: string
+                    provider:
+                      type: string
+                    revision:
+                      type: string
+                    sshUrl:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              categories:
+                items:
+                  type: string
+                type: array
+              customLogo:
+                description: The Base64 Encode data and mediaType of the Custom Logo
+                properties:
+                  base64Data:
+                    type: string
+                  mediaType:
+                    type: string
+                type: object
+              db:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              default:
+                properties:
+                  scopes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: Params is the list of params passed for Hub customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              scopes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    users:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonHubStatus defines the observed state of TektonHub
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              apiUrl:
+                description: The URL route for API which needs to be exposed
+                type: string
+              authUrl:
+                description: The URL route for Auth server
+                type: string
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              hubInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              manifests:
+                description: The url links of the manifests, separated by comma
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              uiUrl:
+                description: The URL route for UI which needs to be exposed
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -253,34 +2801,114 @@ spec:
     listKind: TektonInstallerSetList
     plural: tektoninstallersets
     singular: tektoninstallerset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektoninstallerset API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
+            properties:
+              manifests:
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -288,37 +2916,382 @@ spec:
     listKind: TektonPipelineList
     plural: tektonpipelines
     singular: tektonpipeline
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonpipelines API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPipeline is the Schema for the tektonpipelines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
+            properties:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                format: int32
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                type: boolean
+              set-security-context:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -326,37 +3299,344 @@ spec:
     listKind: TektonResultList
     plural: tektonresults
     singular: tektonresult
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonResults API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonResult is the Schema for the tektonresults API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonResultSpec defines the desired state of TektonResult
+            properties:
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                format: int64
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                format: int64
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                format: int64
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                format: int64
+                type: integer
+              storage_emulator_host:
+                type: string
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              tls_hostname_override:
+                type: string
+            required:
+            - disabled
+            - is_external_db
+            - options
+            type: object
+          status:
+            description: TektonResultStatus defines the observed state of TektonResult
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -364,37 +3644,219 @@ spec:
     listKind: TektonTriggerList
     plural: tektontriggers
     singular: tektontrigger
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektontriggers API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonTrigger is the Schema for the tektontriggers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
+              disabled:
+                description: enable or disable Trigger Component
+                type: boolean
+              enable-api-fields:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - options
+            type: object
+          status:
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -402,37 +3864,217 @@ spec:
     listKind: TektonPrunerList
     plural: tektonpruners
     singular: tektonpruner
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the TektonPruner API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPruner is the Schema for the TektonPruner API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              disabled:
+                description: enable or disable TektonPruner Component
+                type: boolean
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - global-config
+            - options
+            type: object
+          status:
+            description: TektonPrunerStatus defines the observed state of TektonPruner
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -440,37 +4082,177 @@ spec:
     listKind: TektonSchedulerList
     plural: tektonschedulers
     singular: tektonscheduler
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the tektonschedulers API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonScheduler is the Schema for the TektonScheduler API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config.yaml:
+                description: |-
+                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                  match the key here
+                x-kubernetes-preserve-unknown-fields: true
+              disabled:
+                description: enable or disable TektonScheduler Component
+                type: boolean
+              multi-cluster-disabled:
+                type: boolean
+              multi-cluster-role:
+                description: |-
+                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                  can be one of Hub or Spoke
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - config.yaml
+            - disabled
+            - multi-cluster-disabled
+            - multi-cluster-role
+            - options
+            type: object
+          status:
+            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tekton-scheduler:
+                description: The current installer set name for TektonScheduler
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -478,38 +4260,160 @@ spec:
     listKind: TektonMulticlusterProxyAAEList
     plural: tektonmulticlusterproxyaaes
     singular: tektonmulticlusterproxyaae
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |
-            TektonMulticlusterProxyAAE configures the Proxy AAE (Aggregated API Extension).
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additional fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    operator.tekton.dev/release: "devel"
-    version: "devel"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -517,27 +4421,197 @@ spec:
     listKind: SyncerServiceList
     plural: syncerservices
     singular: syncerservice
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Schema for the SyncerService API
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SyncerService is the Schema for the syncerservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: SyncerServiceStatus defines the observed state of SyncerService
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end -}}

--- a/config/base/300-operator_v1alpha1_hub_crd.yaml
+++ b/config/base/300-operator_v1alpha1_hub_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonhubs.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,32 +28,247 @@ spec:
     listKind: TektonHubList
     plural: tektonhubs
     singular: tektonhub
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-        - jsonPath: .status.apiUrl
-          name: ApiUrl
-          type: string
-        - jsonPath: .status.uiUrl
-          name: UiUrl
-          type: string
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: Schema for the tektonhubs API
-          x-kubernetes-preserve-unknown-fields: true
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    - jsonPath: .status.apiUrl
+      name: ApiUrl
+      type: string
+    - jsonPath: .status.uiUrl
+      name: UiUrl
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonHub is the Schema for the tektonhub API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              api:
+                properties:
+                  catalogRefreshInterval:
+                    type: string
+                  hubConfigUrl:
+                    description: Deprecated, will be removed in further release
+                    type: string
+                  routeHostUrl:
+                    type: string
+                  secret:
+                    type: string
+                type: object
+              catalogs:
+                items:
+                  properties:
+                    contextDir:
+                      type: string
+                    name:
+                      type: string
+                    org:
+                      type: string
+                    provider:
+                      type: string
+                    revision:
+                      type: string
+                    sshUrl:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              categories:
+                items:
+                  type: string
+                type: array
+              customLogo:
+                description: The Base64 Encode data and mediaType of the Custom Logo
+                properties:
+                  base64Data:
+                    type: string
+                  mediaType:
+                    type: string
+                type: object
+              db:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              default:
+                properties:
+                  scopes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: Params is the list of params passed for Hub customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              scopes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    users:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonHubStatus defines the observed state of TektonHub
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              apiUrl:
+                description: The URL route for API which needs to be exposed
+                type: string
+              authUrl:
+                description: The URL route for Auth server
+                type: string
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              hubInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              manifests:
+                description: The url links of the manifests, separated by comma
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              uiUrl:
+                description: The URL route for UI which needs to be exposed
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_installer_set_crd.yaml
+++ b/config/base/300-operator_v1alpha1_installer_set_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,23 +28,101 @@ spec:
     listKind: TektonInstallerSetList
     plural: tektoninstallersets
     singular: tektoninstallerset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Reason
-          type: string
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: Schema for the tektoninstallerset API
-          x-kubernetes-preserve-unknown-fields: true
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
+            properties:
+              manifests:
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_manualapprovalgate_crd.yaml
+++ b/config/base/300-operator_v1alpha1_manualapprovalgate_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
   labels:
     version: "devel"
@@ -25,29 +27,148 @@ spec:
     kind: ManualApprovalGate
     listKind: ManualApprovalGateList
     plural: manualapprovalgates
-    singular: manualapprovalgate
     shortNames:
     - mag
-  preserveUnknownFields: false
+    singular: manualapprovalgate
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - jsonPath: ".status.conditions[?(@.type==\"Ready\")].message"
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ManualApprovalGate is the Schema for the ManualApprovalGate API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: ManualApprovalGateStatus defines the observed state of ManualApprovalGate
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for ManualApprovalGate
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the ManualApprovalGate API
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_multiclusterproxyaae_crd.yaml
+++ b/config/base/300-operator_v1alpha1_multiclusterproxyaae_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,30 +28,147 @@ spec:
     listKind: TektonMulticlusterProxyAAEList
     plural: tektonmulticlusterproxyaaes
     singular: tektonmulticlusterproxyaae
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additional fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
     subresources:
       status: {}
-    additionalPrinterColumns:
-      - jsonPath: .status.version
-        name: Version
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].status
-        name: Ready
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].message
-        name: Reason
-        type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        description: |
-          TektonMulticlusterProxyAAE configures the Proxy AAE (Aggregated API Extension) from
-          https://github.com/openshift-pipelines/multicluster-proxy-aae. It provides a unified
-          Kubernetes API for accessing Tekton resources (TaskRuns, Pods, logs) across multiple
-          worker clusters managed by MultiKueue.
-        x-kubernetes-preserve-unknown-fields: true

--- a/config/base/300-operator_v1alpha1_pipeline_crd.yaml
+++ b/config/base/300-operator_v1alpha1_pipeline_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,15 +28,9 @@ spec:
     listKind: TektonPipelineList
     plural: tektonpipelines
     singular: tektonpipeline
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
@@ -44,8 +40,357 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: TektonPipeline is the Schema for the tektonpipelines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
+            properties:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                format: int32
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                type: boolean
+              set-security-context:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
+                type: string
+            required:
+            - options
+            type: object
+          status:
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the tektonpipelines API
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_pruner_crd.yaml
+++ b/config/base/300-operator_v1alpha1_pruner_crd.yaml
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,26 +28,204 @@ spec:
     listKind: TektonPrunerList
     plural: tektonpruners
     singular: tektonpruner
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPruner is the Schema for the TektonPruner API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              disabled:
+                description: enable or disable TektonPruner Component
+                type: boolean
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - global-config
+            - options
+            type: object
+          status:
+            description: TektonPrunerStatus defines the observed state of TektonPruner
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
     subresources:
       status: {}
-    additionalPrinterColumns:
-      - jsonPath: .status.version
-        name: Version
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].status
-        name: Ready
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].message
-        name: Reason
-        type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        description: Schema for the tektonpruners API
-        x-kubernetes-preserve-unknown-fields: true

--- a/config/base/300-operator_v1alpha1_result_crd.yaml
+++ b/config/base/300-operator_v1alpha1_result_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
   labels:
     version: "devel"
@@ -24,17 +26,11 @@ spec:
   names:
     kind: TektonResult
     listKind: TektonResultList
-    singular: tektonresult
     plural: tektonresults
-  preserveUnknownFields: false
+    singular: tektonresult
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
@@ -44,8 +40,319 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: TektonResult is the Schema for the tektonresults API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonResultSpec defines the desired state of TektonResult
+            properties:
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                format: int64
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                format: int64
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                format: int64
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                format: int64
+                type: integer
+              storage_emulator_host:
+                type: string
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              tls_hostname_override:
+                type: string
+            required:
+            - disabled
+            - is_external_db
+            - options
+            type: object
+          status:
+            description: TektonResultStatus defines the observed state of TektonResult
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the TektonResults API
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_syncerservice_crd.yaml
+++ b/config/base/300-operator_v1alpha1_syncerservice_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
   labels:
     version: "devel"
@@ -24,17 +26,11 @@ spec:
   names:
     kind: SyncerService
     listKind: SyncerServiceList
-    singular: syncerservice
     plural: syncerservices
-  preserveUnknownFields: false
+    singular: syncerservice
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
@@ -44,8 +40,184 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: SyncerService is the Schema for the syncerservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: SyncerServiceStatus defines the observed state of SyncerService
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the SyncerService API
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/base/300-operator_v1alpha1_trigger_crd.yaml
+++ b/config/base/300-operator_v1alpha1_trigger_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,26 +28,206 @@ spec:
     listKind: TektonTriggerList
     plural: tektontriggers
     singular: tektontrigger
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonTrigger is the Schema for the tektontriggers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
+              disabled:
+                description: enable or disable Trigger Component
+                type: boolean
+              enable-api-fields:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - options
+            type: object
+          status:
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
     subresources:
       status: {}
-    additionalPrinterColumns:
-      - jsonPath: .status.version
-        name: Version
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].status
-        name: Ready
-        type: string
-      - jsonPath: .status.conditions[?(@.type=="Ready")].message
-        name: Reason
-        type: string
-    schema:
-      openAPIV3Schema:
-        type: object
-        description: Schema for the tektontriggers API
-        x-kubernetes-preserve-unknown-fields: true

--- a/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
@@ -1,33 +1,19 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: manualapprovalgates.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: ManualApprovalGate
+    listKind: ManualApprovalGateList
+    plural: manualapprovalgates
+    shortNames:
+    - mag
+    singular: manualapprovalgate
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +29,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: ManualApprovalGate is the Schema for the ManualApprovalGate API
         properties:
           apiVersion:
             description: |-
@@ -64,21 +50,6 @@ spec:
             type: object
           spec:
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -116,14 +87,10 @@ spec:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: ManualApprovalGateStatus defines the observed state of ManualApprovalGate
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +144,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              tektonInstallerSet:
+                description: The current installer set name for ManualApprovalGate
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -1,33 +1,20 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: openshiftpipelinesascodes.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: OpenShiftPipelinesAsCode
+    listKind: OpenShiftPipelinesAsCodeList
+    plural: openshiftpipelinesascodes
+    shortNames:
+    - opac
+    - pac
+    singular: openshiftpipelinesascode
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +30,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: OpenShiftPipelinesAsCode is the Schema for the OpenShiftPipelinesAsCode
+          API
         properties:
           apiVersion:
             description: |-
@@ -63,22 +51,82 @@ spec:
           metadata:
             type: object
           spec:
+            description: OpenShiftPipelinesAsCodeSpec defines the desired state of
+              OpenShiftPipelinesAsCode
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
+              additionalPACControllers:
+                additionalProperties:
+                  description: AdditionalPACControllerConfig contains config for additionalPACControllers
+                  properties:
+                    configMapName:
+                      description: Name of the additional controller configMap
+                      type: string
+                    enable:
+                      description: Enable or disable this additional pipelines as
+                        code instance by changing this bool
+                      type: boolean
+                    secretName:
+                      description: Name of the additional controller Secret
+                      type: string
+                    settings:
+                      additionalProperties:
+                        type: string
+                      description: Setting will contains the configMap data
+                      type: object
+                  type: object
+                description: AdditionalPACControllers allows to deploy additional
+                  PAC controller
+                type: object
+              config:
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -112,18 +160,19 @@ spec:
                       type: object
                     type: object
                 type: object
+              settings:
+                additionalProperties:
+                  type: string
+                type: object
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: OpenShiftPipelinesAsCodeStatus defines the observed state
+              of OpenShiftPipelinesAsCode
             properties:
               annotations:
                 additionalProperties:
@@ -177,9 +226,6 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
-                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: syncerservices.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: SyncerService
+    listKind: SyncerServiceList
+    plural: syncerservices
+    singular: syncerservice
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: SyncerService is the Schema for the syncerservices API
         properties:
           apiVersion:
             description: |-
@@ -63,24 +47,62 @@ spec:
           metadata:
             type: object
           spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               options:
-                description: options holds additions fields and these fields will
+                description: Options holds additions fields and these fields will
                   be updated on the manifests
                 properties:
                   configMaps:
@@ -115,15 +137,9 @@ spec:
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
-            - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: SyncerServiceStatus defines the observed state of SyncerService
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +193,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_tektonaddons.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonaddons.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonaddons.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonAddon
+    listKind: TektonAddonList
+    plural: tektonaddons
+    singular: tektonaddon
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonAddon is the Schema for the tektonaddons API
         properties:
           apiVersion:
             description: |-
@@ -63,67 +47,83 @@ spec:
           metadata:
             type: object
           spec:
+            description: TektonAddonSpec defines the desired state of TektonAddon
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
-              options:
-                description: options holds additions fields and these fields will
-                  be updated on the manifests
+              config:
+                description: Config holds the configuration for resources created
+                  by Addon
                 properties:
-                  configMaps:
-                    x-kubernetes-preserve-unknown-fields: true
-                  deployments:
-                    x-kubernetes-preserve-unknown-fields: true
-                  disabled:
-                    type: boolean
-                  horizontalPodAutoscalers:
-                    x-kubernetes-preserve-unknown-fields: true
-                  statefulSets:
-                    x-kubernetes-preserve-unknown-fields: true
-                  webhookConfigurationOptions:
+                  nodeSelector:
                     additionalProperties:
-                      description: WebhookOptions defines options for webhooks
-                      properties:
-                        failurePolicy:
-                          description: FailurePolicyType specifies a failure policy
-                            that defines how unrecognized errors from the admission
-                            endpoint are handled.
-                          type: string
-                        sideEffects:
-                          description: SideEffectClass specifies the types of side
-                            effects a webhook may have.
-                          type: string
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
-                      type: object
+                      type: string
                     type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                 type: object
+              enablePipelinesAsCode:
+                description: |-
+                  Deprecated, will be removed in further release
+                  EnablePAC field defines whether to install PAC
+                type: boolean
+              params:
+                description: Params is the list of params passed for Addon customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
-            - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonAddonStatus defines the observed state of TektonAddon
             properties:
               annotations:
                 additionalProperties:
@@ -171,15 +171,17 @@ spec:
                   - type
                   type: object
                 type: array
+              installerSets:
+                additionalProperties:
+                  type: string
+                description: TektonInstallerSet created to install addons
+                type: object
               observedGeneration:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
-                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
@@ -1,26 +1,10 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -1,26 +1,10 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonDashboard
+    listKind: TektonDashboardList
+    plural: tektondashboards
+    singular: tektondashboard
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonDashboard is the Schema for the tektondashboards API
         properties:
           apiVersion:
             description: |-
@@ -63,21 +47,61 @@ spec:
           metadata:
             type: object
           spec:
+            description: TektonDashboardSpec defines the desired state of TektonDashboard
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonDashboard
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              external-logs:
                 type: string
               options:
                 description: options holds additions fields and these fields will
@@ -112,18 +136,19 @@ spec:
                       type: object
                     type: object
                 type: object
+              readonly:
+                description: Readonly when set to true configures the Tekton dashboard
+                  in read-only mode
+                type: boolean
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
+            - readonly
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonDashboardStatus defines the observed state of TektonDashboard
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +202,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              tektonInstallerSet:
+                description: The current installer set name for TektonDashboard
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_tektonhubs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonhubs.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonHub
+    listKind: TektonHubList
+    plural: tektonhubs
+    singular: tektonhub
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -40,10 +24,16 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    - jsonPath: .status.apiUrl
+      name: ApiUrl
+      type: string
+    - jsonPath: .status.uiUrl
+      name: UiUrl
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonHub is the Schema for the tektonhub API
         properties:
           apiVersion:
             description: |-
@@ -64,21 +54,63 @@ spec:
             type: object
           spec:
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
+              api:
+                properties:
+                  catalogRefreshInterval:
+                    type: string
+                  hubConfigUrl:
+                    description: Deprecated, will be removed in further release
+                    type: string
+                  routeHostUrl:
+                    type: string
+                  secret:
+                    type: string
+                type: object
+              catalogs:
+                items:
+                  properties:
+                    contextDir:
+                      type: string
+                    name:
+                      type: string
+                    org:
+                      type: string
+                    provider:
+                      type: string
+                    revision:
+                      type: string
+                    sshUrl:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                type: array
+              categories:
+                items:
+                  type: string
+                type: array
+              customLogo:
+                description: The Base64 Encode data and mediaType of the Custom Logo
+                properties:
+                  base64Data:
+                    type: string
+                  mediaType:
+                    type: string
+                type: object
+              db:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              default:
+                properties:
+                  scopes:
+                    items:
+                      type: string
+                    type: array
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -112,18 +144,37 @@ spec:
                       type: object
                     type: object
                 type: object
+              params:
+                description: Params is the list of params passed for Hub customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              scopes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    users:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonHubStatus defines the observed state of TektonHub
             properties:
               annotations:
                 additionalProperties:
@@ -134,6 +185,12 @@ spec:
                   roughly akin to Annotations on any k8s resource, just the reconciler conveying
                   richer information outwards.
                 type: object
+              apiUrl:
+                description: The URL route for API which needs to be exposed
+                type: string
+              authUrl:
+                description: The URL route for Auth server
+                type: string
               conditions:
                 description: Conditions the latest available observations of a resource's
                   current state.
@@ -171,14 +228,24 @@ spec:
                   - type
                   type: object
                 type: array
+              hubInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              manifests:
+                description: The url links of the manifests, separated by comma
+                items:
+                  type: string
+                type: array
               observedGeneration:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              uiUrl:
+                description: The URL route for UI which needs to be exposed
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_tektoninstallersets.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektoninstallersets.yaml
@@ -1,39 +1,20 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonInstallerSet
+    listKind: TektonInstallerSetList
+    plural: tektoninstallersets
+    singular: tektoninstallerset
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.version
-      name: Version
-      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -43,7 +24,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
         properties:
           apiVersion:
             description: |-
@@ -63,67 +44,13 @@ spec:
           metadata:
             type: object
           spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
+              manifests:
                 x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
-              options:
-                description: options holds additions fields and these fields will
-                  be updated on the manifests
-                properties:
-                  configMaps:
-                    x-kubernetes-preserve-unknown-fields: true
-                  deployments:
-                    x-kubernetes-preserve-unknown-fields: true
-                  disabled:
-                    type: boolean
-                  horizontalPodAutoscalers:
-                    x-kubernetes-preserve-unknown-fields: true
-                  statefulSets:
-                    x-kubernetes-preserve-unknown-fields: true
-                  webhookConfigurationOptions:
-                    additionalProperties:
-                      description: WebhookOptions defines options for webhooks
-                      properties:
-                        failurePolicy:
-                          description: FailurePolicyType specifies a failure policy
-                            that defines how unrecognized errors from the admission
-                            endpoint are handled.
-                          type: string
-                        sideEffects:
-                          description: SideEffectClass specifies the types of side
-                            effects a webhook may have.
-                          type: string
-                        timeoutSeconds:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: object
-                type: object
-              targetNamespace:
-                description: TargetNamespace is where resources will be installed
-                type: string
-            required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
-            - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
             properties:
               annotations:
                 additionalProperties:
@@ -177,12 +104,6 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
-                type: string
-              version:
-                description: The version of the installed release
-                type: string
             type: object
         type: object
     served: true

--- a/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonMulticlusterProxyAAE
+    listKind: TektonMulticlusterProxyAAEList
+    plural: tektonmulticlusterproxyaaes
+    singular: tektonmulticlusterproxyaae
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
         properties:
           apiVersion:
             description: |-
@@ -64,23 +49,8 @@ spec:
             type: object
           spec:
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
-              disabled:
-                description: enable or disable TektonScheduler Component
-                type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
               options:
-                description: options holds additions fields and these fields will
+                description: options holds additional fields and these fields will
                   be updated on the manifests
                 properties:
                   configMaps:
@@ -116,14 +86,11 @@ spec:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
-            - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +144,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
@@ -1,36 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: openshiftpipelinesascodes.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: OpenShiftPipelinesAsCode
-    listKind: OpenShiftPipelinesAsCodeList
-    plural: openshiftpipelinesascodes
-    shortNames:
-    - opac
-    - pac
-    singular: openshiftpipelinesascode
+    kind: TektonPipeline
+    listKind: TektonPipelineList
+    plural: tektonpipelines
+    singular: tektonpipeline
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -46,8 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OpenShiftPipelinesAsCode is the Schema for the OpenShiftPipelinesAsCode
-          API
+        description: TektonPipeline is the Schema for the tektonpipelines API
         properties:
           apiVersion:
             description: |-
@@ -67,33 +47,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: OpenShiftPipelinesAsCodeSpec defines the desired state of
-              OpenShiftPipelinesAsCode
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
             properties:
-              additionalPACControllers:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
                 additionalProperties:
-                  description: AdditionalPACControllerConfig contains config for additionalPACControllers
-                  properties:
-                    configMapName:
-                      description: Name of the additional controller configMap
-                      type: string
-                    enable:
-                      description: Enable or disable this additional pipelines as
-                        code instance by changing this bool
-                      type: boolean
-                    secretName:
-                      description: Name of the additional controller Secret
-                      type: string
-                    settings:
-                      additionalProperties:
-                        type: string
-                      description: Setting will contains the configMap data
-                      type: object
-                  type: object
-                description: AdditionalPACControllers allows to deploy additional
-                  PAC controller
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
                 type: object
               config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
                 properties:
                   nodeSelector:
                     additionalProperties:
@@ -143,6 +111,91 @@ spec:
                       type: object
                     type: array
                 type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                format: int32
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -176,19 +229,85 @@ spec:
                       type: object
                     type: object
                 type: object
-              settings:
-                additionalProperties:
-                  type: string
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
                 type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                type: boolean
+              set-security-context:
+                type: boolean
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
                 type: string
             required:
             - options
             type: object
           status:
-            description: OpenShiftPipelinesAsCodeStatus defines the observed state
-              of OpenShiftPipelinesAsCode
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
             properties:
               annotations:
                 additionalProperties:
@@ -236,12 +355,20 @@ spec:
                   - type
                   type: object
                 type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
               observedGeneration:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
                 format: int64
                 type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonpruners.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonPruner is the Schema for the TektonPruner API
         properties:
           apiVersion:
             description: |-
@@ -64,21 +48,63 @@ spec:
             type: object
           spec:
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
               disabled:
-                description: enable or disable TektonScheduler Component
+                description: enable or disable TektonPruner Component
                 type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
-                type: string
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -116,14 +142,12 @@ spec:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
             - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
+            - global-config
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonPrunerStatus defines the observed state of TektonPruner
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +201,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
                 type: string
               version:
                 description: The version of the installed release

--- a/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
@@ -1,36 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: openshiftpipelinesascodes.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: OpenShiftPipelinesAsCode
-    listKind: OpenShiftPipelinesAsCodeList
-    plural: openshiftpipelinesascodes
-    shortNames:
-    - opac
-    - pac
-    singular: openshiftpipelinesascode
+    kind: TektonResult
+    listKind: TektonResultList
+    plural: tektonresults
+    singular: tektonresult
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -46,8 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OpenShiftPipelinesAsCode is the Schema for the OpenShiftPipelinesAsCode
-          API
+        description: TektonResult is the Schema for the tektonresults API
         properties:
           apiVersion:
             description: |-
@@ -67,33 +47,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: OpenShiftPipelinesAsCodeSpec defines the desired state of
-              OpenShiftPipelinesAsCode
+            description: TektonResultSpec defines the desired state of TektonResult
             properties:
-              additionalPACControllers:
-                additionalProperties:
-                  description: AdditionalPACControllerConfig contains config for additionalPACControllers
-                  properties:
-                    configMapName:
-                      description: Name of the additional controller configMap
-                      type: string
-                    enable:
-                      description: Enable or disable this additional pipelines as
-                        code instance by changing this bool
-                      type: boolean
-                    secretName:
-                      description: Name of the additional controller Secret
-                      type: string
-                    settings:
-                      additionalProperties:
-                        type: string
-                      description: Setting will contains the configMap data
-                      type: object
-                  type: object
-                description: AdditionalPACControllers allows to deploy additional
-                  PAC controller
-                type: object
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
               config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
                 properties:
                   nodeSelector:
                     additionalProperties:
@@ -143,8 +105,77 @@ spec:
                       type: object
                     type: array
                 type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                format: int64
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                format: int64
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
               options:
-                description: options holds additions fields and these fields will
+                description: Options holds additions fields and these fields will
                   be updated on the manifests
                 properties:
                   configMaps:
@@ -176,19 +207,74 @@ spec:
                       type: object
                     type: object
                 type: object
-              settings:
-                additionalProperties:
-                  type: string
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    format: int32
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
                 type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                format: int64
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                format: int64
+                type: integer
+              storage_emulator_host:
+                type: string
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
+              tls_hostname_override:
+                type: string
             required:
+            - disabled
+            - is_external_db
             - options
             type: object
           status:
-            description: OpenShiftPipelinesAsCodeStatus defines the observed state
-              of OpenShiftPipelinesAsCode
+            description: TektonResultStatus defines the observed state of TektonResult
             properties:
               annotations:
                 additionalProperties:
@@ -242,6 +328,9 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
@@ -1,26 +1,10 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
@@ -1,33 +1,17 @@
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: tektonschedulers.operator.tekton.dev
-  labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+  name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
   names:
-    kind: TektonScheduler
-    listKind: TektonSchedulerList
-    plural: tektonschedulers
-    singular: tektonscheduler
+    kind: TektonTrigger
+    listKind: TektonTriggerList
+    plural: tektontriggers
+    singular: tektontrigger
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -43,7 +27,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: TektonScheduler is the Schema for the TektonScheduler API
+        description: TektonTrigger is the Schema for the tektontriggers API
         properties:
           apiVersion:
             description: |-
@@ -63,21 +47,66 @@ spec:
           metadata:
             type: object
           spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
             properties:
-              config.yaml:
-                description: |-
-                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-                  match the key here
-                x-kubernetes-preserve-unknown-fields: true
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
               disabled:
-                description: enable or disable TektonScheduler Component
+                description: enable or disable Trigger Component
                 type: boolean
-              multi-cluster-disabled:
-                type: boolean
-              multi-cluster-role:
-                description: |-
-                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
-                  can be one of Hub or Spoke
+              enable-api-fields:
                 type: string
               options:
                 description: options holds additions fields and these fields will
@@ -116,14 +145,11 @@ spec:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - config.yaml
             - disabled
-            - multi-cluster-disabled
-            - multi-cluster-role
             - options
             type: object
           status:
-            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
             properties:
               annotations:
                 additionalProperties:
@@ -177,8 +203,8 @@ spec:
                   was last processed by the controller.
                 format: int64
                 type: integer
-              tekton-scheduler:
-                description: The current installer set name for TektonScheduler
+              tektonInstallerSet:
+                description: The current installer set name
                 type: string
               version:
                 description: The version of the installed release

--- a/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
+++ b/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektondashboards.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,26 +28,205 @@ spec:
     listKind: TektonDashboardList
     plural: tektondashboards
     singular: tektondashboard
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - jsonPath: ".status.conditions[?(@.type==\"Ready\")].message"
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: TektonDashboard is the Schema for the tektondashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonDashboardSpec defines the desired state of TektonDashboard
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonDashboard
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              external-logs:
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              readonly:
+                description: Readonly when set to true configures the Tekton dashboard
+                  in read-only mode
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - options
+            - readonly
+            type: object
+          status:
+            description: TektonDashboardStatus defines the observed state of TektonDashboard
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonDashboard
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the tektondashboards API
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
+++ b/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2025 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonaddons.operator.tekton.dev
   labels:
     version: "devel"
@@ -26,26 +28,182 @@ spec:
     listKind: TektonAddonList
     plural: tektonaddons
     singular: tektonaddon
-  preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
+  - additionalPrinterColumns:
     - jsonPath: .status.version
       name: Version
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
-    - jsonPath: ".status.conditions[?(@.type==\"Ready\")].message"
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Reason
       type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: TektonAddon is the Schema for the tektonaddons API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonAddonSpec defines the desired state of TektonAddon
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by Addon
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              enablePipelinesAsCode:
+                description: |-
+                  Deprecated, will be removed in further release
+                  EnablePAC field defines whether to install PAC
+                type: boolean
+              params:
+                description: Params is the list of params passed for Addon customization
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: TektonAddonStatus defines the observed state of TektonAddon
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              installerSets:
+                additionalProperties:
+                  type: string
+                description: TektonInstallerSet created to install addons
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                format: int64
+                type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
         type: object
-        description: Schema for the tektonaddons API. Supported on OpenShift only.
-        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script syncs generated CRDs from config/base/generated-crds/ into:
+#   1. config/base/, config/kubernetes/base/, config/openshift/base/ (kustomize source-of-truth)
+#   2. charts/tekton-operator/templates/ (Helm chart CRDs)
+#
+# Prerequisites: Run `make generate-crds` first (or use `make sync-helm-crds` which calls this).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GENERATED_DIR="${REPO_ROOT}/config/base/generated-crds"
+BASE_DIR="${REPO_ROOT}/config/base"
+K8S_DIR="${REPO_ROOT}/config/kubernetes/base"
+OPENSHIFT_DIR="${REPO_ROOT}/config/openshift/base"
+HELM_DIR="${REPO_ROOT}/charts/tekton-operator/templates"
+
+# inject_labels adds the standard labels after the metadata.name line in a generated CRD
+inject_labels() {
+  local input_file="$1"
+  local tmpfile
+  tmpfile=$(mktemp)
+  while IFS= read -r line; do
+    echo "$line" >> "$tmpfile"
+    # After the "  name: ..." line under metadata, inject labels
+    if echo "$line" | grep -qE '^  name: .*\.operator\.tekton\.dev$'; then
+      echo '  labels:' >> "$tmpfile"
+      echo '    version: "devel"' >> "$tmpfile"
+      echo '    operator.tekton.dev/release: "devel"' >> "$tmpfile"
+    fi
+  done < "$input_file"
+  cat "$tmpfile"
+  rm -f "$tmpfile"
+}
+
+# strip_leading_separator removes the leading "---" from controller-gen output
+strip_leading_separator() {
+  sed '1{/^---$/d;}'
+}
+
+# write_config_crd writes a CRD to the appropriate config/ directory with copyright header and labels
+write_config_crd() {
+  local src_file="$1"
+  local dest_dir="$2"
+  local dest_file="$3"
+
+  cat > "${dest_dir}/${dest_file}" <<'HEADER'
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HEADER
+
+  inject_labels "$src_file" | strip_leading_separator >> "${dest_dir}/${dest_file}"
+  echo "  Updated: ${dest_dir}/${dest_file}"
+}
+
+# assemble_helm_crds assembles a Helm chart CRD file from multiple generated CRDs
+assemble_helm_crds() {
+  local output_file="$1"
+  local condition="$2"
+  shift 2
+  local crd_files=("$@")
+
+  echo "${condition}" > "$output_file"
+  for crd_file in "${crd_files[@]}"; do
+    echo "---" >> "$output_file"
+    inject_labels "${GENERATED_DIR}/${crd_file}" | strip_leading_separator >> "$output_file"
+  done
+  echo '{{- end -}}' >> "$output_file"
+
+  echo "  Updated: ${output_file}"
+}
+
+echo "Syncing generated CRDs..."
+echo ""
+
+# Step 1: Update config/ directories
+echo "Step 1: Updating config/ CRD files..."
+
+# base CRDs (common to both kubernetes and openshift)
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_manualapprovalgates.yaml"         "$BASE_DIR"      "300-operator_v1alpha1_manualapprovalgate_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonchains.yaml"                "$BASE_DIR"      "300-operator_v1alpha1_chain_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonconfigs.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_config_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonhubs.yaml"                  "$BASE_DIR"      "300-operator_v1alpha1_hub_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektoninstallersets.yaml"          "$BASE_DIR"      "300-operator_v1alpha1_installer_set_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonpipelines.yaml"             "$BASE_DIR"      "300-operator_v1alpha1_pipeline_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonresults.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_result_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektontriggers.yaml"              "$BASE_DIR"      "300-operator_v1alpha1_trigger_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonpruners.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_pruner_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonschedulers.yaml"            "$BASE_DIR"      "300-operator_v1alpha1_scheduler_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" "$BASE_DIR"      "300-operator_v1alpha1_multiclusterproxyaae_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_syncerservices.yaml"              "$BASE_DIR"      "300-operator_v1alpha1_syncerservice_crd.yaml"
+
+# kubernetes-only CRDs
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektondashboards.yaml"            "$K8S_DIR"       "300-operator_v1alpha1_dashboard_crd.yaml"
+
+# openshift-only CRDs
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonaddons.yaml"                "$OPENSHIFT_DIR" "300-operator_v1alpha1_addon_crd.yaml"
+write_config_crd "${GENERATED_DIR}/operator.tekton.dev_openshiftpipelinesascodes.yaml"   "$OPENSHIFT_DIR" "300-operator_v1alpha1_openshiftpipelinesascode_crd.yaml"
+
+echo ""
+
+# Step 2: Assemble Helm chart CRDs
+echo "Step 2: Assembling Helm chart CRD files..."
+
+assemble_helm_crds \
+  "${HELM_DIR}/kubernetes-crds.yaml" \
+  '{{- if (and (not .Values.openshift.enabled) .Values.installCRDs) -}}' \
+  "operator.tekton.dev_manualapprovalgates.yaml" \
+  "operator.tekton.dev_openshiftpipelinesascodes.yaml" \
+  "operator.tekton.dev_tektonchains.yaml" \
+  "operator.tekton.dev_tektonconfigs.yaml" \
+  "operator.tekton.dev_tektondashboards.yaml" \
+  "operator.tekton.dev_tektonhubs.yaml" \
+  "operator.tekton.dev_tektoninstallersets.yaml" \
+  "operator.tekton.dev_tektonpipelines.yaml" \
+  "operator.tekton.dev_tektonresults.yaml" \
+  "operator.tekton.dev_tektontriggers.yaml" \
+  "operator.tekton.dev_tektonpruners.yaml" \
+  "operator.tekton.dev_tektonschedulers.yaml" \
+  "operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" \
+  "operator.tekton.dev_syncerservices.yaml"
+
+assemble_helm_crds \
+  "${HELM_DIR}/openshift-crds.yaml" \
+  '{{- if (and .Values.openshift.enabled .Values.installCRDs) -}}' \
+  "operator.tekton.dev_manualapprovalgates.yaml" \
+  "operator.tekton.dev_openshiftpipelinesascodes.yaml" \
+  "operator.tekton.dev_tektonaddons.yaml" \
+  "operator.tekton.dev_tektonchains.yaml" \
+  "operator.tekton.dev_tektonconfigs.yaml" \
+  "operator.tekton.dev_tektonhubs.yaml" \
+  "operator.tekton.dev_tektoninstallersets.yaml" \
+  "operator.tekton.dev_tektonpipelines.yaml" \
+  "operator.tekton.dev_tektonresults.yaml" \
+  "operator.tekton.dev_tektontriggers.yaml" \
+  "operator.tekton.dev_tektonpruners.yaml" \
+  "operator.tekton.dev_tektonschedulers.yaml" \
+  "operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" \
+  "operator.tekton.dev_syncerservices.yaml"
+
+# Step 3: Validate CRD sizes (etcd has a 256KB object size limit)
+echo "Step 3: Validating CRD sizes..."
+
+MAX_SIZE=262144 # 256KB
+FAILED=0
+for file in "${GENERATED_DIR}"/*.yaml; do
+  # Calculate JSON size using yq to simulate the size of the applied configuration
+  SIZE=$(yq -o=json -I=0 . "$file" | wc -c | tr -d ' ')
+  echo "  $(basename "$file"): ${SIZE} bytes"
+  if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+    echo "  ERROR: $(basename "$file") JSON size (${SIZE} bytes) exceeds the limit of ${MAX_SIZE} bytes (256KB)."
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -eq 1 ]; then
+  echo ""
+  echo "FAILED: One or more CRDs exceed the 256KB JSON size limit."
+  echo "Consider adding +kubebuilder:validation:Schemaless to large embedded types."
+  exit 1
+fi
+
+echo ""
+echo "Done! CRDs synced and validated successfully."

--- a/pkg/apis/operator/v1alpha1/additional_options.go
+++ b/pkg/apis/operator/v1alpha1/additional_options.go
@@ -25,10 +25,18 @@ import (
 // additional options will be updated on the manifests
 // these values will be final
 type AdditionalOptions struct {
-	Disabled                    *bool                                            `json:"disabled,omitempty"`
-	ConfigMaps                  map[string]corev1.ConfigMap                      `json:"configMaps,omitempty"`
-	Deployments                 map[string]appsv1.Deployment                     `json:"deployments,omitempty"`
-	HorizontalPodAutoscalers    map[string]autoscalingv2.HorizontalPodAutoscaler `json:"horizontalPodAutoscalers,omitempty"`
-	StatefulSets                map[string]appsv1.StatefulSet                    `json:"statefulSets,omitempty"`
-	WebhookConfigurationOptions map[string]WebhookConfigurationOptions           `json:"webhookConfigurationOptions,omitempty"`
+	Disabled *bool `json:"disabled,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	ConfigMaps map[string]corev1.ConfigMap `json:"configMaps,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	Deployments map[string]appsv1.Deployment `json:"deployments,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	HorizontalPodAutoscalers map[string]autoscalingv2.HorizontalPodAutoscaler `json:"horizontalPodAutoscalers,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	StatefulSets                map[string]appsv1.StatefulSet          `json:"statefulSets,omitempty"`
+	WebhookConfigurationOptions map[string]WebhookConfigurationOptions `json:"webhookConfigurationOptions,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
+++ b/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
@@ -31,6 +31,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster,shortName=mag
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type ManualApprovalGate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,6 +56,7 @@ type ManualApproval struct {
 }
 
 // ManualApprovalGateList contains a list of ManualApprovalGate
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type ManualApprovalGateList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
@@ -26,6 +26,12 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster,shortName=opac;pac
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type OpenShiftPipelinesAsCode struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -61,6 +67,7 @@ type OpenShiftPipelinesAsCodeStatus struct {
 }
 
 // OpenShiftPipelinesAsCodeList contains a list of OpenShiftPipelinesAsCode
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type OpenShiftPipelinesAsCodeList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/syncerservice_types.go
+++ b/pkg/apis/operator/v1alpha1/syncerservice_types.go
@@ -31,6 +31,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type SyncerService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -94,6 +100,7 @@ func (sss *SyncerServiceStatus) MarkPostReconcilerFailed(msg string) {
 }
 
 // SyncerServiceList contains a list of SyncerService
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type SyncerServiceList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonaddon_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonaddon_types.go
@@ -26,6 +26,12 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonAddon struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -87,6 +93,7 @@ func (a Addon) IsEmpty() bool {
 }
 
 // TektonAddonsList contains a list of TektonAddon
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonAddonList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -36,6 +36,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonChain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -134,6 +140,7 @@ type ChainProperties struct {
 	Performance PerformanceProperties `json:"performance,omitempty"`
 }
 
+// +kubebuilder:validation:Type=string
 type BoolValue string
 
 func (bv *BoolValue) UnmarshalJSON(value []byte) error {
@@ -169,6 +176,7 @@ type TektonChainStatus struct {
 }
 
 // TektonChainList contains a list of TektonChain
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonChainList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -29,6 +29,12 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -183,6 +189,7 @@ func (in *TektonConfigStatus) MarkPostReconcilerFailed(s string) {
 }
 
 // TektonConfigList contains a list of TektonConfig
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektondashboard_types.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_types.go
@@ -31,6 +31,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonDashboard struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -72,6 +78,7 @@ type TektonDashboardStatus struct {
 }
 
 // TektonDashboardsList contains a list of TektonDashboard
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonDashboardList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonhub_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_types.go
@@ -36,6 +36,14 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
+// +kubebuilder:printcolumn:name="ApiUrl",type=string,JSONPath=`.status.apiUrl`
+// +kubebuilder:printcolumn:name="UiUrl",type=string,JSONPath=`.status.uiUrl`
 type TektonHub struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -152,6 +160,7 @@ func (in *TektonHubStatus) MarkInstallerSetAvailable() {
 }
 
 // TektonHubList contains a list of TektonHub
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonHubList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektoninstallerset_types.go
+++ b/pkg/apis/operator/v1alpha1/tektoninstallerset_types.go
@@ -27,6 +27,11 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonInstallerSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -37,6 +42,8 @@ type TektonInstallerSet struct {
 
 // TektonInstallerSetSpec defines the desired state of TektonInstallerSet
 type TektonInstallerSetSpec struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Manifests mf.Slice `json:"manifests,omitempty"`
 }
 
@@ -46,6 +53,7 @@ type TektonInstallerSetStatus struct {
 }
 
 // TektonInstallerSetList contains a list of TektonInstallerSet
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonInstallerSetList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
@@ -31,7 +31,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
-
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonMulticlusterProxyAAE struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -51,6 +56,7 @@ type MulticlusterProxyAAEOptions struct {
 }
 
 // TektonMulticlusterProxyAAEList contains a list of TektonMulticlusterProxyAAE
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonMulticlusterProxyAAEList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -27,6 +27,12 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonPipeline struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -69,6 +75,7 @@ type TektonPipelineStatus struct {
 }
 
 // TektonPipelineList contains a list of TektonPipeline
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonPipelineList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -32,8 +32,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
-
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonPruner struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -42,6 +46,8 @@ type TektonPruner struct {
 }
 
 type TektonPrunerConfig struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	GlobalConfig *config.GlobalConfig `json:"global-config"`
 }
 
@@ -55,6 +61,7 @@ type Pruner struct {
 }
 
 // TektonPrunerList contains a list of TektonPruner
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonPrunerList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -31,6 +31,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonResult struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -160,6 +166,7 @@ func (trs *TektonResultStatus) MarkPostReconcilerFailed(msg string) {
 }
 
 // TektonResultsList contains a list of TektonResult
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonResultList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
@@ -32,8 +32,12 @@ var (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
-
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonScheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +57,9 @@ type Scheduler struct {
 
 type SchedulerConfig struct {
 	// This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
-	//match the key here
+	// match the key here
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	config.Config `json:"config.yaml"`
 }
 
@@ -68,6 +74,7 @@ type MultiClusterConfig struct {
 type MultiClusterRole string
 
 // TektonSchedulerList contains a list of TektonScheduler
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonSchedulerList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/operator/v1alpha1/tektontrigger_types.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_types.go
@@ -26,6 +26,12 @@ import (
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:nonNamespaced
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.version`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`
 type TektonTrigger struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -67,6 +73,7 @@ type TektonTriggerStatus struct {
 }
 
 // TektonTriggersList contains a list of TektonTrigger
+// +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TektonTriggerList struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
# Changes

Replace the hand-written CRDs that used a bare `x-kubernetes-preserve-unknown-fields: true` with no `spec`/`status` schema, with fully-typed OpenAPI v3 schemas generated from the Go types using `controller-gen`.

**Problem:** Every CRD in this project had no resource metadata defined — just `type: object` with preserve-unknown-fields. This meant no server-side validation, no `kubectl explain`, no IDE autocompletion, and no field pruning.

**Solution:** Use `controller-gen` to generate proper schemas from the existing Go types (which are already richly typed), then sync them into the config/ directories and Helm chart.

### Commit breakdown

1. **Add kubebuilder markers to CRD Go types**: Adds `+kubebuilder:object:root`, `+kubebuilder:resource:scope=Cluster`, `+kubebuilder:subresource:status`, and `+kubebuilder:printcolumn` markers to all 15 root types and list types. Escape-hatch fields that embed full k8s API types (AdditionalOptions, mf.Slice, external configs) are marked with `PreserveUnknownFields + Schemaless` to keep CRD size manageable.

2. **Add controller-gen toolchain and CRD sync script**: Adds `controller-gen` v0.17.3 to the Makefile (`make generate-crds`, `make sync-helm-crds`) and a `hack/sync-helm-crds.sh` script that syncs generated CRDs into `config/{base,kubernetes/base,openshift/base}/` and assembles the Helm chart CRD template files with proper conditionals and labels.

3. **Regenerate CRD manifests**: Mechanical output of `make sync-helm-crds`. All 15 CRDs now carry typed spec/status schemas.

### What this enables

- **Server-side validation**: the API server rejects unknown/malformed fields
- **`kubectl explain`**: users can discover the API from the CLI
- **IDE autocompletion**: tools that consume the OpenAPI schema get full field info
- **Field pruning**: unknown fields are rejected instead of silently preserved

### Notes

- The `AdditionalOptions` fields (Deployments, ConfigMaps, StatefulSets, HPAs) and a few external types (pruner config, scheduler config, mf.Slice manifests) retain `x-kubernetes-preserve-unknown-fields` since they intentionally accept arbitrary k8s objects.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
CRD manifests now include full OpenAPI v3 schemas generated for all operator.tekton.dev custom resources.
```
