### PR TITLE
fix: remove YAML document separator from .tekton files

### DIFF
--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -19,7 +19,6 @@
 #
 # The version and release_as_latest parameters are passed dynamically
 # through the incoming webhook payload.
----
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -19,7 +19,6 @@
 # The release pipeline builds, publishes images for both kubernetes
 # and openshift platforms, uploads artifacts to the release bucket,
 # and a draft GitHub release is created separately.
----
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:


### PR DESCRIPTION
# Changes

Remove the `---` YAML document separator between the license/description comments and the PipelineRun manifest in `.tekton/release.yaml` and `.tekton/release-patch.yaml`.

The `---` creates a multi-document YAML file where the first document contains only comments (no Kubernetes object). PAC tries to parse each YAML document and logs an error for the empty one:

```
cannot read the PipelineRun: unknown, error: error decoding yaml document: Object 'Kind' is missing
```

This does not block incoming webhooks or release automation (PAC matches by PipelineRun name for those), but it generates **noisy error logs on every GitHub event** (PRs, pushes, comments, label changes) hitting the operator Repository CR.

Removing the `---` makes the comments part of the same YAML document as the PipelineRun, eliminating the spurious parse errors.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

/kind bug