### PR TITLE
WIP - Security Fix: Reduce permissions in tekton-scheduler-role 

### DIFF
--- a/config/base/tekton_scheduler_role.yaml
+++ b/config/base/tekton_scheduler_role.yaml
@@ -21,18 +21,43 @@ rules:
       - kueue.x-k8s.io
     resources:
       - resourceflavors
-      - workloads
-      - workloads/finalizers
-      - workloads/status
       - workloadpriorityclasses
     verbs:
       - get
       - list
-      - create
-      - update
-      - delete
-      - patch
       - watch
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloadpriorityclasses
+    verbs:
+      - create
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - scheduling.k8s.io
     resources:
@@ -49,8 +74,6 @@ rules:
     verbs:
       - get
       - create
-      - update
-      - list
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/config/base/tekton_scheduler_role_binding.yaml
+++ b/config/base/tekton_scheduler_role_binding.yaml
@@ -17,9 +17,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-scheduler-rolebinding
 subjects:
-  - kind: Group
-    apiGroup: rbac.authorization.k8s.io
-    name: 'system:authenticated'
+  - kind: ServiceAccount
+    name: tekton-operator
+    namespace: tekton-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION



# Changes

Reduced the permissions of tekton-scheduler-role 
Also updated the subject to tekton-operator only. Earlier this role was assigned to every authenticated user. Now only tekton-operator can  have this role.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
