### PR TITLE
Security Fix: Update subject for tekton-scheduler-role to tekton-operator

### DIFF
--- a/config/base/tekton_scheduler_role_binding.yaml
+++ b/config/base/tekton_scheduler_role_binding.yaml
@@ -17,9 +17,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-scheduler-rolebinding
 subjects:
-  - kind: Group
-    apiGroup: rbac.authorization.k8s.io
-    name: 'system:authenticated'
+  - kind: ServiceAccount
+    name: tekton-operator
+    namespace: tekton-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/openshift/base/kustomization.yaml
+++ b/config/openshift/base/kustomization.yaml
@@ -14,6 +14,16 @@
 
 patches:
 - target:
+    kind: ClusterRoleBinding
+    name: tekton-scheduler-rolebinding
+  patch: |-
+    - op: replace
+      path: /subjects
+      value:
+        - kind: ServiceAccount
+          name: openshift-pipelines-operator
+          namespace: openshift-operators
+- target:
     kind: Deployment
     name: tekton-operator
   patch: |-


### PR DESCRIPTION
# Changes

Currently TektonScheduler Role is  Assigned to every authenticated user which  makes system vulnerable.
Reducing the scope of role to  tekton-operator will make  assure that users don't get additional permission by default.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note

Changed the Subject for  tekton-scheduler-rolebinding from  group system:authenticated to  ServiceAccount tekton-operator (k8s) or openshift-pipelines-operator (Openshift)

By Doing this tekton-scheduler-role is assigned to operator service account only. Earlier this was getting assigned to every authenticated user.


```
