### PR TITLE
fix: use correct fully qualified image names in release pipeline

### DIFF
--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -428,7 +428,7 @@ spec:
         description: Whether Chains signing succeeded (true, failed, or timeout)
       steps:
       - name: wait-and-extract
-        image: docker.io/library/alpine/k8s:1.32.2
+        image: docker.io/alpine/k8s:1.32.2
         script: |
           #!/bin/sh
           set -e
@@ -535,7 +535,7 @@ spec:
       - name: workarea
       steps:
       - name: setup
-        image: docker.io/library/alpine:3.21
+        image: docker.io/library/alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
         script: |
           #!/bin/sh
           set -e


### PR DESCRIPTION
# Changes

Fix fully qualified image names in the release pipeline. The OCI cluster enforces fully qualified image names. `alpine/k8s` is a user image (`docker.io/alpine/k8s`), not a library image (`docker.io/library/alpine/k8s`), causing image pull failures in the `wait-for-chains` task during PAC-triggered releases.

- `docker.io/library/alpine/k8s:1.32.2` → `docker.io/alpine/k8s:1.32.2`
- Pin `alpine:3.21` to digest for reproducibility

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```