### PR TITLE
Use dedicated release ServiceAccount in PAC release pipelines

### DIFF
--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -29,6 +29,8 @@ metadata:
     pipelinesascode.tekton.dev/pipeline: "tekton/operator-release-pipeline.yaml"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
+  taskRunTemplate:
+    serviceAccountName: release
   pipelineRef:
     name: operator-release
   params:

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -37,6 +37,8 @@ metadata:
     pipelinesascode.tekton.dev/pipeline: "tekton/operator-release-pipeline.yaml"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
+  taskRunTemplate:
+    serviceAccountName: release
   pipelineRef:
     name: operator-release
   params:


### PR DESCRIPTION
# Changes

Use the dedicated `release` ServiceAccount (provisioned in
[tektoncd/plumbing#3335](https://github.com/tektoncd/plumbing/pull/3335))
in both `.tekton/release-patch.yaml` and `.tekton/release.yaml`.

The `wait-for-chains` task needs to list/get TaskRuns to check Tekton
Chains signing status. The `default` SA lacks these RBAC permissions,
causing `wait-for-chains` to return `signed="error"` and skipping the
`create-draft-release` task.

Depends on: tektoncd/plumbing#3335

/kind bug

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```