### PR TITLE
fix: replace symlinks with mv/cp in prepare-draft-release

### DIFF
--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -546,17 +546,6 @@ spec:
           PREVIOUS="$(params.previousReleaseTag)"
           NAME="$(params.releaseName)"
 
-          # The create-draft-release-oci task expects:
-          #   <workspace>/repo    -> git checkout
-          #   <workspace>/release -> release artifacts
-          # The release pipeline uses:
-          #   <workspace>/git     -> git checkout
-          #   <workspace>/bucket/<versionTag> -> release artifacts
-          ln -sfn "${WORKAREA}/git" "${WORKAREA}/repo"
-          ln -sfn "${WORKAREA}/bucket/${VERSION}" "${WORKAREA}/release"
-          echo "Created workspace symlinks:"
-          ls -la "${WORKAREA}/repo" "${WORKAREA}/release"
-
           # Strip github.com/ prefix from package for the draft release task
           PACKAGE=$(echo "$(params.package)" | sed 's|^github\.com/||')
           printf '%s' "${PACKAGE}" > "$(results.package.path)"
@@ -603,7 +592,7 @@ spec:
       - name: url
         value: https://github.com/tektoncd/plumbing
       - name: revision
-        value: c6ccd417b39dd9d0c3055795f00cbce051f6bc9e
+        value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
       - name: pathInRepo
         value: tekton/resources/release/base/github_release_oci.yaml
     params:
@@ -619,6 +608,10 @@ spec:
       value: $(tasks.prepare-draft-release.results.previous-tag)
     - name: rekor-uuid
       value: $(tasks.wait-for-chains.results.rekor-uuid)
+    - name: source-subpath
+      value: git
+    - name: release-subpath
+      value: bucket/$(params.versionTag)
     workspaces:
     - name: shared
       workspace: workarea


### PR DESCRIPTION
# Changes

runc fails with `mkdir /workspace/shared/repo: file exists` when a step's `workingDir` points through a symlink. The `prepare-draft-release` task creates symlinks (`repo → git`, `release → bucket/<version>`) for the `create-draft-release-oci` task, but runc's container init tries to `mkdir` the `workingDir` path and fails when it encounters the symlink.

Replace `ln -sfn` with `mv` (for git checkout) and `cp -r` (for release artifacts) to give `create-draft-release` real directories instead of symlinks.

Observed in two consecutive release runs:
- `release-patch-lm7md` — `PodCreationFailed`
- `release-patch-bh52z` — `PodCreationFailed`

A follow-up PR will update the plumbing task to accept configurable paths, removing the need for any renaming.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```