### PR TITLE
fix(release): correct devel version rewriting in publish-operator-release-task

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -95,6 +95,27 @@ spec:
       done
       cp ${DOCKER_CONFIG} /workspace/${KUBE_DISTRO}-docker-config.json
 
+  - name: rewrite-devel-in-source
+    image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
+    script: |
+      #!/usr/bin/env sh
+      set -ex
+
+      # Rewrite VERSION env var value in operator.yaml (not in ko/kustomize output, sed on release.yaml won't catch it)
+      # Uses awk for multi-line: match '- name: VERSION', then rewrite the following 'value:' line
+      # (avoids reliance on GNU sed which is not available in this image)
+      awk '/- name: VERSION/{found=1} found && /value:/{sub(/"?devel"?/, "$(params.versionTag)"); found=0} {print}' \
+        ${PROJECT_ROOT}/config/${KUBE_DISTRO}/base/operator.yaml > /tmp/operator.yaml.tmp
+      cp /tmp/operator.yaml.tmp ${PROJECT_ROOT}/config/${KUBE_DISTRO}/base/operator.yaml
+
+      # Rewrite kodata cabundles (openshift only) - these are baked into the container image
+      # and never appear in release.yaml, so must be updated before ko builds the image
+      if [ -d "${PROJECT_ROOT}/cmd/openshift/operator/kodata/cabundles" ]; then
+        sed -i -E \
+          -e 's/(operator.tekton.dev\/release): "?devel"?/\1: $(params.versionTag)/g' \
+          ${PROJECT_ROOT}/cmd/openshift/operator/kodata/cabundles/*.yaml
+      fi
+
   - name: run-kustomize-ko
     image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
     env:
@@ -154,9 +175,9 @@ spec:
           --platform=$(params.platforms) ${KO_EXTRA_ARGS} \
           -f - > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.notags.yaml
 
-      # Rewrite "devel" to params.versionTag
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(operator.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
+      # Rewrite "devel" (quoted or unquoted) to params.versionTag
+      sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
+      sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
   - name: koparse
     image: ghcr.io/tektoncd/plumbing/koparse@sha256:194c2ab9dce5f778ed757af13c626d6b85f15452e2c2902c79b0d0f5a0adf4d1
     script: |


### PR DESCRIPTION

# Changes

The publish-operator-release task had  issues with rewriting devel version labels in the release artifacts.

Problems fixed:

1. Removed `pipeline.tekton.dev/release` sed pattern -  this label never exists in this repo (copied from tektoncd/pipeline), making it a no-op.

2. Fixed unquoted devel not being matched - switched from BRE to ERE (-E) and made quotes optional ("?devel"?) to handle both version: devel and version: "devel" which coexist in source files.

3. Added **rewrite-devel-in-source step** (runs before run-kustomize-ko) to handle two cases that are never reachable via release.yaml sed:

- > - name: VERSION / value: "devel" env var in config/${KUBE_DISTRO}/base/operator.yaml , rendered into the container binary, not a k8s label, so not matched by any label-targeted pattern
- > cmd/openshift/operator/kodata/cabundles/*.yaml ,  bundled inside the container image via kodata, never appear in release.yaml

4. Uses awk (not sed) for the **multi-line VERSION** rewrite since the ko-gcloud image does not ship GNU sed. This is unique to Operator and does not apply to rest of the components.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
