### PR TITLE
fix: version mismatch issue in release automation

### DIFF
--- a/charts/tekton-operator/Chart.yaml
+++ b/charts/tekton-operator/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: tekton-operator
 description: A Helm chart to deploy the Tekton Operator and its CRDs
 type: application
-version: 0.79.1
+version: "devel"
 # corresponds to the version of tekton-operator
 # https://github.com/tektoncd/operator/releases
-appVersion: v0.79.1
+appVersion: "devel"
 maintainers:
   - name: Jack Henschel
     email: jack.henschel@cern.ch

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -5,8 +5,8 @@ kind: CustomResourceDefinition
 metadata:
   name: manualapprovalgates.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -44,8 +44,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -82,8 +82,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -120,8 +120,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektondashboards.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -158,8 +158,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -202,8 +202,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -237,8 +237,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -275,8 +275,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -313,8 +313,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -351,8 +351,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonpruners.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -389,8 +389,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonschedulers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -427,8 +427,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -466,8 +466,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: syncerservices.operator.tekton.dev
 spec:
   group: operator.tekton.dev

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -5,8 +5,8 @@ kind: CustomResourceDefinition
 metadata:
   name: manualapprovalgates.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:
@@ -44,8 +44,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: openshiftpipelinesascodes.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -85,8 +85,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonaddons.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -123,8 +123,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonchains.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -161,8 +161,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonconfigs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -199,8 +199,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonhubs.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -243,8 +243,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektoninstallersets.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -278,8 +278,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonpipelines.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -316,8 +316,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonresults.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -354,8 +354,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektontriggers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -392,8 +392,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonpruners.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -430,8 +430,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonschedulers.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -468,8 +468,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:
   group: operator.tekton.dev
@@ -507,8 +507,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.1
-    version: v0.79.1
+    operator.tekton.dev/release: "devel"
+    version: "devel"
   name: syncerservices.operator.tekton.dev
 spec:
   group: operator.tekton.dev

--- a/cmd/openshift/operator/kodata/cabundles/config-service-cabundle.yaml
+++ b/cmd/openshift/operator/kodata/cabundles/config-service-cabundle.yaml
@@ -21,7 +21,7 @@ metadata:
   name: config-service-cabundle
   namespace: openshift-pipelines
   labels:
-    operator.tekton.dev/release: v0.79.1
+    operator.tekton.dev/release: "devel"
     app.kubernetes.io/part-of: tekton-pipelines
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/cmd/openshift/operator/kodata/cabundles/config-trusted-cabundle.yaml
+++ b/cmd/openshift/operator/kodata/cabundles/config-trusted-cabundle.yaml
@@ -21,6 +21,6 @@ metadata:
   name: config-trusted-cabundle
   namespace: openshift-pipelines
   labels:
-    operator.tekton.dev/release: v0.79.1
+    operator.tekton.dev/release: "devel"
     app.kubernetes.io/part-of: tekton-pipelines
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/config/base/300-operator_v1alpha1_chain_crd.yaml
+++ b/config/base/300-operator_v1alpha1_chain_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonchains.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_config_crd.yaml
+++ b/config/base/300-operator_v1alpha1_config_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonconfigs.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_hub_crd.yaml
+++ b/config/base/300-operator_v1alpha1_hub_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonhubs.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_installer_set_crd.yaml
+++ b/config/base/300-operator_v1alpha1_installer_set_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektoninstallersets.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_manualapprovalgate_crd.yaml
+++ b/config/base/300-operator_v1alpha1_manualapprovalgate_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: manualapprovalgates.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_multiclusterproxyaae_crd.yaml
+++ b/config/base/300-operator_v1alpha1_multiclusterproxyaae_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_pipeline_crd.yaml
+++ b/config/base/300-operator_v1alpha1_pipeline_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonpipelines.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_pruner_crd.yaml
+++ b/config/base/300-operator_v1alpha1_pruner_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonpruners.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_result_crd.yaml
+++ b/config/base/300-operator_v1alpha1_result_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonresults.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_scheduler_crd.yaml
+++ b/config/base/300-operator_v1alpha1_scheduler_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonschedulers.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_syncerservice_crd.yaml
+++ b/config/base/300-operator_v1alpha1_syncerservice_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: syncerservices.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/300-operator_v1alpha1_trigger_crd.yaml
+++ b/config/base/300-operator_v1alpha1_trigger_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektontriggers.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/base/config-info.yaml
+++ b/config/base/config-info.yaml
@@ -21,4 +21,4 @@ metadata:
 data:
   # Contains operator version which can be queried by external
   # tools such as CLI.
-  version: v0.79.1
+  version: "devel"

--- a/config/base/config-leader-election.yaml
+++ b/config/base/config-leader-election.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: tekton-operator-controller-config-leader-election
   labels:
-    operator.tekton.dev/release: v0.79.1
+    operator.tekton.dev/release: "devel"
     app.kubernetes.io/instance: default
 data:
   _example: |

--- a/config/base/config-logging.yaml
+++ b/config/base/config-logging.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-logging
   labels:
-    operator.tekton.dev/release: v0.79.1
+    operator.tekton.dev/release: "devel"
 
 data:
   zap-logger-config: |

--- a/config/base/operator.yaml
+++ b/config/base/operator.yaml
@@ -17,6 +17,6 @@ kind: Deployment
 metadata:
   name: tekton-operator
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec: {}

--- a/config/base/tekton-config-defaults.yaml
+++ b/config/base/tekton-config-defaults.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: tekton-config-defaults
   labels:
-    operator.tekton.dev/release: v0.79.1
+    operator.tekton.dev/release: "devel"
 
 data:
   AUTOINSTALL_COMPONENTS: "true"

--- a/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
+++ b/config/kubernetes/base/300-operator_v1alpha1_dashboard_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektondashboards.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/kubernetes/base/operator.yaml
+++ b/config/kubernetes/base/operator.yaml
@@ -57,7 +57,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/operator
         - name: VERSION
-          value: v0.79.1
+          value: "devel"
         - name: CONFIG_OBSERVABILITY_NAME
           value: tekton-config-observability
         - name: CONFIG_LEADERELECTION_NAME
@@ -104,7 +104,7 @@ spec:
           - name: PROFILING_PORT
             value: "9009"
           - name: VERSION
-            value: v0.79.1
+            value: "devel"
           - name: METRICS_DOMAIN
             value: tekton.dev/operator
           - name: CONFIG_LEADERELECTION_NAME

--- a/config/kubernetes/base/operator_service.yaml
+++ b/config/kubernetes/base/operator_service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    version: v0.79.1
+    version: "devel"
     app: tekton-pipelines-controller
   name: tekton-operator
 spec:

--- a/config/kubernetes/base/webhook.yaml
+++ b/config/kubernetes/base/webhook.yaml
@@ -17,8 +17,8 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:

--- a/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
+++ b/config/openshift/base/300-operator_v1alpha1_addon_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tektonaddons.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/openshift/base/300-operator_v1alpha1_openshiftpipelinesascode_crd.yaml
+++ b/config/openshift/base/300-operator_v1alpha1_openshiftpipelinesascode_crd.yaml
@@ -17,8 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: openshiftpipelinesascodes.operator.tekton.dev
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -72,7 +72,7 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/operator
         - name: VERSION
-          value: v0.79.1
+          value: "devel"
         - name: AUTOINSTALL_COMPONENTS
           valueFrom:
             configMapKeyRef:
@@ -137,7 +137,7 @@ spec:
           - name: PROFILING_PORT
             value: "9009"
           - name: VERSION
-            value: v0.79.1
+            value: "devel"
           - name: METRICS_DOMAIN
             value: tekton.dev/operator
           - name: CONFIG_LEADERELECTION_NAME

--- a/config/openshift/base/operator_service.yaml
+++ b/config/openshift/base/operator_service.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    version: v0.79.1
+    version: "devel"
     name: openshift-pipelines-operator
   name: tekton-operator
 spec:

--- a/config/openshift/base/webhook.yaml
+++ b/config/openshift/base/webhook.yaml
@@ -17,8 +17,8 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: v0.79.1
-    operator.tekton.dev/release: v0.79.1
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:

--- a/config/webhooks/webhook-config-leader-election.yaml
+++ b/config/webhooks/webhook-config-leader-election.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: tekton-operator-webhook-config-leader-election
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     app.kubernetes.io/instance: default
 data:
   _example: |

--- a/config/webhooks/webhook-service.yaml
+++ b/config/webhooks/webhook-service.yaml
@@ -17,8 +17,8 @@ kind: Service
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: v0.79.0
-    operator.tekton.dev/release: v0.79.0
+    version: "devel"
+    operator.tekton.dev/release: "devel"
     name: tekton-operator-webhook
     app: tekton-operator
 spec:

--- a/config/webhooks/webhook.yaml
+++ b/config/webhooks/webhook.yaml
@@ -17,6 +17,6 @@ kind: Deployment
 metadata:
   name: tekton-operator-webhook
   labels:
-    version: v0.79.0
-    operator.tekton.dev/release: v0.79.0
+    version: "devel"
+    operator.tekton.dev/release: "devel"
 spec: {}

--- a/operatorhub/Makefile
+++ b/operatorhub/Makefile
@@ -10,7 +10,7 @@ IMAGE_HOST ?= quay.io
 IMAGE_NAMESPACE ?= jkhelil/tektoncd/operator
 IMAGE_REPO ?= $(IMAGE_HOST)/$(IMAGE_NAMESPACE)
 IMAGE_TAG_BASE ?= $(IMAGE_REPO)/operator
-VERSION ?= 0.79.0
+VERSION ?= devel
 
 # Define the bundle image with versioning
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/config-logging_v1_configmap.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/config-logging_v1_configmap.yaml
@@ -69,5 +69,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: config-logging

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_manualapprovalgates.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_manualapprovalgates.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: manualapprovalgates.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_syncerservices.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_syncerservices.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: syncerservices.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonchains.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonchains.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonchains.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonconfigs.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonconfigs.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonconfigs.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektondashboards.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektondashboards.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektondashboards.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonhubs.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonhubs.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonhubs.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektoninstallersets.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektoninstallersets.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektoninstallersets.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpipelines.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpipelines.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonpipelines.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpruners.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpruners.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonpruners.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonresults.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonresults.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonresults.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonschedulers.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektonschedulers.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonschedulers.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektontriggers.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/operator.tekton.dev_tektontriggers.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektontriggers.operator.tekton.dev
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-config-defaults_v1_configmap.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-config-defaults_v1_configmap.yaml
@@ -5,5 +5,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-config-defaults

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-controller-config-leader-election_v1_configmap.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-controller-config-leader-election_v1_configmap.yaml
@@ -33,5 +33,5 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-operator-controller-config-leader-election

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-webhook-config-leader-election_v1_configmap.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-webhook-config-leader-election_v1_configmap.yaml
@@ -33,5 +33,5 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-operator-webhook-config-leader-election

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-webhook_v1_service.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/tekton-operator-webhook_v1_service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tekton-operator-webhook
 spec:

--- a/operatorhub/kubernetes/release-artifacts/bundle/manifests/tektoncd-operator.clusterserviceversion.yaml
+++ b/operatorhub/kubernetes/release-artifacts/bundle/manifests/tektoncd-operator.clusterserviceversion.yaml
@@ -893,7 +893,7 @@ spec:
         serviceAccountName: tekton-operator
       deployments:
       - label:
-          operator.tekton.dev/release: v0.79.0
+          operator.tekton.dev/release: "devel"
           version: v0.79.0
         name: tekton-operator
         spec:
@@ -1007,7 +1007,7 @@ spec:
                     type: RuntimeDefault
               serviceAccountName: tekton-operator
       - label:
-          operator.tekton.dev/release: v0.79.0
+          operator.tekton.dev/release: "devel"
           version: v0.79.0
         name: tekton-operator-webhook
         spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/config-logging_v1_configmap.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/config-logging_v1_configmap.yaml
@@ -69,5 +69,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: config-logging

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1314,7 +1314,7 @@ spec:
         serviceAccountName: openshift-pipelines-operator
       deployments:
       - label:
-          operator.tekton.dev/release: v0.79.0
+          operator.tekton.dev/release: "devel"
           version: v0.79.0
         name: openshift-pipelines-operator
         spec:
@@ -1447,7 +1447,7 @@ spec:
                   type: RuntimeDefault
               serviceAccountName: openshift-pipelines-operator
       - label:
-          operator.tekton.dev/release: v0.79.0
+          operator.tekton.dev/release: "devel"
           version: v0.79.0
         name: tekton-operator-webhook
         spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_manualapprovalgates.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_manualapprovalgates.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: manualapprovalgates.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_multiclusterproxyaaes.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_multiclusterproxyaaes.yaml
@@ -18,7 +18,7 @@ metadata:
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
   labels:
     version: v0.79.0
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
 spec:
   group: operator.tekton.dev
   names:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: openshiftpipelinesascodes.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_syncerservices.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_syncerservices.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: syncerservices.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonaddons.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonaddons.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonaddons.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonchains.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonchains.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonchains.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonconfigs.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonconfigs.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonconfigs.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonhubs.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonhubs.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonhubs.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektoninstallersets.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektoninstallersets.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektoninstallersets.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpipelines.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpipelines.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonpipelines.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpruners.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonpruners.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonpruners.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonresults.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonresults.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonresults.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonschedulers.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektonschedulers.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektonschedulers.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektontriggers.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/operator.tekton.dev_tektontriggers.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tektontriggers.operator.tekton.dev
 spec:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-config-defaults_v1_configmap.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-config-defaults_v1_configmap.yaml
@@ -5,5 +5,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-config-defaults

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-controller-config-leader-election_v1_configmap.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-controller-config-leader-election_v1_configmap.yaml
@@ -33,5 +33,5 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-operator-controller-config-leader-election

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-webhook-config-leader-election_v1_configmap.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-webhook-config-leader-election_v1_configmap.yaml
@@ -33,5 +33,5 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: default
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
   name: tekton-operator-webhook-config-leader-election

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-webhook_v1_service.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/tekton-operator-webhook_v1_service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: tekton-operator
     name: tekton-operator-webhook
-    operator.tekton.dev/release: v0.79.0
+    operator.tekton.dev/release: "devel"
     version: v0.79.0
   name: tekton-operator-webhook
 spec:

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -95,6 +95,27 @@ spec:
       done
       cp ${DOCKER_CONFIG} /workspace/${KUBE_DISTRO}-docker-config.json
 
+  - name: rewrite-devel-in-source
+    image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
+    script: |
+      #!/usr/bin/env sh
+      set -ex
+
+      # Rewrite VERSION env var value in operator.yaml (not in ko/kustomize output, sed on release.yaml won't catch it)
+      # Uses awk for multi-line: match '- name: VERSION', then rewrite the following 'value:' line
+      # (avoids reliance on GNU sed which is not available in this image)
+      awk '/- name: VERSION/{found=1} found && /value:/{sub(/"?devel"?/, "$(params.versionTag)"); found=0} {print}' \
+        ${PROJECT_ROOT}/config/${KUBE_DISTRO}/base/operator.yaml > /tmp/operator.yaml.tmp
+      cp /tmp/operator.yaml.tmp ${PROJECT_ROOT}/config/${KUBE_DISTRO}/base/operator.yaml
+
+      # Rewrite kodata cabundles (openshift only) - these are baked into the container image
+      # and never appear in release.yaml, so must be updated before ko builds the image
+      if [ -d "${PROJECT_ROOT}/cmd/openshift/operator/kodata/cabundles" ]; then
+        sed -i -E \
+          -e 's/(operator.tekton.dev\/release): "?devel"?/\1: $(params.versionTag)/g' \
+          ${PROJECT_ROOT}/cmd/openshift/operator/kodata/cabundles/*.yaml
+      fi
+
   - name: run-kustomize-ko
     image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
     env:
@@ -154,9 +175,9 @@ spec:
           --platform=$(params.platforms) ${KO_EXTRA_ARGS} \
           -f - > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.notags.yaml
 
-      # Rewrite "devel" to params.versionTag
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
+      # Rewrite "devel" (quoted or unquoted) to params.versionTag
+      sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
+      sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
   - name: koparse
     image: ghcr.io/tektoncd/plumbing/koparse@sha256:194c2ab9dce5f778ed757af13c626d6b85f15452e2c2902c79b0d0f5a0adf4d1
     script: |


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

PR to revert the version value from v0.79.1 & v0.79.0 (in some files) to devel. This ensures source code remains with "devel" while  generated manifests are populated with correct values as per automation. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
