### PR TITLE
Security: Fix CVE-2026-40938 - tektoncd/pipeline git resolver argument injection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/tektoncd/pipeline v1.6.1
+	github.com/tektoncd/pipeline v1.6.2
 	github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2
 	github.com/tektoncd/pruner v0.3.5
 	github.com/tektoncd/triggers v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -2638,8 +2638,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhgwZDDc=
 github.com/tchap/go-patricia/v2 v2.3.3/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
-github.com/tektoncd/pipeline v1.6.1 h1:DLeA6gVQrDHw9hy7eI48rOp2MO+Fwawj1+AcgSpJysk=
-github.com/tektoncd/pipeline v1.6.1/go.mod h1:5SNoYgRYPQopkv7ApVq5GO3JqPk2AjV+VMMjwBsbJOg=
+github.com/tektoncd/pipeline v1.6.2 h1:lcpC4fuoc9Uy6uWjjNmtRJgYd+e6XIcFZKYitbVnORc=
+github.com/tektoncd/pipeline v1.6.2/go.mod h1:lnC/pCLLG37eZE3B5QPCumkWZyY0Lb2LZBpQlJCNaio=
 github.com/tektoncd/pipelines-as-code v0.39.5 h1:3hT+X3/nGFdJT1O5XeE66gb4K4HXj+eHkYl/0H7rDJ4=
 github.com/tektoncd/pipelines-as-code v0.39.5/go.mod h1:5KqGAgmiFldqi4KG4Vj/5juzbUbPucASmqKrWwePG9U=
 github.com/tektoncd/plumbing v0.0.0-20250805154627-25448098dea2 h1:v4UPEbe6MEto5i4ELtiXWBxUAUIAWL5U1DznfPhi4WE=

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -197,8 +198,9 @@ func (s *Step) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -434,8 +434,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1400,8 +1400,8 @@ github.com/syndtr/goleveldb/leveldb/util
 # github.com/tchap/go-patricia/v2 v2.3.3
 ## explicit; go 1.16
 github.com/tchap/go-patricia/v2/patricia
-# github.com/tektoncd/pipeline v1.6.1
-## explicit; go 1.24.0
+# github.com/tektoncd/pipeline v1.6.2
+## explicit; go 1.24.13
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/pipeline


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-40938** by upgrading `github.com/tektoncd/pipeline` from v1.6.1 to v1.6.2.

### CVE Details

| Field | Value |
|-------|-------|
| **CVE ID** | CVE-2026-40938 |
| **GHSA** | GHSA-94jr-7pqp-xhcq |
| **Package** | github.com/tektoncd/pipeline |
| **Severity** | HIGH |
| **Impact** | Git resolver unsanitized revision parameter enables argument injection into the git CLI, potentially leading to remote code execution on the resolver pod. The tekton-pipelines-resolvers ServiceAccount holds cluster-wide get/list/watch on all Secrets, so code execution enables full cluster-wide secret exfiltration. |
| **Vulnerable versions** | v1.0.0 – v1.6.1 |
| **Fixed version** | v1.6.2 |
| **Jira Issues** | SRVKP-11752 |

### Additional CVEs Fixed in v1.6.2

This upgrade also resolves the following security issues:

- **GHSA-wjxp-xrpv-xpff / CVE-2026-40161** (HIGH): Git resolver API mode leaks system-configured API token to user-controlled `serverURL`
- **GHSA-rx35-6rhx-7858 / CVE-2026-40923** (Medium): VolumeMount path restriction bypass via missing `filepath.Clean` normalization
- **GHSA-rmx9-2pp3-xhcr / CVE-2026-25542** (Medium): VerificationPolicy regex pattern bypass via unanchored substring matching
- **GHSA-m2cx-gpqf-qf74 / CVE-2026-40924** (Medium): HTTP resolver unbounded response body read enables OOM denial of service

### Changes

```
go.mod:   github.com/tektoncd/pipeline v1.6.1 → v1.6.2
go.sum:   updated checksums
vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go:     filepath.Clean fix (CVE-2026-40923)
vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go:    filepath.Clean fix (CVE-2026-40923)
vendor/modules.txt:  version updated
```

5 files changed, 12 insertions(+), 9 deletions(-)

### Test Results

**Status**: ⚠️ TIMEOUT (no failures)

**Tests discovered**: Yes
**Test command**: `go test ./...`
**Exit code**: 124 (timeout — same behavior as previous automation runs on this repo)
**Duration**: 5m (timeout limit)

| Result | Count |
|--------|-------|
| Packages passed | 8 |
| Packages failed | **0** |
| Packages timed out | remaining (long-running integration tests) |

**Packages passed:**
- `pkg/apis/operator/v1alpha1`
- `pkg/common`
- `pkg/reconciler/common`
- `pkg/reconciler/common/tektoninstallerset`
- `pkg/reconciler/kubernetes/tektonchain`
- `pkg/reconciler/kubernetes/tektonconfig/extension`
- `pkg/reconciler/kubernetes/tektondashboard`
- `pkg/reconciler/kubernetes/tektoninstallerset`

The timeout is expected — this repo has long-running integration tests requiring a live cluster. All unit tests that completed **passed with 0 failures**. Full test coverage will be provided by CI after this PR.

### Breaking Changes

None. This is a patch-level upgrade within the v1.6.x minor line. The only API changes are:
- `filepath.Clean()` applied to VolumeMount paths before the `/tekton/` prefix check (CVE-2026-40923 fix) — this is a security hardening change that rejects previously-invalid paths like `/tekton/../sensitive`

### Verification Steps

- [ ] Confirm `github.com/tektoncd/pipeline` is at v1.6.2 in `go.mod`
- [ ] Run `go mod verify` to confirm checksums
- [ ] Verify CVE is resolved: `govulncheck -show verbose ./...` should not report CVE-2026-40938
- [ ] CI tests pass
- [ ] Review VolumeMount validation change for any edge cases

### Risk Assessment

| Dimension | Assessment |
|-----------|------------|
| **Overall Risk** | Low |
| **Change scope** | Minimal — patch upgrade within same minor version |
| **Breaking changes** | None for valid inputs |
| **Rollback** | Revert go.mod/go.sum/vendor to v1.6.1 |

---

🤖 Generated by CVE Fixer Workflow | Resolves: SRVKP-11752


# Release Notes

```release-note
Security fix: upgrade github.com/tektoncd/pipeline from v1.6.1 to v1.6.2 to address CVE-2026-40938 (HIGH) - git resolver argument injection enabling RCE and secret exfiltration.
```