### PR TITLE
feat(tls): inject centrally managed TLS config into triggers webhook

### DIFF
--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -21,10 +21,17 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+)
+
+const (
+	tektonTriggersWebhookDeployment = "tekton-triggers-webhook"
+	webhookContainerName            = "webhook"
 )
 
 // triggersProperties holds fields for configuring runAsUser and runAsGroup.
@@ -44,30 +51,57 @@ var triggersData = triggersProperties{
 }
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
-	return openshiftExtension{}
+	return &openshiftExtension{
+		tektonConfigLister: tektonConfiginformer.Get(ctx).Lister(),
+	}
 }
 
-type openshiftExtension struct{}
+type openshiftExtension struct {
+	tektonConfigLister occommon.TektonConfigLister
+	resolvedTLSConfig  *occommon.TLSEnvVars
+}
 
-func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{
+func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	trns := []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
 		occommon.ApplyCABundlesToDeployment,
 		common.AddConfigMapValues(tektontrigger.ConfigDefaults, triggersData),
 		replaceDeploymentArgs("-el-events", "enable"),
 	}
+
+	// Inject APIServer TLS profile env vars into the webhook so that it applies
+	// the cluster-wide TLS version and cipher suite policy (PQC readiness).
+	if oe.resolvedTLSConfig != nil {
+		trns = append(trns, occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", tektonTriggersWebhookDeployment, []string{webhookContainerName}))
+	}
+
+	return trns
 }
-func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
-	return nil
-}
-func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
-	return nil
-}
-func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+
+func (oe *openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
+	logger := logging.FromContext(ctx)
+
+	resolvedTLS, err := occommon.ResolveCentralTLSToEnvVars(ctx, oe.tektonConfigLister)
+	if err != nil {
+		return err
+	}
+	oe.resolvedTLSConfig = resolvedTLS
+	if oe.resolvedTLSConfig != nil {
+		logger.Infof("Injecting central TLS config into triggers webhook: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
+	}
+
 	return nil
 }
 
-func (oe openshiftExtension) GetPlatformData() string {
+func (oe *openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}
+
+func (oe *openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+	return nil
+}
+
+func (oe *openshiftExtension) GetPlatformData() string {
 	return ""
 }

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -32,6 +32,8 @@ import (
 const (
 	tektonTriggersWebhookDeployment = "tekton-triggers-webhook"
 	webhookContainerName            = "webhook"
+	tektonTriggersCoreInterceptors  = "tekton-triggers-core-interceptors"
+	coreInterceptorsContainerName   = "tekton-triggers-core-interceptors"
 )
 
 // triggersProperties holds fields for configuring runAsUser and runAsGroup.
@@ -70,10 +72,15 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 		replaceDeploymentArgs("-el-events", "enable"),
 	}
 
-	// Inject APIServer TLS profile env vars into the webhook so that it applies
-	// the cluster-wide TLS version and cipher suite policy (PQC readiness).
+	// Inject APIServer TLS profile env vars into the webhook and core interceptors
+	// so that both apply the cluster-wide TLS version and cipher suite policy (PQC readiness).
 	if oe.resolvedTLSConfig != nil {
-		trns = append(trns, occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", tektonTriggersWebhookDeployment, []string{webhookContainerName}))
+		trns = append(trns,
+			// tekton-triggers-webhook uses the Knative webhook framework which reads WEBHOOK_TLS_* env vars.
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", tektonTriggersWebhookDeployment, []string{webhookContainerName}, occommon.WebhookEnvVarPrefix),
+			// tekton-triggers-core-interceptors uses its own tlsconfig.LoadFromEnv() which reads TLS_* env vars directly (no prefix).
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", tektonTriggersCoreInterceptors, []string{coreInterceptorsContainerName}, ""),
+		)
 	}
 
 	return trns
@@ -88,7 +95,7 @@ func (oe *openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekt
 	}
 	oe.resolvedTLSConfig = resolvedTLS
 	if oe.resolvedTLSConfig != nil {
-		logger.Infof("Injecting central TLS config into triggers webhook: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
+		logger.Infof("Injecting central TLS config into triggers webhook and core interceptors: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
 	}
 
 	return nil

--- a/pkg/reconciler/openshift/tektontrigger/extension_test.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektontrigger
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// makeTriggersWebhookDeployment returns an unstructured triggers webhook Deployment for transformer tests.
+func makeTriggersWebhookDeployment(t *testing.T) unstructured.Unstructured {
+	t.Helper()
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tektonTriggersWebhookDeployment,
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: webhookContainerName},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert deployment to unstructured: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+	return u
+}
+
+func TestTriggersTransformers_NoTLSConfig(t *testing.T) {
+	ext := &openshiftExtension{
+		resolvedTLSConfig: nil,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonTrigger{})
+
+	u := makeTriggersWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != webhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
+			}
+		}
+	}
+}
+
+func TestTriggersTransformers_WithTLSConfig_InjectsEnvVarsIntoWebhook(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{
+		resolvedTLSConfig: tlsConfig,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonTrigger{})
+
+	u := makeTriggersWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	envMap := map[string]string{}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != webhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			envMap[e.Name] = e.Value
+		}
+	}
+
+	if got := envMap[occommon.TLSMinVersionEnvVar]; got != tlsConfig.MinVersion {
+		t.Errorf("%s = %q, want %q", occommon.TLSMinVersionEnvVar, got, tlsConfig.MinVersion)
+	}
+	if got := envMap[occommon.TLSCipherSuitesEnvVar]; got != tlsConfig.CipherSuites {
+		t.Errorf("%s = %q, want %q", occommon.TLSCipherSuitesEnvVar, got, tlsConfig.CipherSuites)
+	}
+}
+
+func TestTriggersTransformers_WithTLSConfig_DoesNotInjectIntoOtherDeployments(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.3",
+		CipherSuites: "TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{
+		resolvedTLSConfig: tlsConfig,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonTrigger{})
+
+	// Use a different deployment name — TLS env vars must NOT be injected.
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tekton-triggers-controller",
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "controller"},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	result := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, result); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	for _, c := range result.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s injected into non-webhook deployment", e.Name)
+			}
+		}
+	}
+}

--- a/pkg/reconciler/openshift/tektontrigger/extension_test.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension_test.go
@@ -29,20 +29,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// makeTriggersWebhookDeployment returns an unstructured triggers webhook Deployment for transformer tests.
-func makeTriggersWebhookDeployment(t *testing.T) unstructured.Unstructured {
+// makeDeployment returns an unstructured Deployment with the given name and container name.
+func makeDeployment(t *testing.T, deploymentName, containerName string) unstructured.Unstructured {
 	t.Helper()
 
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tektonTriggersWebhookDeployment,
+			Name:      deploymentName,
 			Namespace: "openshift-pipelines",
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						{Name: webhookContainerName},
+						{Name: containerName},
 					},
 				},
 			},
@@ -56,6 +56,16 @@ func makeTriggersWebhookDeployment(t *testing.T) unstructured.Unstructured {
 	u.SetKind("Deployment")
 	u.SetAPIVersion("apps/v1")
 	return u
+}
+
+// makeTriggersWebhookDeployment returns an unstructured triggers webhook Deployment for transformer tests.
+func makeTriggersWebhookDeployment(t *testing.T) unstructured.Unstructured {
+	return makeDeployment(t, tektonTriggersWebhookDeployment, webhookContainerName)
+}
+
+// makeCoreInterceptorsDeployment returns an unstructured core interceptors Deployment for transformer tests.
+func makeCoreInterceptorsDeployment(t *testing.T) unstructured.Unstructured {
+	return makeDeployment(t, tektonTriggersCoreInterceptors, coreInterceptorsContainerName)
 }
 
 func TestTriggersTransformers_NoTLSConfig(t *testing.T) {
@@ -85,7 +95,8 @@ func TestTriggersTransformers_NoTLSConfig(t *testing.T) {
 			continue
 		}
 		for _, e := range c.Env {
-			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar {
+			if e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
 				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
 			}
 		}
@@ -129,11 +140,92 @@ func TestTriggersTransformers_WithTLSConfig_InjectsEnvVarsIntoWebhook(t *testing
 		}
 	}
 
+	webhookMinVersion := occommon.WebhookEnvVarPrefix + occommon.TLSMinVersionEnvVar
+	webhookCipherSuites := occommon.WebhookEnvVarPrefix + occommon.TLSCipherSuitesEnvVar
+
+	if got := envMap[webhookMinVersion]; got != tlsConfig.MinVersion {
+		t.Errorf("%s = %q, want %q", webhookMinVersion, got, tlsConfig.MinVersion)
+	}
+	if got := envMap[webhookCipherSuites]; got != tlsConfig.CipherSuites {
+		t.Errorf("%s = %q, want %q", webhookCipherSuites, got, tlsConfig.CipherSuites)
+	}
+}
+
+func TestTriggersTransformers_WithTLSConfig_InjectsEnvVarsIntoCoreInterceptors(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{
+		resolvedTLSConfig: tlsConfig,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonTrigger{})
+
+	u := makeCoreInterceptorsDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	envMap := map[string]string{}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != coreInterceptorsContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			envMap[e.Name] = e.Value
+		}
+	}
+
 	if got := envMap[occommon.TLSMinVersionEnvVar]; got != tlsConfig.MinVersion {
 		t.Errorf("%s = %q, want %q", occommon.TLSMinVersionEnvVar, got, tlsConfig.MinVersion)
 	}
 	if got := envMap[occommon.TLSCipherSuitesEnvVar]; got != tlsConfig.CipherSuites {
 		t.Errorf("%s = %q, want %q", occommon.TLSCipherSuitesEnvVar, got, tlsConfig.CipherSuites)
+	}
+}
+
+func TestTriggersTransformers_NoTLSConfig_DoesNotInjectIntoCoreInterceptors(t *testing.T) {
+	ext := &openshiftExtension{
+		resolvedTLSConfig: nil,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.TektonTrigger{})
+
+	u := makeCoreInterceptorsDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
+			}
+		}
 	}
 }
 
@@ -189,7 +281,9 @@ func TestTriggersTransformers_WithTLSConfig_DoesNotInjectIntoOtherDeployments(t 
 
 	for _, c := range result.Spec.Template.Spec.Containers {
 		for _, e := range c.Env {
-			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
 				t.Errorf("unexpected TLS env var %s injected into non-webhook deployment", e.Name)
 			}
 		}

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -266,6 +266,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 	// Ensure Pipeline Trigger
 	if !tc.Spec.Trigger.Disabled && (tc.Spec.Profile == v1alpha1.ProfileAll || tc.Spec.Profile == v1alpha1.ProfileBasic) {
 		tektontrigger := trigger.GetTektonTriggerCR(tc, r.operatorVersion)
+		if platformData := r.extension.GetPlatformData(); platformData != "" {
+			if tektontrigger.Annotations == nil {
+				tektontrigger.Annotations = map[string]string{}
+			}
+			tektontrigger.Annotations[v1alpha1.PlatformDataHashKey] = platformData
+		}
 		logger.Debug("Ensuring TektonTrigger CR exists")
 		if _, err := trigger.EnsureTektonTriggerExists(ctx, r.operatorClientSet.OperatorV1alpha1().TektonTriggers(), tektontrigger); err != nil {
 			errMsg := fmt.Sprintf("TektonTrigger: %s", err.Error())

--- a/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
+++ b/pkg/reconciler/shared/tektonconfig/trigger/trigger.go
@@ -127,6 +127,16 @@ func UpdateTrigger(ctx context.Context, old *v1alpha1.TektonTrigger, new *v1alph
 		updated = true
 	}
 
+	oldPlatformData := old.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey]
+	newPlatformData := new.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey]
+	if oldPlatformData != newPlatformData {
+		if old.ObjectMeta.Annotations == nil {
+			old.ObjectMeta.Annotations = map[string]string{}
+		}
+		old.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey] = newPlatformData
+		updated = true
+	}
+
 	if updated {
 		_, err := clients.Update(ctx, old, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
JIRA: SRVKP-9615

# Problem
The tekton-triggers-webhook managed its own TLS configuration locally, preventing OpenShift's Post-Quantum Cryptography (PQC) readiness. Changes to the cluster's APIServer TLS profile had no effect on the webhook.

# Solution
Wire the OpenShift APIServer TLS security profile into the triggers webhook deployment via environment variables (WEBHOOK_TLS_MIN_VERSION, WEBHOOK_TLS_CIPHER_SUITES, WEBHOOK_TLS_CURVE_PREFERENCES), and ensure any future profile changes automatically re-reconcile the webhook.

# Changes:

openshift/tektontrigger/extension.go — resolve TLS profile in PreReconcile, inject it via Transformers into the tekton-triggers-webhook Deployment
shared/tektonconfig/tektonconfig.go — stamp operator.tekton.dev/platform-data-hash on the TektonTrigger CR
shared/tektonconfig/trigger/trigger.go — propagate the annotation during CR updates
Feature is opt-in via TektonConfig.spec.platforms.openShift.enableCentralTLSConfig
Evidence
Enabling the feature injects the cluster's TLS profile into the webhook:
```

$ oc patch tektonconfig config --type=merge \
    -p '{"spec":{"platforms":{"openShift":{"enableCentralTLSConfig":true}}}}'
$ oc get deploy tekton-triggers-webhook -n openshift-pipelines \
    -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | grep TLS_
TLS_CIPHER_SUITES=TLS_AES_128_GCM_SHA256,...,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
TLS_MIN_VERSION=1.2
Changing the APIServer TLS profile automatically updates the webhook:

```

# Restrict to 3 ciphers
```
$ oc patch apiserver cluster --type=merge -p '{
  "spec":{"tlsSecurityProfile":{"type":"Custom","custom":{
    "ciphers":["ECDHE-RSA-AES128-GCM-SHA256","ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES256-GCM-SHA384"],
    "minTLSVersion":"VersionTLS12"
  }}}}'
# platform-data-hash updated:  d96e4890 → 89c859ef
$ oc get deploy tekton-triggers-webhook -n openshift-pipelines \
    -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | grep TLS_
TLS_CIPHER_SUITES=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
TLS_MIN_VERSION=1.2
# Restore default → webhook reverts automatically, hash returns to d96e4890
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
The tekton-triggers-webhook and tekton-triggers-core-interceptor  now inherits TLS configuration (minimum version and cipher suites) from the OpenShift cluster's APIServer TLS security profile when enableCentralTLSConfig is set in TektonConfig. Changes to the cluster TLS profile are automatically propagated to the webhook without operator restarts, enabling PQC readiness (SRVKP-9615)
```
