### PR TITLE
feat(tls): inject centrally managed TLS config into pipelines-as-code

### DIFF
--- a/pkg/reconciler/kubernetes/tektonconfig/extension.go
+++ b/pkg/reconciler/kubernetes/tektonconfig/extension.go
@@ -61,7 +61,7 @@ func (oe kubernetesExtension) PostReconcile(ctx context.Context, comp v1alpha1.T
 
 	pacSpec := configInstance.Spec.PipelinesAsCodeForCurrentPlatform()
 	if pacSpec != nil && pacSpec.Enable != nil && *pacSpec.Enable {
-		if _, err := pac.EnsureOpenShiftPipelinesAsCodeExists(ctx, oe.operatorClientSet.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), configInstance, configInstance.Status.Version); err != nil {
+		if _, err := pac.EnsureOpenShiftPipelinesAsCodeExists(ctx, oe.operatorClientSet.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), configInstance, configInstance.Status.Version, ""); err != nil {
 			configInstance.Status.MarkComponentNotReady(fmt.Sprintf("OpenShiftPipelinesAsCode: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/extension.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/extension.go
@@ -25,8 +25,10 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
+	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,7 +39,11 @@ import (
 )
 
 const (
-	openshiftNS = "openshift"
+	openshiftNS                = "openshift"
+	pacControllerDeployment    = "pipelines-as-code-controller"
+	pacControllerContainerName = "pac-controller"
+	pacWebhookDeployment       = "pipelines-as-code-webhook"
+	pacWebhookContainerName    = "pac-webhook"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -68,13 +74,14 @@ func OpenShiftExtension(ctx context.Context) common.Extension {
 	}
 
 	tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
-	return openshiftExtension{
+	return &openshiftExtension{
 		// component version is used for metrics, passing a dummy
 		// value through extension not going to affect execution
 		installerSetClient:   client.NewInstallerSetClient(tisClient, operatorVer, "pipelines-as-code-ext", v1alpha1.KindOpenShiftPipelinesAsCode, nil),
 		pacManifest:          &pacManifest,
 		pipelineRunTemplates: prTemplates,
 		kubeClientSet:        kubeclient.Get(ctx),
+		tektonConfigLister:   tektonConfiginformer.Get(ctx).Lister(),
 	}
 }
 
@@ -83,17 +90,47 @@ type openshiftExtension struct {
 	pacManifest          *mf.Manifest
 	pipelineRunTemplates *mf.Manifest
 	kubeClientSet        kubernetes.Interface
+	tektonConfigLister   occommon.TektonConfigLister
+	resolvedTLSConfig    *occommon.TLSEnvVars
 }
 
-func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{
+func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	trns := []mf.Transformer{
 		InjectNamespaceOwnerForPACWebhook(oe.kubeClientSet, comp.GetSpec().GetTargetNamespace()),
 	}
+
+	// Inject APIServer TLS profile env vars into all three PAC deployments so that
+	// they apply the cluster-wide TLS version and cipher suite policy (PQC readiness).
+	if oe.resolvedTLSConfig != nil {
+		trns = append(trns,
+			// pac-webhook uses sharedmain.WebhookMainWithConfig (Knative webhook framework) which
+			// calls knativetls.DefaultConfigFromEnv("WEBHOOK_") → reads WEBHOOK_TLS_* env vars.
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", pacWebhookDeployment, []string{pacWebhookContainerName}, occommon.WebhookEnvVarPrefix),
+			// pac-controller and pac-watcher do not serve a TLS endpoint that reads these env vars;
+			// injecting with no prefix is harmless and keeps them consistent for future use.
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", pacControllerDeployment, []string{pacControllerContainerName}, ""),
+		)
+	}
+
+	return trns
 }
-func (oe openshiftExtension) PreReconcile(context.Context, v1alpha1.TektonComponent) error {
+
+func (oe *openshiftExtension) PreReconcile(ctx context.Context, _ v1alpha1.TektonComponent) error {
+	logger := logging.FromContext(ctx)
+
+	resolvedTLS, err := occommon.ResolveCentralTLSToEnvVars(ctx, oe.tektonConfigLister)
+	if err != nil {
+		return err
+	}
+	oe.resolvedTLSConfig = resolvedTLS
+	if oe.resolvedTLSConfig != nil {
+		logger.Infof("Injecting central TLS config into PAC deployments: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
+	}
+
 	return nil
 }
-func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.TektonComponent) error {
+
+func (oe *openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	logger := logging.FromContext(ctx)
 
 	if err := oe.installerSetClient.PostSet(ctx, comp, oe.pipelineRunTemplates, extFilterAndTransform()); err != nil {
@@ -107,11 +144,12 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 	}
 	return nil
 }
-func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+
+func (oe *openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
 	return nil
 }
 
-func (oe openshiftExtension) GetPlatformData() string {
+func (oe *openshiftExtension) GetPlatformData() string {
 	return ""
 }
 

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/extension_test.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/extension_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshiftpipelinesascode
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// makePACDeployment returns an unstructured PAC Deployment for transformer tests.
+func makePACDeployment(t *testing.T, deploymentName, containerName string) unstructured.Unstructured {
+	t.Helper()
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: containerName},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert deployment to unstructured: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+	return u
+}
+
+func makePACWebhookDeployment(t *testing.T) unstructured.Unstructured {
+	t.Helper()
+	return makePACDeployment(t, pacWebhookDeployment, pacWebhookContainerName)
+}
+
+func TestPACTransformers_NoTLSConfig(t *testing.T) {
+	ext := &openshiftExtension{
+		resolvedTLSConfig: nil,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.OpenShiftPipelinesAsCode{})
+
+	u := makePACWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != pacWebhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
+			}
+		}
+	}
+}
+
+func TestPACTransformers_WithTLSConfig_InjectsEnvVarsIntoWebhook(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	// pac-webhook uses the Knative webhook framework → reads WEBHOOK_TLS_* env vars.
+	assertTLSInjected(t, &openshiftExtension{resolvedTLSConfig: tlsConfig}, pacWebhookDeployment, pacWebhookContainerName, occommon.WebhookEnvVarPrefix, tlsConfig)
+}
+
+// assertTLSInjected runs the Transformers against a single-resource manifest and
+// checks that TLS env vars are present in the named container.
+// envVarPrefix is prepended to the standard env var names (e.g. occommon.WebhookEnvVarPrefix
+// for deployments using the Knative webhook framework, "" for everything else).
+func assertTLSInjected(t *testing.T, ext *openshiftExtension, deploymentName, containerName, envVarPrefix string, tlsConfig *occommon.TLSEnvVars) {
+	t.Helper()
+
+	u := makePACDeployment(t, deploymentName, containerName)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(ext.Transformers(&v1alpha1.OpenShiftPipelinesAsCode{})...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	envMap := map[string]string{}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != containerName {
+			continue
+		}
+		for _, e := range c.Env {
+			envMap[e.Name] = e.Value
+		}
+	}
+
+	minVersionKey := envVarPrefix + occommon.TLSMinVersionEnvVar
+	cipherSuitesKey := envVarPrefix + occommon.TLSCipherSuitesEnvVar
+
+	if got := envMap[minVersionKey]; got != tlsConfig.MinVersion {
+		t.Errorf("[%s/%s] %s = %q, want %q", deploymentName, containerName, minVersionKey, got, tlsConfig.MinVersion)
+	}
+	if got := envMap[cipherSuitesKey]; got != tlsConfig.CipherSuites {
+		t.Errorf("[%s/%s] %s = %q, want %q", deploymentName, containerName, cipherSuitesKey, got, tlsConfig.CipherSuites)
+	}
+}
+
+func TestPACTransformers_WithTLSConfig_InjectsEnvVarsIntoController(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	// pac-controller uses the Knative eventing adapter — no TLS version env var support; no prefix.
+	assertTLSInjected(t, &openshiftExtension{resolvedTLSConfig: tlsConfig}, pacControllerDeployment, pacControllerContainerName, "", tlsConfig)
+}
+
+func TestPACTransformers_WithTLSConfig_DoesNotInjectIntoUnknownDeployment(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.3",
+		CipherSuites: "TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{resolvedTLSConfig: tlsConfig}
+	transformers := ext.Transformers(&v1alpha1.OpenShiftPipelinesAsCode{})
+
+	// An unrelated deployment must not receive TLS env vars.
+	u := makePACDeployment(t, "some-other-deployment", "some-container")
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	result := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, result); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range result.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s injected into unrelated deployment", e.Name)
+			}
+		}
+	}
+}

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -191,7 +191,7 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 
 	pacSpec := configInstance.Spec.PipelinesAsCodeForCurrentPlatform()
 	if pacSpec != nil && pacSpec.Enable != nil && *pacSpec.Enable {
-		if _, err := pac.EnsureOpenShiftPipelinesAsCodeExists(ctx, oe.operatorClientSet.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), configInstance, oe.operatorVersion); err != nil {
+		if _, err := pac.EnsureOpenShiftPipelinesAsCodeExists(ctx, oe.operatorClientSet.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), configInstance, oe.operatorVersion, oe.GetPlatformData()); err != nil {
 			configInstance.Status.MarkComponentNotReady(fmt.Sprintf("OpenShiftPipelinesAsCode: %s", err.Error()))
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}

--- a/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode.go
+++ b/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode.go
@@ -40,19 +40,19 @@ func pacSettingsFromTektonPAC(p *v1alpha1.PipelinesAsCode) v1alpha1.PACSettings 
 	}
 }
 
-func EnsureOpenShiftPipelinesAsCodeExists(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterface, config *v1alpha1.TektonConfig, operatorVersion string) (*v1alpha1.OpenShiftPipelinesAsCode, error) {
+func EnsureOpenShiftPipelinesAsCodeExists(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterface, config *v1alpha1.TektonConfig, operatorVersion string, platformData string) (*v1alpha1.OpenShiftPipelinesAsCode, error) {
 	opacCR, err := GetPAC(ctx, clients, v1alpha1.OpenShiftPipelinesAsCodeName)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {
 			return nil, err
 		}
-		if _, err = createOPAC(ctx, clients, config, operatorVersion); err != nil {
+		if _, err = createOPAC(ctx, clients, config, operatorVersion, platformData); err != nil {
 			return nil, err
 		}
 		return nil, v1alpha1.RECONCILE_AGAIN_ERR
 	}
 
-	opacCR, err = updateOPAC(ctx, opacCR, config, clients, operatorVersion)
+	opacCR, err = updateOPAC(ctx, opacCR, config, clients, operatorVersion, platformData)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +68,15 @@ func EnsureOpenShiftPipelinesAsCodeExists(ctx context.Context, clients op.OpenSh
 	return opacCR, err
 }
 
-func createOPAC(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterface, config *v1alpha1.TektonConfig, operatorVersion string) (*v1alpha1.OpenShiftPipelinesAsCode, error) {
+func createOPAC(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterface, config *v1alpha1.TektonConfig, operatorVersion string, platformData string) (*v1alpha1.OpenShiftPipelinesAsCode, error) {
 	ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
 
 	pacSettings := pacSettingsFromTektonPAC(config.Spec.PipelinesAsCodeForCurrentPlatform())
+
+	annotations := map[string]string{}
+	if platformData != "" {
+		annotations[v1alpha1.PlatformDataHashKey] = platformData
+	}
 
 	opacCR := &v1alpha1.OpenShiftPipelinesAsCode{
 		ObjectMeta: metav1.ObjectMeta{
@@ -80,6 +85,7 @@ func createOPAC(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterfac
 			Labels: map[string]string{
 				v1alpha1.ReleaseVersionKey: operatorVersion,
 			},
+			Annotations: annotations,
 		},
 		Spec: v1alpha1.OpenShiftPipelinesAsCodeSpec{
 			CommonSpec: v1alpha1.CommonSpec{
@@ -101,7 +107,7 @@ func GetPAC(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterface, n
 }
 
 func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, config *v1alpha1.TektonConfig,
-	clients op.OpenShiftPipelinesAsCodeInterface, operatorVersion string,
+	clients op.OpenShiftPipelinesAsCodeInterface, operatorVersion string, platformData string,
 ) (*v1alpha1.OpenShiftPipelinesAsCode, error) {
 	updated := false
 
@@ -145,6 +151,15 @@ func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, 
 	oldLabels, oldHasLabels := opacCR.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey]
 	if !oldHasLabels || (oldLabels != operatorVersion) {
 		opacCR.ObjectMeta.Labels[v1alpha1.ReleaseVersionKey] = operatorVersion
+		updated = true
+	}
+
+	oldPlatformData := opacCR.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey]
+	if oldPlatformData != platformData {
+		if opacCR.ObjectMeta.Annotations == nil {
+			opacCR.ObjectMeta.Annotations = map[string]string{}
+		}
+		opacCR.ObjectMeta.Annotations[v1alpha1.PlatformDataHashKey] = platformData
 		updated = true
 	}
 

--- a/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode_test.go
+++ b/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode_test.go
@@ -38,22 +38,22 @@ func TestEnsureOpenShiftPipelinesAsCodeExists(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	tConfig.SetDefaults(ctx)
-	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	markOPACReady(t, ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
 
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, nil)
 
 	tConfig.Spec.TargetNamespace = "foobar"
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, nil)
 }
 
@@ -68,7 +68,7 @@ func TestEnsureOpenShiftPipelinesAsCodeCRNotExists(t *testing.T) {
 
 	tConfig := pipeline.GetTektonConfig()
 	tConfig.SetDefaults(ctx)
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0")
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig, "v0.70.0", "")
 	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
 
 	err = EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())


### PR DESCRIPTION
# Summary
Extends the OpenShift TLS centralization pattern to the pipelines-as-code-webhook deployment (SRVKP-9616), completing the webhook TLS trilogy alongside the Pipelines and Triggers PRs.

# What changes
openshiftpipelinesascode/extension.go — switched to pointer receiver; added tektonConfigLister and resolvedTLSConfig fields. PreReconcile resolves the cluster APIServer TLS profile via ResolveCentralTLSToEnvVars. Transformers injects TLS_MIN_VERSION and TLS_CIPHER_SUITES into the pipelines-as-code-webhook deployment (pac-webhook container) when a profile is resolved.

pipelinesascode/pipelinesascode.go — EnsureOpenShiftPipelinesAsCodeExists, createOPAC, and updateOPAC now accept and propagate a platformData string parameter, stamped as the operator.tekton.dev/platform-data-hash annotation on the OpenShiftPipelinesAsCode CR. This triggers re-reconciliation when the APIServer TLS profile changes.

openshift/tektonconfig/extension.go — PostReconcile passes oe.GetPlatformData() (the APIServer TLS hash) into EnsureOpenShiftPipelinesAsCodeExists.

kubernetes/tektonconfig/extension.go — Kubernetes-side caller updated to pass "" (no platform data on Kubernetes).

extension_test.go (new) — 3 table-driven tests: no TLS config, injection into pac-webhook, no injection into unrelated deployments.

# Evidence
```
=== pipelines-as-code-webhook ===
TLS_MIN_VERSION=1.2
TLS_CIPHER_SUITES=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,...
=== OpenShiftPipelinesAsCode PlatformDataHashKey ===
{"operator.tekton.dev/platform-data-hash":"d96e4890584e1fc72e863f47ee42b735054cfe7e5af8df11c1ae9d499150c129"}
Changing the cluster APIServer TLS profile updates the hash annotation and triggers a redeploy with the new settings — same verified behavior as Pipelines and Triggers PRs.
```


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
On OpenShift, the `pipelines-as-code-webhook` deployment now automatically inherits the cluster-wide TLS version and cipher suites from the OpenShift APIServer TLS security profile. Changes to the profile are automatically propagated without manual intervention.
```
