### PR TITLE
fix: missing subjects in attestation and capture UUID instead of index

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -41,7 +41,10 @@ spec:
     description: Prefix to be added to release files
     default: ""
   results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
   - name: IMAGES
+    description: Images built and published by this task, used by Tekton Chains to generate signed attestations.
   workspaces:
   - name: source
     description: >-
@@ -229,6 +232,8 @@ spec:
         IMAGE_WITHOUT_SHA=${IMAGE%%@*}
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
 
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -423,7 +423,7 @@ spec:
       - name: namespace
       results:
       - name: rekor-uuid
-        description: Rekor UUID from Chains transparency log
+        description: Rekor UUID (64-char hex) derived from the Chains transparency log URL
       - name: signed
         description: Whether Chains signing succeeded (true, failed, or timeout)
       steps:
@@ -476,8 +476,12 @@ spec:
                 -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
 
               if [ -n "${TRANSPARENCY}" ]; then
-                REKOR_UUID=$(echo "${TRANSPARENCY}" | grep -oE 'logIndex=[0-9]+' | cut -d= -f2)
-                if [ -z "${REKOR_UUID}" ]; then
+                echo "Transparency URL: ${TRANSPARENCY}"
+                # Derive the true Rekor UUID from the transparency log URL.
+                # The API response is a map keyed by the 64-char hex UUID, so keys[0] extracts it.
+                REKOR_UUID=$(curl -s "${TRANSPARENCY}" | jq -r 'keys[0]')
+                if [ -z "${REKOR_UUID}" ] || [ "${REKOR_UUID}" = "null" ]; then
+                  echo "WARNING: Could not extract UUID from transparency URL, falling back to URL"
                   REKOR_UUID="${TRANSPARENCY}"
                 fi
                 echo "Rekor UUID: ${REKOR_UUID}"


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Minor fixes to handle missing subject in attestations (Ex: https://search.sigstore.dev/?logIndex=1439829829 does not include subject of images that were generated during release pipeline run) and also a minor fix to replace the correct UUID instead of logindex.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
