### PR TITLE
[cherry-pick to release-v0.79.x] fix: missing subjects in attestation and capture UUID instead of rekor index

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -41,7 +41,10 @@ spec:
     description: Prefix to be added to release files
     default: ""
   results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
   - name: IMAGES
+    description: Images built and published by this task, used by Tekton Chains to generate signed attestations.
   workspaces:
   - name: source
     description: >-
@@ -229,6 +232,8 @@ spec:
         IMAGE_WITHOUT_SHA=${IMAGE%%@*}
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
 
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -44,6 +44,12 @@ spec:
   - name: runTests
     description: If set to something other than "true", skip the build and test tasks
     default: "true"
+  - name: previousReleaseTag
+    description: Previous release tag for changelog generation (e.g. v0.78.0). If empty, auto-detected from git tags.
+    default: ""
+  - name: releaseName
+    description: Release name (e.g. "Swallow Sparrow"). If empty, uses version tag.
+    default: ""
   - name: kubeDistros
     description: The kubernetes platform (e.g. kubernetes or openshift ... ) targeted by a pipeline run
     default: "kubernetes openshift"
@@ -57,6 +63,13 @@ spec:
     description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
   - name: release-images-secret
     description: The secret that contains a service account authorized to push to the imageRegistry
+  - name: github-secret
+    description: |
+      The secret containing GITHUB_TOKEN for creating draft releases.
+      When not bound, the draft-release tasks (wait-for-chains, prepare-draft-release,
+      create-draft-release) are skipped and the draft must be created manually
+      following the cheat sheet instructions.
+    optional: true
   results:
   - name: commit-sha
     description: the sha of the commit that was released
@@ -389,3 +402,220 @@ spec:
           echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)
           echo "${BASE_URL}/openshift-release.yaml" > $(results.openshift-release.path)
           echo "${BASE_URL}/openshift-release.notags.yaml" > $(results.openshift-release-no-tag.path)
+
+  - name: wait-for-chains
+    runAfter:
+    - publish-images-platform-kubernetes
+    - publish-images-platform-openshift
+    timeout: "30m"
+    when:
+    - input: "$(workspaces.github-secret.bound)"
+      operator: in
+      values: ["true"]
+    params:
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: namespace
+      value: $(context.pipelineRun.namespace)
+    taskSpec:
+      params:
+      - name: pipelineRunName
+      - name: namespace
+      results:
+      - name: rekor-uuid
+        description: Rekor UUID (64-char hex) derived from the Chains transparency log URL
+      - name: signed
+        description: Whether Chains signing succeeded (true, failed, or timeout)
+      steps:
+      - name: wait-and-extract
+        image: docker.io/alpine/k8s:1.32.2
+        script: |
+          #!/bin/sh
+          set -e
+
+          NAMESPACE="$(params.namespace)"
+          PIPELINERUN="$(params.pipelineRunName)"
+
+          # Find the TaskRun for publish-images-platform-kubernetes
+          echo "Looking for publish-images TaskRuns in PipelineRun ${PIPELINERUN}..."
+          TASKRUN_NAME=""
+          MAX_FIND_ATTEMPTS=10
+          FIND_ATTEMPT=0
+          while [ -z "${TASKRUN_NAME}" ] && [ $FIND_ATTEMPT -lt $MAX_FIND_ATTEMPTS ]; do
+            TASKRUN_NAME=$(kubectl get taskrun -n "${NAMESPACE}" \
+              -l tekton.dev/pipelineRun="${PIPELINERUN}",tekton.dev/pipelineTask=publish-images-platform-kubernetes \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+            if [ -z "${TASKRUN_NAME}" ]; then
+              FIND_ATTEMPT=$((FIND_ATTEMPT + 1))
+              echo "  Attempt ${FIND_ATTEMPT}/${MAX_FIND_ATTEMPTS} - TaskRun not found yet..."
+              sleep 10
+            fi
+          done
+
+          if [ -z "${TASKRUN_NAME}" ]; then
+            echo "ERROR: Could not find publish-images-platform-kubernetes TaskRun"
+            printf 'unknown' > "$(results.rekor-uuid.path)"
+            printf 'error' > "$(results.signed.path)"
+            exit 0
+          fi
+
+          echo "Found TaskRun: ${TASKRUN_NAME}"
+          echo "Waiting for Chains to sign TaskRun ${TASKRUN_NAME}..."
+
+          MAX_ATTEMPTS=60  # 30 minutes with 30s interval
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            SIGNED=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+              -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/signed}' 2>/dev/null || echo "")
+
+            if [ "${SIGNED}" = "true" ] || [ "${SIGNED}" = "failed" ]; then
+              echo "Chains signing status: ${SIGNED}"
+              printf '%s' "${SIGNED}" > "$(results.signed.path)"
+
+              TRANSPARENCY=$(kubectl get taskrun "${TASKRUN_NAME}" -n "${NAMESPACE}" \
+                -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' 2>/dev/null || echo "")
+
+              if [ -n "${TRANSPARENCY}" ]; then
+                echo "Transparency URL: ${TRANSPARENCY}"
+                # Derive the true Rekor UUID from the transparency log URL.
+                # The API response is a map keyed by the 64-char hex UUID, so keys[0] extracts it.
+                REKOR_UUID=$(curl -s "${TRANSPARENCY}" | jq -r 'keys[0]')
+                if [ -z "${REKOR_UUID}" ] || [ "${REKOR_UUID}" = "null" ]; then
+                  echo "WARNING: Could not extract UUID from transparency URL, falling back to URL"
+                  REKOR_UUID="${TRANSPARENCY}"
+                fi
+                echo "Rekor UUID: ${REKOR_UUID}"
+                printf '%s' "${REKOR_UUID}" > "$(results.rekor-uuid.path)"
+              else
+                echo "WARNING: No transparency URL found"
+                printf 'unknown' > "$(results.rekor-uuid.path)"
+              fi
+              exit 0
+            fi
+
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "  Attempt ${ATTEMPT}/${MAX_ATTEMPTS} - signing status: '${SIGNED}'"
+            sleep 30
+          done
+
+          echo "WARNING: Timed out waiting for Chains to sign"
+          printf 'timeout' > "$(results.signed.path)"
+          printf 'unknown' > "$(results.rekor-uuid.path)"
+          exit 0
+
+  - name: prepare-draft-release
+    runAfter:
+    - publish-to-bucket
+    when:
+    - input: "$(workspaces.github-secret.bound)"
+      operator: in
+      values: ["true"]
+    params:
+    - name: package
+      value: $(params.package)
+    - name: versionTag
+      value: $(params.versionTag)
+    - name: previousReleaseTag
+      value: $(params.previousReleaseTag)
+    - name: releaseName
+      value: $(params.releaseName)
+    workspaces:
+    - name: workarea
+      workspace: workarea
+    taskSpec:
+      params:
+      - name: package
+      - name: versionTag
+      - name: previousReleaseTag
+      - name: releaseName
+      results:
+      - name: package
+        description: The package in org/repo format (without github.com/ prefix)
+      - name: previous-tag
+        description: The previous release tag
+      - name: release-name
+        description: The release name to use
+      workspaces:
+      - name: workarea
+      steps:
+      - name: setup
+        image: docker.io/library/alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+        script: |
+          #!/bin/sh
+          set -e
+          apk add --no-cache git > /dev/null 2>&1
+
+          WORKAREA="$(workspaces.workarea.path)"
+          VERSION="$(params.versionTag)"
+          PREVIOUS="$(params.previousReleaseTag)"
+          NAME="$(params.releaseName)"
+
+          # Strip github.com/ prefix from package for the draft release task
+          PACKAGE=$(echo "$(params.package)" | sed 's|^github\.com/||')
+          printf '%s' "${PACKAGE}" > "$(results.package.path)"
+          echo "Package: ${PACKAGE}"
+
+          # Detect previous tag if not provided
+          if [ -z "${PREVIOUS}" ]; then
+            git config --global --add safe.directory "${WORKAREA}/git"
+            git -C "${WORKAREA}/git" fetch --tags
+            PREVIOUS=$(git -C "${WORKAREA}/git" tag --sort=-v:refname | grep '^v[0-9]' | while read tag; do
+              if [ "$(printf '%s\n%s' "$tag" "$VERSION" | sort -V | head -1)" = "$tag" ] && [ "$tag" != "$VERSION" ]; then
+                echo "$tag"
+                break
+              fi
+            done)
+            if [ -z "${PREVIOUS}" ]; then
+              echo "WARNING: Could not auto-detect previous tag"
+              PREVIOUS="unknown"
+            fi
+            echo "Auto-detected previous tag: ${PREVIOUS}"
+          fi
+          printf '%s' "${PREVIOUS}" > "$(results.previous-tag.path)"
+
+          # Use provided name or fall back to version
+          if [ -z "${NAME}" ]; then
+            NAME="Release ${VERSION}"
+          fi
+          printf '%s' "${NAME}" > "$(results.release-name.path)"
+
+  - name: create-draft-release
+    runAfter:
+    - prepare-draft-release
+    - wait-for-chains
+    when:
+    - input: "$(workspaces.github-secret.bound)"
+      operator: in
+      values: ["true"]
+    - input: "$(tasks.wait-for-chains.results.signed)"
+      operator: in
+      values: ["true"]
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/tektoncd/plumbing
+      - name: revision
+        value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+      - name: pathInRepo
+        value: tekton/resources/release/base/github_release_oci.yaml
+    params:
+    - name: package
+      value: $(tasks.prepare-draft-release.results.package)
+    - name: git-revision
+      value: $(params.gitRevision)
+    - name: release-name
+      value: $(tasks.prepare-draft-release.results.release-name)
+    - name: release-tag
+      value: $(params.versionTag)
+    - name: previous-release-tag
+      value: $(tasks.prepare-draft-release.results.previous-tag)
+    - name: rekor-uuid
+      value: $(tasks.wait-for-chains.results.rekor-uuid)
+    - name: source-subpath
+      value: git
+    - name: release-subpath
+      value: bucket/$(params.versionTag)
+    workspaces:
+    - name: shared
+      workspace: workarea


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

cherry-pick #3402 along with conflict resolution

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
