### PR TITLE
Security: Fix Go stdlib CVEs - update go 1.25.0 → 1.25.10 (release-v0.78.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/operator
 
-go 1.25.0
+go 1.25.10
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Updates Go from go 1.25.0 to go 1.25.10 to fix 10 stdlib CVEs (GO-2026-4986, GO-2026-4982, GO-2026-4980, GO-2026-4977, GO-2026-4971, GO-2026-4947, GO-2026-4946, GO-2026-4918, GO-2026-4870, GO-2026-4865). See main branch PR tektoncd/operator#3409 for full details.

Risk: Low — patch version bump only, no API changes.

Resolves: SRVKP-11355, SRVKP-11344, SRVKP-11343

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>