### PR TITLE
fix: harden patch-release workflow against script injection

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -20,6 +20,8 @@ name: Patch Release
     # Weekly on Thursday at 10:00 UTC
     - cron: "0 10 * * 4"
 
+permissions: {}
+
 env:
   PAC_CONTROLLER_URL: "https://pac.infra.tekton.dev"
   PAC_REPOSITORY_NAME: "tektoncd-operator"
@@ -38,6 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Scan release branches for new commits
         id: scan
@@ -126,21 +129,24 @@ jobs:
       - name: Trigger PAC incoming webhook
         env:
           PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+          RELEASE_BRANCH: ${{ matrix.release.branch }}
+          RELEASE_VERSION: ${{ matrix.release.version }}
+          RELEASE_AS_LATEST: ${{ matrix.release.release_as_latest }}
         run: |
-          echo "::notice::Triggering release ${{ matrix.release.version }} on ${{ matrix.release.branch }} (latest=${{ matrix.release.release_as_latest }})"
+          echo "::notice::Triggering release ${RELEASE_VERSION} on ${RELEASE_BRANCH} (latest=${RELEASE_AS_LATEST})"
           curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
             -H "Content-Type: application/json" \
             -d '{
               "repository": "'"${PAC_REPOSITORY_NAME}"'",
-              "branch": "${{ matrix.release.branch }}",
+              "branch": "'"${RELEASE_BRANCH}"'",
               "pipelinerun": "release-patch",
               "secret": "'"${PAC_INCOMING_SECRET}"'",
               "params": {
-                "version": "${{ matrix.release.version }}",
-                "release_as_latest": "${{ matrix.release.release_as_latest }}"
+                "version": "'"${RELEASE_VERSION}"'",
+                "release_as_latest": "'"${RELEASE_AS_LATEST}"'"
               }
             }'
-          echo "Release triggered successfully"
+          echo "✅ Release triggered successfully"
 
   trigger-manual-release:
     name: "Trigger ${{ inputs.version }} (${{ inputs.branch }})"
@@ -148,33 +154,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate inputs
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           # Validate branch format
-          if [[ ! "${{ inputs.branch }}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
-            echo "::error::Invalid branch format: ${{ inputs.branch }}. Expected: release-vX.Y.x"
+          if [[ ! "${INPUT_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Invalid branch format: ${INPUT_BRANCH}. Expected: release-vX.Y.x"
             exit 1
           fi
           # Validate version format
-          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: ${{ inputs.version }}. Expected: vX.Y.Z"
+          if [[ ! "${INPUT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${INPUT_VERSION}. Expected: vX.Y.Z"
             exit 1
           fi
 
       - name: Trigger PAC incoming webhook
         env:
           PAC_INCOMING_SECRET: ${{ secrets.PAC_INCOMING_SECRET }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_AS_LATEST: ${{ inputs.release_as_latest }}
         run: |
-          echo "::notice::Triggering release ${{ inputs.version }} on ${{ inputs.branch }} (latest=${{ inputs.release_as_latest }})"
+          echo "::notice::Triggering release ${INPUT_VERSION} on ${INPUT_BRANCH} (latest=${INPUT_RELEASE_AS_LATEST})"
           curl -sf -X POST "${PAC_CONTROLLER_URL}/incoming" \
             -H "Content-Type: application/json" \
             -d '{
               "repository": "'"${PAC_REPOSITORY_NAME}"'",
-              "branch": "${{ inputs.branch }}",
+              "branch": "'"${INPUT_BRANCH}"'",
               "pipelinerun": "release-patch",
               "secret": "'"${PAC_INCOMING_SECRET}"'",
               "params": {
-                "version": "${{ inputs.version }}",
-                "release_as_latest": "${{ inputs.release_as_latest }}"
+                "version": "'"${INPUT_VERSION}"'",
+                "release_as_latest": "'"${INPUT_RELEASE_AS_LATEST}"'"
               }
             }'
-          echo "Release triggered successfully"
+          echo "✅ Release triggered successfully"


### PR DESCRIPTION
# Changes

Harden the `patch-release.yaml` GitHub Actions workflow against script injection attacks, aligning with the same fixes applied in [tektoncd/pipeline#9671](https://github.com/tektoncd/pipeline/pull/9671).

### Fixes

1. **`permissions: {}`** — restrict workflow to least-privilege (no default token permissions)
2. **`persist-credentials: false`** — prevent checkout action from persisting git credentials
3. **Environment variable indirection** — replace direct `${{ inputs.* }}` and `${{ matrix.release.* }}` interpolation in `run:` blocks with environment variables (`${INPUT_BRANCH}`, `${RELEASE_VERSION}`, etc.) to prevent script injection

### Why

Using `${{ }}` expressions directly in `run:` blocks is a known [script injection vector](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections). While the current inputs are validated or come from trusted sources, using env vars is a defense-in-depth best practice.

/kind cleanup

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```