### PR TITLE
fix: update-tektoncd-task-versions workflow to resolve CI failures

### DIFF
--- a/.github/workflows/update-tektoncd-task-versions.yml
+++ b/.github/workflows/update-tektoncd-task-versions.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 0 * * *"  # Runs daily at midnight
   workflow_dispatch: {}  # Allows manual trigger
 
+permissions: {}
+
 jobs:
   update-task-versions:
     runs-on: ubuntu-latest
@@ -16,7 +18,6 @@ jobs:
       - name: Checkout Operator Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Clone TektonCD Catalog (p branch)
@@ -24,37 +25,16 @@ jobs:
           git clone --branch p https://github.com/openshift-pipelines/tektoncd-catalog.git ../tektoncd-catalog
 
       - name: Update Task Versions
-        id: update
-        run: |
-          ./hack/openshift/update-openshift-tekton-task-versions.sh \
-            --catalog-path ../tektoncd-catalog \
-            --script-path hack/openshift/fetch-tektoncd-catalog-tasks.sh
-          echo "has_changes=$(git diff --name-only | grep -q fetch-tektoncd-catalog-tasks.sh && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-
-      - name: Set up Git config
-        if: steps.update.outputs.has_changes == 'true'
-        run: |
-          git config user.name "tekton-robot"
-          git config user.email "dlorenc+tekton@google.com"
-
-      - name: Commit Changes
-        if: steps.update.outputs.has_changes == 'true'
-        run: |
-          git add hack/openshift/fetch-tektoncd-catalog-tasks.sh
-          if ! git diff --cached --quiet; then
-            git commit -m "Update Tekton task versions"
-          else
-            echo "No changes to commit. Skipping."
-          fi
+        run: ./hack/openshift/update-openshift-tekton-task-versions.sh
 
       - name: Create Pull Request
-        if: steps.update.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CHATOPS_TOKEN }}
           commit-message: "Update Tekton task versions"
-          committer: Shubham Bhardwaj <shubbhar@redhat.com>
+          committer: tekton-bot <tekton-bot@users.noreply.github.com>
           author: Shubham Bhardwaj <shubbhar@redhat.com>
+          signoff: true
           title: "Update Tekton task versions"
           body: |
             This PR automatically updates the task versions in the `fetch-tektoncd-catalog-tasks.sh` script.
@@ -62,5 +42,7 @@ jobs:
             The versions are pulled from the latest available versions in the [tektoncd-catalog](https://github.com/openshift-pipelines/tektoncd-catalog) repository.
           branch: update-tekton-versions
           base: main
-          labels: automation
+          labels: |
+            automation
+            release-note-none
           delete-branch: true

--- a/hack/openshift/update-openshift-tekton-task-versions.sh
+++ b/hack/openshift/update-openshift-tekton-task-versions.sh
@@ -6,12 +6,9 @@ FETCH_SCRIPT="hack/openshift/fetch-tektoncd-catalog-tasks.sh"
 
 # Check if the tektoncd-catalog repo exists
 if [[ ! -d "$TEKTON_CATALOG_DIR" ]]; then
-  echo "Error: tektoncd-catalog repo is missing! Clone it first."
+  echo "Error: tektoncd-catalog repo is missing! Clone it first." >&2
   exit 1
 fi
-
-# Backup the original fetch script before modifying
-cp "$FETCH_SCRIPT" "$FETCH_SCRIPT.bak"
 
 # Track if any updates were made
 updated=false


### PR DESCRIPTION
# Changes

Fixes the automated `update-tektoncd-task-versions` workflow and the first PR it ever created (#3422).

 - **EasyCLA failure**: Removed manual `git commit` as `tekton-robot` (no CLA).

  - **`.bak` commit**: Removed unnecessary `cp .bak` line that leaked as a second commit.

  - **No CI checks**: Switched `GITHUB_TOKEN` to `CHATOPS_TOKEN` so PRs trigger CI workflows.

  - **Missing release-note label**: Added `release-note-none` to prevent Prow merge blocker.

Relates to: #3422, #2657


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
/kind cleanup