### PR TITLE
[release-v0.79.x] fix(tekton-results): use passthrough TLS termination for route

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
@@ -58,5 +58,5 @@ spec:
   port:
     targetPort: 8080
   tls:
-    termination: edge
+    termination: passthrough
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION


# Changes

Cherry-pick for https://github.com/tektoncd/operator/pull/3425

Change the default TLS termination from edge to passthrough for the Tekton Results API route. This aligns with the operator's support for TLS customization via the TektonResult CR route_tls_termination field.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Tekton Results API route now uses passthrough TLS termination by default, enabling end-to-end encryption between clients and the Results API service. 
```
