### PR TITLE
docs(install): document that default namespace is unsupported for pipelines on OpenShift (#3427)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -30,3 +30,13 @@ To configure images from a custom registry, follow the [Air Gap Configuration](.
     ```
     $ kubectl apply -f https://raw.githubusercontent.com/tektoncd/operator/main/config/crs/kubernetes/config/all/operator_v1alpha1_config_cr.yaml
     ```
+
+## Platform notes
+
+### OpenShift: do not run pipelines in the `default` namespace
+
+On OpenShift, the `default` namespace is classified as a "highly privileged" system namespace. Pod Security Admission (PSA) label synchronization is permanently disabled there by the platform, so even though the operator correctly creates the `pipeline` ServiceAccount and RBAC bindings in `default`, PipelineRuns submitted to that namespace fail with `permissionDenied` errors: PSA enforces the `restricted` profile and the SCC-to-PSA label sync never runs.
+
+User-created namespaces are not affected because the Cluster Policy Controller automatically syncs SCC privileges into PSA labels. The OpenShift documentation has the same guidance ([Do not run workloads in or share access to default projects](https://docs.openshift.com/container-platform/latest/welcome/index.html#about-namespaces)).
+
+Run pipelines in a dedicated namespace instead of `default` on OpenShift. See [tektoncd/operator#3427](https://github.com/tektoncd/operator/issues/3427) for the original report.

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,6 +37,6 @@ To configure images from a custom registry, follow the [Air Gap Configuration](.
 
 On OpenShift, the `default` namespace is classified as a "highly privileged" system namespace. Pod Security Admission (PSA) label synchronization is permanently disabled there by the platform, so even though the operator correctly creates the `pipeline` ServiceAccount and RBAC bindings in `default`, PipelineRuns submitted to that namespace fail with `permissionDenied` errors: PSA enforces the `restricted` profile and the SCC-to-PSA label sync never runs.
 
-User-created namespaces are not affected because the Cluster Policy Controller automatically syncs SCC privileges into PSA labels. The OpenShift documentation has the same guidance ([Do not run workloads in or share access to default projects](https://docs.openshift.com/container-platform/latest/welcome/index.html#about-namespaces)).
+User-created namespaces are not affected because the Cluster Policy Controller automatically syncs SCC privileges into PSA labels. The OpenShift documentation has the same guidance ([Do not run workloads in or share access to default projects](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/building_applications/projects)).
 
 Run pipelines in a dedicated namespace instead of `default` on OpenShift. See [tektoncd/operator#3427](https://github.com/tektoncd/operator/issues/3427) for the original report.


### PR DESCRIPTION
Closes #3427.

Adds a "Platform notes" section to `docs/install.md` explaining that the `default` namespace on OpenShift is unsupported for running pipelines, and pointing installers to dedicated namespaces. The operator silently creates the `pipeline` ServiceAccount and RBAC in `default`, but PipelineRuns then fail with `permissionDenied` because OpenShift permanently disables PSA label synchronization on `default` and PSA enforces the `restricted` profile.

This matches the OpenShift documentation guidance ("Do not run workloads in or share access to default projects") and the report in the linked downstream Jira (SRVKP-12017).

### Change Type

- [x] Documentation