### PR TITLE
chore(deps): Update postgres-15 images for Openshift

### DIFF
--- a/config/openshift/base/operator.yaml
+++ b/config/openshift/base/operator.yaml
@@ -88,7 +88,7 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: tekton-operator-controller-config-leader-election
         - name: IMAGE_HUB_TEKTON_HUB_DB
-          value: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
+          value: registry.redhat.io/rhel9/postgresql-15@sha256:327d89e4b62d990dbf55d3c78f271373747816c2e0ab3c943fb016cdcf12f9b5
         - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
           value: registry.redhat.io/rhel9/buildah@sha256:0e29338c43fbf9847f2060d7685b872594e3b39bfcf56278f470279089e48048
         - name: IMAGE_ADDONS_PARAM_KN_IMAGE

--- a/operatorhub/openshift/config.yaml
+++ b/operatorhub/openshift/config.yaml
@@ -210,7 +210,7 @@ image-substitutions:
         containerName: openshift-pipelines-operator-lifecycle
         envKeys:
           - IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-- image: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
+- image: registry.redhat.io/rhel9/postgresql-15@sha256:327d89e4b62d990dbf55d3c78f271373747816c2e0ab3c943fb016cdcf12f9b5
   replaceLocations:
     envTargets:
       - deploymentName: openshift-pipelines-operator

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1374,7 +1374,7 @@ spec:
                 - name: CONFIG_LEADERELECTION_NAME
                   value: tekton-operator-controller-config-leader-election
                 - name: IMAGE_HUB_TEKTON_HUB_DB
-                  value: registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59
+                  value: registry.redhat.io/rhel9/postgresql-15@sha256:327d89e4b62d990dbf55d3c78f271373747816c2e0ab3c943fb016cdcf12f9b5
                 - name: IMAGE_ADDONS_PARAM_BUILDER_IMAGE
                   value: registry.redhat.io/rhel9/buildah@sha256:0e29338c43fbf9847f2060d7685b872594e3b39bfcf56278f470279089e48048
                 - name: IMAGE_ADDONS_PARAM_KN_IMAGE


### PR DESCRIPTION
# Changes

Update the postgres-15 images used by Openshift for Tekton Results and Tekton Hub.
Made by running `./hack/openshift/update-image-sha.sh` and staging only the updates to the postgres images

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Update Openshift Postgres15 image from `90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59` to `327d89e4b62d990dbf55d3c78f271373747816c2e0ab3c943fb016cdcf12f9b5`
```
