### PR TITLE
[release-v0.78.x] update the hub version to v1.23.11

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -6,7 +6,7 @@ dashboard:
   version: v0.63.1
 hub:
   github: openshift-pipelines/hub
-  version: v1.23.10
+  version: v1.23.11
 manual-approval-gate:
   github: openshift-pipelines/manual-approval-gate
   version: v0.7.0

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -334,7 +334,7 @@ spec:
     - Tekton Triggers: v0.34.0
     - Pipelines as Code: v0.39.5
     - Tekton Chains: v0.26.2
-    - Tekton Hub (tech-preview): v1.23.10
+    - Tekton Hub (tech-preview): v1.23.11
     - Tekton Results: v0.17.2
     - Manual Approval Gate (tech-preview): v0.7.0
     - Tekton Pruner: v0.3.5


### PR DESCRIPTION
# Changes

Hub 1.23.11 hase been released with few CVEs fixes for OSP 1.21.2 release and needs to update the Hub version in Operator.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
