### PR TITLE
fix(cve): Update Go 1.25.10 → 1.25.11 to fix CVE-2026-27145, CVE-2026-42504, CVE-2026-42507 [release-v0.77.x]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/operator
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## CVE Details (release-v0.77.x / Pipelines 1.20)

| CVE | Go ID | Package | Fixed In |
|-----|-------|---------|----------|
| CVE-2026-27145 | GO-2026-5037 | crypto/x509 | go1.25.11 |
| CVE-2026-42504 | GO-2026-5038 | mime | go1.25.11 |
| CVE-2026-42507 | GO-2026-5039 | net/textproto | go1.25.11 |

## Fix Summary

Bumps `go` directive in `go.mod` from `1.25.10` to `1.25.11`.

- **CVE-2026-27145**: Inefficient hostname parsing in `crypto/x509`
- **CVE-2026-42504**: Quadratic complexity in `mime.WordDecoder.DecodeHeader`
- **CVE-2026-42507**: Arbitrary inputs in errors without escaping in `net/textproto`

## Test Results

✅ **go mod tidy** — passed
✅ **go mod verify** — all modules verified
✅ **go mod vendor** — completed

## Breaking Changes

None. Patch-level Go upgrade within 1.25.x.

## Jira References

No Jira tickets filed for these CVEs. Discovered via automated govulncheck scanning.

## Risk Assessment

**Low** — Patch-level Go upgrade, no API or behavioral changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)