### PR TITLE
fix(openshift): delete operator webhooks before namespace cleanup on uninstall

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/admission_webhooks.go
+++ b/pkg/reconciler/openshift/tektonconfig/admission_webhooks.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	namespaceAdmissionWebhookName = "namespace.operator.tekton.dev"
+	proxyAdmissionWebhookName     = "proxy.operator.tekton.dev"
+)
+
+// removeOperatorAdmissionWebhooks deletes operator admission webhooks before namespace
+// label cleanup during TektonConfig finalization. This prevents finalize from failing when
+// the openshift-pipelines operand namespace (and proxy-webhook service) is already gone
+// but the webhook configurations still exist (SRVKP-12010).
+func removeOperatorAdmissionWebhooks(ctx context.Context, kubeClient kubernetes.Interface) error {
+	if err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(
+		ctx, namespaceAdmissionWebhookName, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete validating webhook %s: %w", namespaceAdmissionWebhookName, err)
+	}
+
+	if err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(
+		ctx, proxyAdmissionWebhookName, metav1.DeleteOptions{},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete mutating webhook %s: %w", proxyAdmissionWebhookName, err)
+	}
+
+	return nil
+}

--- a/pkg/reconciler/openshift/tektonconfig/admission_webhooks_test.go
+++ b/pkg/reconciler/openshift/tektonconfig/admission_webhooks_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestRemoveOperatorAdmissionWebhooks(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes namespace and proxy webhooks", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset(
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceAdmissionWebhookName},
+			},
+			&admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: proxyAdmissionWebhookName},
+			},
+		)
+
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.NilError(t, err)
+
+		_, err = kc.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, namespaceAdmissionWebhookName, metav1.GetOptions{})
+		assert.ErrorContains(t, err, "not found")
+
+		_, err = kc.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, proxyAdmissionWebhookName, metav1.GetOptions{})
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("succeeds when webhooks are already gone", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset()
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.NilError(t, err)
+	})
+
+	t.Run("returns error when delete fails", func(t *testing.T) {
+		kc := kubefake.NewSimpleClientset(
+			&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceAdmissionWebhookName},
+			},
+		)
+		kc.PrependReactor("delete", "validatingwebhookconfigurations", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("delete failed")
+		})
+
+		err := removeOperatorAdmissionWebhooks(ctx, kc)
+		assert.ErrorContains(t, err, "failed to delete validating webhook")
+	})
+}

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -256,6 +256,10 @@ func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonC
 		}
 	}
 
+	if err := removeOperatorAdmissionWebhooks(ctx, oe.kubeClientSet); err != nil {
+		return err
+	}
+
 	r := rbac{
 		kubeClientSet: oe.kubeClientSet,
 		version:       os.Getenv(versionKey),

--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -67,6 +67,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
+		return err
 	}
 
 	if original.Spec.Profile == v1alpha1.ProfileLite {


### PR DESCRIPTION
## Problem

When uninstalling via the Console UI, \`TektonConfig\` finalization calls
\`rbac.cleanUp()\` which updates user namespaces to strip the
\`openshift-pipelines.tekton.dev/namespace-reconcile-version\` label.
The \`namespace.operator.tekton.dev\` ValidatingWebhookConfiguration
intercepts every namespace update and calls the
\`tekton-operator-proxy-webhook\` service in \`openshift-pipelines\`.

When the UI removes \`openshift-pipelines\` before finalization completes,
the VWH still exists (GC lag) but the backend service is already gone:

\`\`\`
Failed to finalize platform resources failed to update namespace default:
failed calling webhook "namespace.operator.tekton.dev":
service "tekton-operator-proxy-webhook" not found
\`\`\`

Result: finalization stuck → Subscription/CSV never deleted → operator pod,
deployments, CRDs and ClusterRoles remain in \`openshift-operators\`.

## Root cause

The VWH/MWH are owned by the \`openshift-pipelines\` Namespace (SRVKP-8901)
and are GC'd when it is deleted — but there is a window where the namespace
is **Terminating** (services gone) while the webhook configs still exist.
\`cleanUp()\` namespace updates fail during that window.

## Fix

Delete \`namespace.operator.tekton.dev\` (VWH) and \`proxy.operator.tekton.dev\`
(MWH) at the **start of \`openshiftExtension.Finalize\`**, before
\`rbac.cleanUp()\` runs. \`NotFound\` is ignored (already GC'd). The
ownerRef-based GC from SRVKP-8901 is kept as the normal cleanup path.

Also propagate errors from \`extension.Finalize\` in \`FinalizeKind\` so the
finalizer retries on failure instead of silently continuing.

## Testing

Verified on OpenShift 4.20 (AWS) — installed OSP 1.22.2 via OperatorHub,
patched operator image with this fix, triggered UI uninstall. Confirmed:

- No \`service "tekton-operator-proxy-webhook" not found\` errors in logs ✅
- VWH \`namespace.operator.tekton.dev\` removed ✅
- MWH \`proxy.operator.tekton.dev\` removed ✅
- Subscription, CSV, operator deployments all removed ✅
- \`openshift-pipelines\` namespace removed ✅
- CRDs remain (expected — OLM does not delete CRDs on uninstall)

Unit tests: \`TestRemoveOperatorAdmissionWebhooks\` (delete both, already-absent, delete-failure).

Fixes: SRVKP-12010

Made with [Cursor](https://cursor.com)

```release-note
Bug fix: OpenShift Pipelines operator now uninstalls cleanly via the Console UI.
Previously, operator admission webhooks (namespace.operator.tekton.dev,
proxy.operator.tekton.dev) could still be registered while their backend service
was already removed during uninstall, causing TektonConfig finalization to fail
and leaving the Subscription, CSV, and operator deployment behind in
openshift-operators. The webhooks are now explicitly removed at the start of
finalization before namespace label cleanup runs.
```