### PR TITLE
feat(openshift): add mTLS for Prometheus metrics

### DIFF
--- a/cmd/openshift/operator/kodata/openshift-monitoring/00-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/00-monitoring.yaml
@@ -58,8 +58,14 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: http-metrics
+      port: https-metrics
       honorLabels: true
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-pipelines-controller.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/cmd/openshift/operator/kodata/openshift-monitoring/01-trigger-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/01-trigger-monitoring.yaml
@@ -25,7 +25,13 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: http-metrics
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-triggers-controller.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/cmd/openshift/operator/kodata/openshift-monitoring/02-chains-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/02-chains-monitoring.yaml
@@ -25,7 +25,13 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: http-metrics
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-chains-metrics.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/cmd/openshift/operator/kodata/openshift-monitoring/03-pipeline-webhook-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/03-pipeline-webhook-monitoring.yaml
@@ -26,6 +26,7 @@ spec:
   endpoints:
     - interval: 10s
       port: http-metrics
+      scheme: http
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/cmd/openshift/operator/kodata/openshift-monitoring/05-results-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/05-results-monitoring.yaml
@@ -25,7 +25,14 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: metrics
+      port: https-metrics
+      honorLabels: true
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-results-watcher.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:
@@ -47,7 +54,14 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: prometheus
+      port: https-prometheus
+      honorLabels: true
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-results-api-service.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/cmd/openshift/operator/kodata/openshift-monitoring/06-pruner-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/06-pruner-monitoring.yaml
@@ -25,7 +25,13 @@ metadata:
 spec:
   endpoints:
     - interval: 10s
-      port: http-metrics
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: tekton-pruner-controller.openshift-pipelines.svc
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/pkg/reconciler/openshift/common/metricsca.go
+++ b/pkg/reconciler/openshift/common/metricsca.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// MetricsClientCAConfigMap is the name of the ConfigMap synced into each
+	// component namespace so that the Prometheus metrics server can verify
+	// the client certificate presented by Prometheus during mTLS scraping.
+	MetricsClientCAConfigMap = "metrics-client-ca"
+
+	// MetricsClientCAKey is the data key within MetricsClientCAConfigMap that
+	// holds the PEM-encoded CA bundle.
+	MetricsClientCAKey = "client-ca-file"
+
+	// SourceConfigMapName is the authoritative ConfigMap in kube-system that
+	// contains the Prometheus client CA bundle on OpenShift.
+	//
+	// When scrapeClass: tls-client-certificate-auth is set on a ServiceMonitor,
+	// CMO configures Prometheus to present metrics-client-certs as the scraping
+	// client certificate. That cert is signed by the kubernetes.io/kube-apiserver-client
+	// signer (kubelet-signer), which is included in extension-apiserver-authentication.
+	SourceConfigMapName = "extension-apiserver-authentication"
+	SystemNamespace     = "kube-system"
+)
+
+// EnsureMetricsClientCA reads the Prometheus client CA from
+// kube-system/extension-apiserver-authentication and creates-or-updates
+// the metrics-client-ca ConfigMap in targetNamespace.
+//
+// The ConfigMap is mounted by Tekton component containers so that the
+// knative prometheus.Server can verify the Prometheus client certificate
+// during mTLS scraping (METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE).
+func EnsureMetricsClientCA(ctx context.Context, kubeClient kubernetes.Interface, targetNamespace string) error {
+	logger := logging.FromContext(ctx)
+
+	src, err := kubeClient.CoreV1().ConfigMaps(SystemNamespace).Get(
+		ctx, SourceConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("reading %s/%s: %w", SystemNamespace, SourceConfigMapName, err)
+	}
+
+	caBundle, ok := src.Data[MetricsClientCAKey]
+	if !ok {
+		return fmt.Errorf("%s/%s has no %q key", SystemNamespace, SourceConfigMapName, MetricsClientCAKey)
+	}
+
+	cmClient := kubeClient.CoreV1().ConfigMaps(targetNamespace)
+
+	existing, err := cmClient.Get(ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("getting %s/%s: %w", targetNamespace, MetricsClientCAConfigMap, err)
+	}
+
+	if errors.IsNotFound(err) {
+		logger.Infof("Creating %s/%s", targetNamespace, MetricsClientCAConfigMap)
+		desired := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      MetricsClientCAConfigMap,
+				Namespace: targetNamespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of": "tekton-pipelines",
+				},
+			},
+			Data: map[string]string{
+				MetricsClientCAKey: caBundle,
+			},
+		}
+		_, err = cmClient.Create(ctx, desired, metav1.CreateOptions{})
+		return err
+	}
+
+	// Already exists — update only if the CA bundle has changed.
+	if existing.Data[MetricsClientCAKey] == caBundle {
+		logger.Debugf("%s/%s is up to date", targetNamespace, MetricsClientCAConfigMap)
+		return nil
+	}
+
+	logger.Infof("Updating %s/%s (CA bundle changed)", targetNamespace, MetricsClientCAConfigMap)
+	updated := existing.DeepCopy()
+	if updated.Data == nil {
+		updated.Data = map[string]string{}
+	}
+	updated.Data[MetricsClientCAKey] = caBundle
+	_, err = cmClient.Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/reconciler/openshift/common/metricsca_test.go
+++ b/pkg/reconciler/openshift/common/metricsca_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+const testCABundle = "-----BEGIN CERTIFICATE-----\nMIIBtest\n-----END CERTIFICATE-----\n"
+
+// sourceConfigMap returns a pre-populated kube-system/extension-apiserver-authentication
+// ConfigMap that EnsureMetricsClientCA reads from.
+func sourceConfigMap(caBundle string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SourceConfigMapName,
+			Namespace: SystemNamespace,
+		},
+		Data: map[string]string{
+			MetricsClientCAKey: caBundle,
+		},
+	}
+}
+
+func TestEnsureMetricsClientCA_Creates(t *testing.T) {
+	client := kubefake.NewSimpleClientset(sourceConfigMap(testCABundle))
+	ctx := context.Background()
+
+	assert.NilError(t, EnsureMetricsClientCA(ctx, client, "openshift-pipelines"))
+
+	cm, err := client.CoreV1().ConfigMaps("openshift-pipelines").Get(
+		ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, testCABundle, cm.Data[MetricsClientCAKey])
+	assert.Equal(t, "tekton-pipelines", cm.Labels["app.kubernetes.io/part-of"])
+}
+
+func TestEnsureMetricsClientCA_NoOp_WhenUpToDate(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MetricsClientCAConfigMap,
+			Namespace: "openshift-pipelines",
+		},
+		Data: map[string]string{MetricsClientCAKey: testCABundle},
+	}
+	client := kubefake.NewSimpleClientset(sourceConfigMap(testCABundle), existing)
+	ctx := context.Background()
+
+	// Record the resource version before the call.
+	before, err := client.CoreV1().ConfigMaps("openshift-pipelines").Get(
+		ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	assert.NilError(t, EnsureMetricsClientCA(ctx, client, "openshift-pipelines"))
+
+	after, err := client.CoreV1().ConfigMaps("openshift-pipelines").Get(
+		ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	// ResourceVersion should be unchanged (no update was issued).
+	assert.Equal(t, before.ResourceVersion, after.ResourceVersion,
+		"ConfigMap should not have been updated when CA bundle is unchanged")
+}
+
+func TestEnsureMetricsClientCA_Updates_WhenStale(t *testing.T) {
+	const updatedBundle = "-----BEGIN CERTIFICATE-----\nMIIBupdated\n-----END CERTIFICATE-----\n"
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MetricsClientCAConfigMap,
+			Namespace: "openshift-pipelines",
+		},
+		Data: map[string]string{MetricsClientCAKey: "old-bundle"},
+	}
+	client := kubefake.NewSimpleClientset(sourceConfigMap(updatedBundle), existing)
+	ctx := context.Background()
+
+	assert.NilError(t, EnsureMetricsClientCA(ctx, client, "openshift-pipelines"))
+
+	cm, err := client.CoreV1().ConfigMaps("openshift-pipelines").Get(
+		ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, updatedBundle, cm.Data[MetricsClientCAKey],
+		"ConfigMap should have been updated with the new CA bundle")
+}
+
+func TestEnsureMetricsClientCA_ErrorWhenSourceMissing(t *testing.T) {
+	// No source ConfigMap pre-seeded.
+	client := kubefake.NewSimpleClientset()
+	ctx := context.Background()
+
+	err := EnsureMetricsClientCA(ctx, client, "openshift-pipelines")
+	assert.ErrorContains(t, err, SourceConfigMapName)
+}
+
+func TestEnsureMetricsClientCA_ErrorWhenKeyMissing(t *testing.T) {
+	srcNoKey := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SourceConfigMapName,
+			Namespace: SystemNamespace,
+		},
+		Data: map[string]string{
+			"some-other-key": "value",
+		},
+	}
+	client := kubefake.NewSimpleClientset(srcNoKey)
+	ctx := context.Background()
+
+	err := EnsureMetricsClientCA(ctx, client, "openshift-pipelines")
+	assert.ErrorContains(t, err, MetricsClientCAKey)
+}
+
+func TestEnsureMetricsClientCA_DifferentTargetNamespaces(t *testing.T) {
+	namespaces := []string{"openshift-pipelines", "tekton-chains", "tekton-results"}
+	client := kubefake.NewSimpleClientset(sourceConfigMap(testCABundle))
+	ctx := context.Background()
+
+	for _, ns := range namespaces {
+		assert.NilError(t, EnsureMetricsClientCA(ctx, client, ns))
+
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(
+			ctx, MetricsClientCAConfigMap, metav1.GetOptions{})
+		assert.NilError(t, err, "namespace %q", ns)
+		assert.Equal(t, testCABundle, cm.Data[MetricsClientCAKey], "namespace %q", ns)
+	}
+}

--- a/pkg/reconciler/openshift/common/metricstls.go
+++ b/pkg/reconciler/openshift/common/metricstls.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	rcommon "github.com/tektoncd/operator/pkg/reconciler/common"
+)
+
+const (
+	// MetricsHTTPPort is the upstream port name for plain-HTTP metrics.
+	MetricsHTTPPort = "http-metrics"
+	// MetricsHTTPSPort is the renamed port name after mTLS is enabled.
+	MetricsHTTPSPort = "https-metrics"
+
+	// metricsServingCertAnnotation is the OpenShift annotation that triggers
+	// automatic provisioning of a service serving certificate.
+	metricsServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
+
+	// metricsServingCertVolume and metricsClientCAVolume are the Pod volume names.
+	metricsServingCertVolume = "metrics-serving-cert"
+	metricsClientCAVolume    = "metrics-client-ca"
+
+	// MetricsTLSMountPath is where the serving-cert Secret is mounted.
+	MetricsTLSMountPath = "/etc/metrics-tls"
+	// MetricsClientCAMountPath is where the client-CA ConfigMap is mounted.
+	MetricsClientCAMountPath = "/etc/metrics-client-ca"
+
+	// Env vars read by knative/pkg prometheus.Server to configure mTLS.
+	envMetricsTLSCert       = "METRICS_PROMETHEUS_TLS_CERT"
+	envMetricsTLSKey        = "METRICS_PROMETHEUS_TLS_KEY"
+	envMetricsTLSClientCA   = "METRICS_PROMETHEUS_TLS_CLIENT_CA_FILE"
+	envMetricsTLSClientAuth = "METRICS_PROMETHEUS_TLS_CLIENT_AUTH"
+
+	// Paths inside the Prometheus pod where CMO mounts the scraping credentials.
+	// These match the tls-client-certificate-auth scrapeClass definition.
+	promCertFile = "/etc/prometheus/secrets/metrics-client-certs/tls.crt"
+	promKeyFile  = "/etc/prometheus/secrets/metrics-client-certs/tls.key"
+	promCAFile   = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+)
+
+// MetricsServingCertSecretName returns the conventional TLS Secret name for
+// the given Service (i.e. "<serviceName>-metrics-tls").
+func MetricsServingCertSecretName(serviceName string) string {
+	return serviceName + "-metrics-tls"
+}
+
+// AnnotateMetricsServingCert adds the OpenShift serving-cert annotation to the
+// named Service so that OpenShift automatically provisions a TLS Secret named
+// "<serviceName>-metrics-tls". Call this once per Service that needs its own
+// metrics serving certificate. If another transformer already sets this
+// annotation on the Service, do not call this — use the existing secret instead.
+func AnnotateMetricsServingCert(serviceName string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Service" || u.GetName() != serviceName {
+			return nil
+		}
+		annotations := u.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[metricsServingCertAnnotation] = MetricsServingCertSecretName(serviceName)
+		u.SetAnnotations(annotations)
+		return nil
+	}
+}
+
+// RenameServicePort renames fromPort to toPort on the named Service.
+// Use this to align the Service port name with what the ServiceMonitor expects
+// (e.g. "http-metrics" → "https-metrics", "prometheus" → "https-prometheus").
+func RenameServicePort(serviceName, fromPort, toPort string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "Service" || u.GetName() != serviceName {
+			return nil
+		}
+		svc := &corev1.Service{}
+		if err := scheme.Scheme.Convert(u, svc, nil); err != nil {
+			return err
+		}
+		renamed := false
+		for i, p := range svc.Spec.Ports {
+			if p.Name == fromPort {
+				svc.Spec.Ports[i].Name = toPort
+				renamed = true
+			}
+		}
+		if !renamed {
+			return nil
+		}
+		svc.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   corev1.SchemeGroupVersion.Group,
+			Version: corev1.SchemeGroupVersion.Version,
+			Kind:    "Service",
+		})
+		m, err := toUnstructured(svc)
+		if err != nil {
+			return err
+		}
+		u.SetUnstructuredContent(m.Object)
+		return nil
+	}
+}
+
+// UpdateServiceMonitorForMetricsMTLS transforms a ServiceMonitor (matched by
+// name) that was previously scraping over plain HTTP into one that uses mTLS:
+//
+//   - Renames the endpoint port from fromPort to toPort
+//   - Sets scheme to "https"
+//   - Injects the standard Prometheus-pod tlsConfig (cert/key/ca file paths +
+//     serverName derived from serviceName and targetNamespace)
+//
+// fromPort and toPort must be consistent with the corresponding RenameServicePort
+// call on the backing Service (e.g. MetricsHTTPPort → MetricsHTTPSPort).
+func UpdateServiceMonitorForMetricsMTLS(smName, fromPort, toPort, serviceName, targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "ServiceMonitor" || u.GetName() != smName {
+			return nil
+		}
+
+		endpoints, found, err := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+		if err != nil {
+			return err
+		}
+		if !found {
+			return nil
+		}
+		for i, ep := range endpoints {
+			epMap, ok := ep.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if epMap["port"] == fromPort {
+				epMap["port"] = toPort
+			}
+			epMap["scheme"] = "https"
+			epMap["tlsConfig"] = map[string]interface{}{
+				"caFile":     promCAFile,
+				"certFile":   promCertFile,
+				"keyFile":    promKeyFile,
+				"serverName": serviceName + "." + targetNamespace + ".svc",
+			}
+			endpoints[i] = epMap
+		}
+		return unstructured.SetNestedSlice(u.Object, endpoints, "spec", "endpoints")
+	}
+}
+
+// ApplyMetricsTLS is a manifest transformer that injects the serving-cert
+// Secret and the metrics-client-ca ConfigMap as volumes into the named
+// Deployment or StatefulSet, and sets the METRICS_PROMETHEUS_TLS_* env vars
+// on all containers so that the knative prometheus.Server enables mTLS.
+//
+//   - kind: "Deployment" or "StatefulSet"
+//   - name: metadata.name of the resource to patch
+//   - secretName: name of the TLS Secret to mount (use MetricsServingCertSecretName)
+func ApplyMetricsTLS(kind, name, secretName string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != kind || u.GetName() != name {
+			return nil
+		}
+
+		switch kind {
+		case "Deployment":
+			return applyMetricsTLSToDeployment(u, secretName)
+		case "StatefulSet":
+			return applyMetricsTLSToStatefulSet(u, secretName)
+		}
+		return nil
+	}
+}
+
+func applyMetricsTLSToDeployment(u *unstructured.Unstructured, secretName string) error {
+	d := &appsv1.Deployment{}
+	if err := scheme.Scheme.Convert(u, d, nil); err != nil {
+		return err
+	}
+
+	injectMetricsTLSIntoPodSpec(&d.Spec.Template.Spec, secretName)
+
+	d.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   appsv1.SchemeGroupVersion.Group,
+		Version: appsv1.SchemeGroupVersion.Version,
+		Kind:    "Deployment",
+	})
+	m, err := toUnstructured(d)
+	if err != nil {
+		return err
+	}
+	u.SetUnstructuredContent(m.Object)
+	return nil
+}
+
+func applyMetricsTLSToStatefulSet(u *unstructured.Unstructured, secretName string) error {
+	sts := &appsv1.StatefulSet{}
+	if err := scheme.Scheme.Convert(u, sts, nil); err != nil {
+		return err
+	}
+
+	injectMetricsTLSIntoPodSpec(&sts.Spec.Template.Spec, secretName)
+
+	sts.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   appsv1.SchemeGroupVersion.Group,
+		Version: appsv1.SchemeGroupVersion.Version,
+		Kind:    "StatefulSet",
+	})
+	m, err := toUnstructured(sts)
+	if err != nil {
+		return err
+	}
+	u.SetUnstructuredContent(m.Object)
+	return nil
+}
+
+// injectMetricsTLSIntoPodSpec adds the TLS volumes and env vars to a PodSpec.
+func injectMetricsTLSIntoPodSpec(spec *corev1.PodSpec, secretName string) {
+	// Add the serving-cert Secret volume.
+	servingCertVol := corev1.Volume{
+		Name: metricsServingCertVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+	spec.Volumes = rcommon.AddOrReplaceInList(
+		spec.Volumes, servingCertVol, func(v corev1.Volume) string { return v.Name },
+	)
+
+	// Add the client-CA ConfigMap volume.
+	clientCAVol := corev1.Volume{
+		Name: metricsClientCAVolume,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: MetricsClientCAConfigMap,
+				},
+			},
+		},
+	}
+	spec.Volumes = rcommon.AddOrReplaceInList(
+		spec.Volumes, clientCAVol, func(v corev1.Volume) string { return v.Name },
+	)
+
+	tlsEnvVars := []corev1.EnvVar{
+		{Name: envMetricsTLSCert, Value: fmt.Sprintf("%s/tls.crt", MetricsTLSMountPath)},
+		{Name: envMetricsTLSKey, Value: fmt.Sprintf("%s/tls.key", MetricsTLSMountPath)},
+		{Name: envMetricsTLSClientCA, Value: fmt.Sprintf("%s/%s", MetricsClientCAMountPath, MetricsClientCAKey)},
+		{Name: envMetricsTLSClientAuth, Value: "require"},
+	}
+
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+
+		// Add serving-cert volume mount.
+		c.VolumeMounts = rcommon.AddOrReplaceInList(
+			c.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      metricsServingCertVolume,
+				MountPath: MetricsTLSMountPath,
+				ReadOnly:  true,
+			},
+			func(vm corev1.VolumeMount) string { return vm.Name },
+		)
+
+		// Add client-CA volume mount.
+		c.VolumeMounts = rcommon.AddOrReplaceInList(
+			c.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      metricsClientCAVolume,
+				MountPath: MetricsClientCAMountPath,
+				ReadOnly:  true,
+			},
+			func(vm corev1.VolumeMount) string { return vm.Name },
+		)
+
+		// Add / replace TLS env vars.
+		for _, env := range tlsEnvVars {
+			c.Env = rcommon.AddOrReplaceInList(
+				c.Env, env, func(e corev1.EnvVar) string { return e.Name },
+			)
+		}
+	}
+}

--- a/pkg/reconciler/openshift/common/metricstls_test.go
+++ b/pkg/reconciler/openshift/common/metricstls_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// ---------------------------------------------------------------------------
+// replaceServerNameNamespace
+// ---------------------------------------------------------------------------
+
+func TestReplaceServerNameNamespace(t *testing.T) {
+	tests := []struct {
+		name            string
+		serverName      string
+		targetNamespace string
+		want            string
+	}{
+		{
+			name:            "simple svc name",
+			serverName:      "tekton-pipelines-controller.tekton-pipelines.svc",
+			targetNamespace: "openshift-pipelines",
+			want:            "tekton-pipelines-controller.openshift-pipelines.svc",
+		},
+		{
+			name:            "with cluster.local suffix",
+			serverName:      "foo.bar.svc.cluster.local",
+			targetNamespace: "my-ns",
+			want:            "foo.my-ns.svc.cluster.local",
+		},
+		{
+			name:            "no .svc segment returns unchanged",
+			serverName:      "foo.bar.example.com",
+			targetNamespace: "my-ns",
+			want:            "foo.bar.example.com",
+		},
+		{
+			name:            "missing namespace segment returns unchanged",
+			serverName:      "foo.svc",
+			targetNamespace: "my-ns",
+			// "foo.svc" → base="foo", SplitN gives only 1 part → unchanged
+			want: "foo.svc",
+		},
+		{
+			name:            "already correct namespace is replaced",
+			serverName:      "svc-a.target-ns.svc",
+			targetNamespace: "target-ns",
+			want:            "svc-a.target-ns.svc",
+		},
+		{
+			name:            "empty string is unchanged",
+			serverName:      "",
+			targetNamespace: "my-ns",
+			want:            "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := replaceServerNameNamespace(tc.serverName, tc.targetNamespace)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyMetricsTLS — Deployment
+// ---------------------------------------------------------------------------
+
+func TestApplyMetricsTLSDeployment(t *testing.T) {
+	const secretName = "tekton-controller-metrics-tls"
+	ud := unstructuredDeployment(t) // name="registry", one container
+
+	assert.NilError(t, ApplyMetricsTLS("Deployment", "registry", secretName)(ud))
+
+	d := &appsv1.Deployment{}
+	assert.NilError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(ud.Object, d))
+
+	spec := d.Spec.Template.Spec
+
+	// Two volumes must be present.
+	assertVolumeSecret(t, spec.Volumes, metricsServingCertVolume, secretName)
+	assertVolumeConfigMap(t, spec.Volumes, metricsClientCAVolume, MetricsClientCAConfigMap)
+
+	// Every container must have the mounts and env vars.
+	for _, c := range spec.Containers {
+		assertVolumeMount(t, c.VolumeMounts, metricsServingCertVolume, MetricsTLSMountPath)
+		assertVolumeMount(t, c.VolumeMounts, metricsClientCAVolume, MetricsClientCAMountPath)
+		assertEnv(t, c.Env, envMetricsTLSCert, fmt.Sprintf("%s/tls.crt", MetricsTLSMountPath))
+		assertEnv(t, c.Env, envMetricsTLSKey, fmt.Sprintf("%s/tls.key", MetricsTLSMountPath))
+		assertEnv(t, c.Env, envMetricsTLSClientCA, fmt.Sprintf("%s/%s", MetricsClientCAMountPath, MetricsClientCAKey))
+		assertEnv(t, c.Env, envMetricsTLSClientAuth, "require")
+	}
+}
+
+func TestApplyMetricsTLSDeploymentIdempotent(t *testing.T) {
+	const secretName = "tekton-controller-metrics-tls"
+	ud := unstructuredDeployment(t)
+
+	assert.NilError(t, ApplyMetricsTLS("Deployment", "registry", secretName)(ud))
+	// Apply a second time — result must be identical (no duplicates).
+	snapshot := ud.DeepCopy()
+	assert.NilError(t, ApplyMetricsTLS("Deployment", "registry", secretName)(ud))
+
+	d1 := &appsv1.Deployment{}
+	d2 := &appsv1.Deployment{}
+	assert.NilError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(snapshot.Object, d1))
+	assert.NilError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(ud.Object, d2))
+
+	assert.Equal(t, len(d1.Spec.Template.Spec.Volumes), len(d2.Spec.Template.Spec.Volumes),
+		"ApplyMetricsTLS should not duplicate volumes")
+	for i, c1 := range d1.Spec.Template.Spec.Containers {
+		c2 := d2.Spec.Template.Spec.Containers[i]
+		assert.Equal(t, len(c1.VolumeMounts), len(c2.VolumeMounts),
+			"ApplyMetricsTLS should not duplicate volume mounts")
+		assert.Equal(t, len(c1.Env), len(c2.Env),
+			"ApplyMetricsTLS should not duplicate env vars")
+	}
+}
+
+func TestApplyMetricsTLSDeploymentSkipsWrongName(t *testing.T) {
+	ud := unstructuredDeployment(t) // name="registry"
+	before := ud.DeepCopy()
+
+	assert.NilError(t, ApplyMetricsTLS("Deployment", "other-name", "some-secret")(ud))
+
+	// Unstructured content must be unchanged.
+	assert.DeepEqual(t, before.Object, ud.Object)
+}
+
+// ---------------------------------------------------------------------------
+// ApplyMetricsTLS — StatefulSet
+// ---------------------------------------------------------------------------
+
+func TestApplyMetricsTLSStatefulSet(t *testing.T) {
+	const secretName = "results-watcher-metrics-tls"
+	ud := unstructuredStatefulSet(t) // name="test-statefulset", one container
+
+	assert.NilError(t, ApplyMetricsTLS("StatefulSet", "test-statefulset", secretName)(ud))
+
+	sts := &appsv1.StatefulSet{}
+	assert.NilError(t, scheme.Scheme.Convert(ud, sts, nil))
+
+	spec := sts.Spec.Template.Spec
+
+	assertVolumeSecret(t, spec.Volumes, metricsServingCertVolume, secretName)
+	assertVolumeConfigMap(t, spec.Volumes, metricsClientCAVolume, MetricsClientCAConfigMap)
+
+	for _, c := range spec.Containers {
+		assertVolumeMount(t, c.VolumeMounts, metricsServingCertVolume, MetricsTLSMountPath)
+		assertVolumeMount(t, c.VolumeMounts, metricsClientCAVolume, MetricsClientCAMountPath)
+		assertEnv(t, c.Env, envMetricsTLSCert, fmt.Sprintf("%s/tls.crt", MetricsTLSMountPath))
+		assertEnv(t, c.Env, envMetricsTLSKey, fmt.Sprintf("%s/tls.key", MetricsTLSMountPath))
+		assertEnv(t, c.Env, envMetricsTLSClientCA, fmt.Sprintf("%s/%s", MetricsClientCAMountPath, MetricsClientCAKey))
+		assertEnv(t, c.Env, envMetricsTLSClientAuth, "require")
+	}
+}
+
+func TestApplyMetricsTLSStatefulSetIdempotent(t *testing.T) {
+	const secretName = "results-watcher-metrics-tls"
+	ud := unstructuredStatefulSet(t)
+
+	assert.NilError(t, ApplyMetricsTLS("StatefulSet", "test-statefulset", secretName)(ud))
+	snapshot := ud.DeepCopy()
+	assert.NilError(t, ApplyMetricsTLS("StatefulSet", "test-statefulset", secretName)(ud))
+
+	s1, s2 := &appsv1.StatefulSet{}, &appsv1.StatefulSet{}
+	assert.NilError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(snapshot.Object, s1))
+	assert.NilError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(ud.Object, s2))
+
+	assert.Equal(t, len(s1.Spec.Template.Spec.Volumes), len(s2.Spec.Template.Spec.Volumes),
+		"ApplyMetricsTLS should not duplicate volumes")
+	for i, c1 := range s1.Spec.Template.Spec.Containers {
+		c2 := s2.Spec.Template.Spec.Containers[i]
+		assert.Equal(t, len(c1.VolumeMounts), len(c2.VolumeMounts),
+			"ApplyMetricsTLS should not duplicate volume mounts")
+		assert.Equal(t, len(c1.Env), len(c2.Env),
+			"ApplyMetricsTLS should not duplicate env vars")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// small assertion helpers
+// ---------------------------------------------------------------------------
+
+func assertVolumeSecret(t *testing.T, volumes []corev1.Volume, name, secretName string) {
+	t.Helper()
+	for _, v := range volumes {
+		if v.Name == name {
+			if v.Secret == nil {
+				t.Errorf("volume %q: expected Secret source, got nil", name)
+				return
+			}
+			assert.Equal(t, secretName, v.Secret.SecretName,
+				"volume %q secretName", name)
+			return
+		}
+	}
+	t.Errorf("volume %q not found", name)
+}
+
+func assertVolumeConfigMap(t *testing.T, volumes []corev1.Volume, name, cmName string) {
+	t.Helper()
+	for _, v := range volumes {
+		if v.Name == name {
+			if v.ConfigMap == nil {
+				t.Errorf("volume %q: expected ConfigMap source, got nil", name)
+				return
+			}
+			assert.Equal(t, cmName, v.ConfigMap.LocalObjectReference.Name,
+				"volume %q configMapName", name)
+			return
+		}
+	}
+	t.Errorf("volume %q not found", name)
+}
+
+func assertVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, mountPath string) {
+	t.Helper()
+	for _, m := range mounts {
+		if m.Name == name {
+			assert.Equal(t, mountPath, m.MountPath, "VolumeMount %q mountPath", name)
+			assert.Assert(t, m.ReadOnly, "VolumeMount %q should be ReadOnly", name)
+			return
+		}
+	}
+	t.Errorf("VolumeMount %q not found", name)
+}
+
+func assertEnv(t *testing.T, envs []corev1.EnvVar, name, value string) {
+	t.Helper()
+	for _, e := range envs {
+		if e.Name == name {
+			assert.Equal(t, value, e.Value, "env %q value", name)
+			return
+		}
+	}
+	t.Errorf("env var %q not found", name)
+}

--- a/pkg/reconciler/openshift/common/transformer.go
+++ b/pkg/reconciler/openshift/common/transformer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package common
 
 import (
+	"strings"
+
 	mf "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -176,13 +178,65 @@ func UpdateServiceMonitorTargetNamespace(targetNamespace string) mf.Transformer 
 		if u.GetKind() != "ServiceMonitor" {
 			return nil
 		}
-		nsSelector, found, err := unstructured.NestedFieldNoCopy(u.Object, "spec", "namespaceSelector")
-		if !found || err != nil {
+
+		// Replace the scrape namespace.
+		matchNames, found, err := unstructured.NestedStringSlice(u.Object, "spec", "namespaceSelector", "matchNames")
+		if err != nil {
 			return err
 		}
-		nsSelector.(map[string]interface{})["matchNames"].([]interface{})[0] = targetNamespace
+		if found && len(matchNames) > 0 {
+			matchNames[0] = targetNamespace
+			if err := unstructured.SetNestedStringSlice(u.Object, matchNames, "spec", "namespaceSelector", "matchNames"); err != nil {
+				return err
+			}
+		}
+
+		// Replace the namespace segment inside any tlsConfig.serverName fields
+		// (format: "<service>.<namespace>.svc") so that the TLS server-name
+		// verification matches the actual cluster DNS name.
+		endpoints, found, err := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+		if err != nil {
+			return err
+		}
+		if found {
+			for i, ep := range endpoints {
+				epMap, ok := ep.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if tlsCfg, ok := epMap["tlsConfig"].(map[string]interface{}); ok {
+					if sn, ok := tlsCfg["serverName"].(string); ok {
+						tlsCfg["serverName"] = replaceServerNameNamespace(sn, targetNamespace)
+					}
+				}
+				endpoints[i] = epMap
+			}
+			if err := unstructured.SetNestedSlice(u.Object, endpoints, "spec", "endpoints"); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
+}
+
+// replaceServerNameNamespace replaces the namespace segment in a Kubernetes
+// in-cluster DNS name of the form "<service>.<namespace>.svc[…]" with
+// targetNamespace. Returns the original string unchanged if it does not match.
+func replaceServerNameNamespace(serverName, targetNamespace string) string {
+	// Preserve any suffix after ".svc" (e.g. ".cluster.local").
+	const svcSuffix = ".svc"
+	idx := strings.Index(serverName, svcSuffix)
+	if idx < 0 {
+		return serverName
+	}
+	base := serverName[:idx] // "<service>.<namespace>"
+	tail := serverName[idx:] // ".svc[…]"
+	parts := strings.SplitN(base, ".", 2)
+	if len(parts) != 2 {
+		return serverName
+	}
+	return parts[0] + "." + targetNamespace + tail
 }
 
 // RemoveRunAsUserForStatefulset will remove RunAsUser from all container in a statefulset

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/extension.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/extension.go
@@ -42,8 +42,12 @@ const (
 	openshiftNS                = "openshift"
 	pacControllerDeployment    = "pipelines-as-code-controller"
 	pacControllerContainerName = "pac-controller"
+	pacWatcherDeployment       = "pipelines-as-code-watcher"
 	pacWebhookDeployment       = "pipelines-as-code-webhook"
 	pacWebhookContainerName    = "pac-webhook"
+	// ServiceMonitor names from PAC's own release manifests.
+	pacControllerServiceMonitor = "pipelines-as-code-controller-monitor"
+	pacWatcherServiceMonitor    = "pipelines-as-code-monitor"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -95,8 +99,21 @@ type openshiftExtension struct {
 }
 
 func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	targetNS := comp.GetSpec().GetTargetNamespace()
 	trns := []mf.Transformer{
-		InjectNamespaceOwnerForPACWebhook(oe.kubeClientSet, comp.GetSpec().GetTargetNamespace()),
+		InjectNamespaceOwnerForPACWebhook(oe.kubeClientSet, targetNS),
+		// mTLS for Prometheus scraping.
+		occommon.AnnotateMetricsServingCert(pacControllerDeployment),
+		occommon.RenameServicePort(pacControllerDeployment, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.AnnotateMetricsServingCert(pacWatcherDeployment),
+		occommon.RenameServicePort(pacWatcherDeployment, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.ApplyMetricsTLS("Deployment", pacControllerDeployment,
+			occommon.MetricsServingCertSecretName(pacControllerDeployment)),
+		occommon.ApplyMetricsTLS("Deployment", pacWatcherDeployment,
+			occommon.MetricsServingCertSecretName(pacWatcherDeployment)),
+		// Update PAC's own ServiceMonitors (from PAC release) to use HTTPS.
+		occommon.UpdateServiceMonitorForMetricsMTLS(pacControllerServiceMonitor, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort, pacControllerDeployment, targetNS),
+		occommon.UpdateServiceMonitorForMetricsMTLS(pacWatcherServiceMonitor, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort, pacWatcherDeployment, targetNS),
 	}
 
 	// Inject APIServer TLS profile env vars into all three PAC deployments so that
@@ -106,8 +123,6 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 			// pac-webhook uses sharedmain.WebhookMainWithConfig (Knative webhook framework) which
 			// calls knativetls.DefaultConfigFromEnv("WEBHOOK_") → reads WEBHOOK_TLS_* env vars.
 			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", pacWebhookDeployment, []string{pacWebhookContainerName}, occommon.WebhookEnvVarPrefix),
-			// pac-controller and pac-watcher do not serve a TLS endpoint that reads these env vars;
-			// injecting with no prefix is harmless and keeps them consistent for future use.
 			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", pacControllerDeployment, []string{pacControllerContainerName}, ""),
 		)
 	}

--- a/pkg/reconciler/openshift/tektonchain/extension.go
+++ b/pkg/reconciler/openshift/tektonchain/extension.go
@@ -25,21 +25,28 @@ import (
 	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
 const (
 	tektonChainsControllerName = "tekton-chains-controller"
+	// tektonChainsMetricsService is the Service that exposes the metrics service
+	// for Tekton Chains; the serving-cert Secret is named after this Service.
+	tektonChainsMetricsService = "tekton-chains-metrics"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
 	ext := openshiftExtension{
 		operatorClientSet: operatorclient.Get(ctx),
+		kubeClientSet:     kubeclient.Get(ctx),
 	}
 	return ext
 }
 
 type openshiftExtension struct {
 	operatorClientSet versioned.Interface
+	kubeClientSet     kubernetes.Interface
 }
 
 func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
@@ -50,9 +57,20 @@ func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Tr
 		occommon.RemoveRunAsGroupForStatefulSet(tektonChainsControllerName),
 		occommon.ApplyCABundlesToDeployment,
 		occommon.ApplyCABundlesForStatefulSet(tektonChainsControllerName),
+		// mTLS for Prometheus scraping.
+		// The metrics Service for chains is "tekton-chains-metrics" (distinct from the
+		// controller Deployment name), so the Secret name is derived from the Service.
+		occommon.AnnotateMetricsServingCert(tektonChainsMetricsService),
+		occommon.RenameServicePort(tektonChainsMetricsService, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		// Cover both Deployment and StatefulSet: chains uses RemoveRunAsUserForStatefulSet
+		// and ApplyCABundlesForStatefulSet, so it can be either kind across releases.
+		occommon.ApplyMetricsTLS("Deployment", tektonChainsControllerName,
+			occommon.MetricsServingCertSecretName(tektonChainsMetricsService)),
+		occommon.ApplyMetricsTLS("StatefulSet", tektonChainsControllerName,
+			occommon.MetricsServingCertSecretName(tektonChainsMetricsService)),
 	}
 }
-func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
+func (oe openshiftExtension) PreReconcile(context.Context, v1alpha1.TektonComponent) error {
 	return nil
 }
 func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -187,6 +187,10 @@ func (oe openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.Tekto
 		oe.consolePluginReconciler.SetTLSConfig(nil)
 	}
 
+	if err := occommon.EnsureMetricsClientCA(ctx, oe.kubeClientSet, tc.GetSpec().GetTargetNamespace()); err != nil {
+		return err
+	}
+
 	return r.createResources(ctx)
 }
 

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -43,6 +43,10 @@ const (
 	tektonRemoteResolversControllerName = "tekton-pipelines-remote-resolvers"
 	tektonPipelinesWebhookDeployment    = "tekton-pipelines-webhook"
 	webhookContainerName                = "webhook"
+
+	// tektonEventsControllerName is the Deployment that exposes an http-metrics
+	// Service and must therefore receive the mTLS volumes and env vars.
+	tektonEventsControllerName = "tekton-events-controller"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
@@ -79,6 +83,27 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 		occommon.ApplyCABundlesForStatefulSet(tektonPipelinesControllerName),
 		occommon.ApplyCABundlesForStatefulSet(tektonRemoteResolversControllerName),
 		common.ReplaceNamespaceInClusterRoleBinding(comp.GetSpec().GetTargetNamespace()),
+		// mTLS for Prometheus scraping: annotate metric Services for cert provisioning,
+		// rename their ports, and mount the TLS Secret + client-CA ConfigMap into pods.
+		// The webhook is intentionally omitted: it does not support METRICS_PROMETHEUS_TLS_* env vars.
+		occommon.AnnotateMetricsServingCert(tektonPipelinesControllerName),
+		occommon.RenameServicePort(tektonPipelinesControllerName, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.AnnotateMetricsServingCert(tektonEventsControllerName),
+		occommon.RenameServicePort(tektonEventsControllerName, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.AnnotateMetricsServingCert(tektonRemoteResolversControllerName),
+		occommon.RenameServicePort(tektonRemoteResolversControllerName, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		// Cover both Deployment and StatefulSet: pipelines-controller and remote-resolvers
+		// use RemoveRunAsUserForStatefulSet/ApplyCABundlesForStatefulSet, so they can be either.
+		occommon.ApplyMetricsTLS("Deployment", tektonPipelinesControllerName,
+			occommon.MetricsServingCertSecretName(tektonPipelinesControllerName)),
+		occommon.ApplyMetricsTLS("StatefulSet", tektonPipelinesControllerName,
+			occommon.MetricsServingCertSecretName(tektonPipelinesControllerName)),
+		occommon.ApplyMetricsTLS("Deployment", tektonEventsControllerName,
+			occommon.MetricsServingCertSecretName(tektonEventsControllerName)),
+		occommon.ApplyMetricsTLS("Deployment", tektonRemoteResolversControllerName,
+			occommon.MetricsServingCertSecretName(tektonRemoteResolversControllerName)),
+		occommon.ApplyMetricsTLS("StatefulSet", tektonRemoteResolversControllerName,
+			occommon.MetricsServingCertSecretName(tektonRemoteResolversControllerName)),
 	}
 
 	// Inject APIServer TLS profile env vars into the webhook so that it applies
@@ -203,16 +228,16 @@ func filterAndTransform() client.FilterAndTransform {
 	}
 }
 
-// filterAndTransformMonitoring applies ServiceMonitor namespace updates to monitoring manifests
+// filterAndTransformMonitoring applies ServiceMonitor namespace and mTLS
+// updates to monitoring manifests.
 func filterAndTransformMonitoring(comp v1alpha1.TektonComponent) client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
 		if err := common.Transform(ctx, manifest, comp); err != nil {
 			return nil, err
 		}
-		// Apply ServiceMonitor namespace transformer specifically for monitoring manifests
-		// This fixes hardcoded namespace in openshift-monitoring ServiceMonitors
+		targetNS := comp.GetSpec().GetTargetNamespace()
 		tfs := []mf.Transformer{
-			occommon.UpdateServiceMonitorTargetNamespace(comp.GetSpec().GetTargetNamespace()),
+			occommon.UpdateServiceMonitorTargetNamespace(targetNS),
 		}
 		if err := common.Transform(ctx, manifest, comp, tfs...); err != nil {
 			return nil, err

--- a/pkg/reconciler/openshift/tektonpruner/extension.go
+++ b/pkg/reconciler/openshift/tektonpruner/extension.go
@@ -24,21 +24,26 @@ import (
 	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 )
 
 const (
-	tektonPrunerWebhookDeployment = "tekton-pruner-webhook"
-	webhookContainerName          = "webhook"
+	tektonPrunerWebhookDeployment    = "tekton-pruner-webhook"
+	tektonPrunerControllerDeployment = "tekton-pruner-controller"
+	webhookContainerName             = "webhook"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
 	return &openshiftExtension{
+		kubeClientSet:      kubeclient.Get(ctx),
 		tektonConfigLister: tektonConfiginformer.Get(ctx).Lister(),
 	}
 }
 
 type openshiftExtension struct {
+	kubeClientSet      kubernetes.Interface
 	tektonConfigLister occommon.TektonConfigLister
 	resolvedTLSConfig  *occommon.TLSEnvVars
 }
@@ -47,6 +52,11 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 	trns := []mf.Transformer{
 		occommon.RemoveRunAsUser(),
 		occommon.RemoveRunAsGroup(),
+		// mTLS for Prometheus scraping.
+		occommon.AnnotateMetricsServingCert(tektonPrunerControllerDeployment),
+		occommon.RenameServicePort(tektonPrunerControllerDeployment, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.ApplyMetricsTLS("Deployment", tektonPrunerControllerDeployment,
+			occommon.MetricsServingCertSecretName(tektonPrunerControllerDeployment)),
 	}
 
 	if oe.resolvedTLSConfig != nil {

--- a/pkg/reconciler/openshift/tektonresult/extension.go
+++ b/pkg/reconciler/openshift/tektonresult/extension.go
@@ -35,6 +35,8 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
 const (
@@ -79,6 +81,7 @@ func OpenShiftExtension(ctx context.Context) common.Extension {
 	ext := &openshiftExtension{
 		installerSetClient: client.NewInstallerSetClient(operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets(),
 			version, "results-ext", v1alpha1.KindTektonResult, nil),
+		kubeClientSet:      kubeclient.Get(ctx),
 		routeManifest:      routeManifest,
 		logsRBACManifest:   logsRBACManifest,
 		tektonConfigLister: tektonConfigLister,
@@ -88,6 +91,7 @@ func OpenShiftExtension(ctx context.Context) common.Extension {
 
 type openshiftExtension struct {
 	installerSetClient *client.InstallerSetClient
+	kubeClientSet      kubernetes.Interface
 	routeManifest      *mf.Manifest
 	logsRBACManifest   *mf.Manifest
 	tektonConfigLister occommon.TektonConfigLister
@@ -108,6 +112,19 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 		injectLokiStackTLSCACert(instance.Spec.LokiStackProperties),
 		injectResultsAPIServiceCACert(instance.Spec.ResultsAPIProperties),
 		injectPostgresUpgradeSupport(),
+		// mTLS for Prometheus scraping.
+		// Watcher: annotate its Service to get a new serving-cert Secret + rename the port.
+		// API: its Service cert annotation is already owned by injectResultsAPIServiceCACert
+		// (points to "tekton-results-tls"), so we only rename the port to avoid overwriting it.
+		// Both workloads then get the TLS Secret + client-CA ConfigMap mounted via ApplyMetricsTLS.
+		occommon.AnnotateMetricsServingCert(tektonResultWatcherName),
+		occommon.RenameServicePort(tektonResultWatcherName, "metrics", "https-metrics"),
+		occommon.ApplyMetricsTLS("Deployment", tektonResultWatcherName,
+			occommon.MetricsServingCertSecretName(tektonResultWatcherName)),
+		occommon.ApplyMetricsTLS("StatefulSet", tektonResultWatcherName,
+			occommon.MetricsServingCertSecretName(tektonResultWatcherName)),
+		occommon.RenameServicePort(serviceAPI, "prometheus", "https-prometheus"),
+		occommon.ApplyMetricsTLS("Deployment", deploymentAPI, secretAPITLS),
 	}
 
 	// Use TLS config resolved in PreReconcile
@@ -124,6 +141,7 @@ func (oe *openshiftExtension) GetPlatformData() string {
 
 func (oe *openshiftExtension) PreReconcile(ctx context.Context, tc v1alpha1.TektonComponent) error {
 	logger := logging.FromContext(ctx)
+
 	result := tc.(*v1alpha1.TektonResult)
 	manifest := mf.Manifest{}
 

--- a/pkg/reconciler/openshift/tektontrigger/extension.go
+++ b/pkg/reconciler/openshift/tektontrigger/extension.go
@@ -25,15 +25,18 @@ import (
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektontrigger"
 	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 )
 
 const (
-	tektonTriggersWebhookDeployment = "tekton-triggers-webhook"
-	webhookContainerName            = "webhook"
-	tektonTriggersCoreInterceptors  = "tekton-triggers-core-interceptors"
-	coreInterceptorsContainerName   = "tekton-triggers-core-interceptors"
+	tektonTriggersWebhookDeployment    = "tekton-triggers-webhook"
+	webhookContainerName               = "webhook"
+	tektonTriggersCoreInterceptors     = "tekton-triggers-core-interceptors"
+	coreInterceptorsContainerName      = "tekton-triggers-core-interceptors"
+	tektonTriggersControllerDeployment = "tekton-triggers-controller"
 )
 
 // triggersProperties holds fields for configuring runAsUser and runAsGroup.
@@ -54,11 +57,13 @@ var triggersData = triggersProperties{
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
 	return &openshiftExtension{
+		kubeClientSet:      kubeclient.Get(ctx),
 		tektonConfigLister: tektonConfiginformer.Get(ctx).Lister(),
 	}
 }
 
 type openshiftExtension struct {
+	kubeClientSet      kubernetes.Interface
 	tektonConfigLister occommon.TektonConfigLister
 	resolvedTLSConfig  *occommon.TLSEnvVars
 }
@@ -70,6 +75,11 @@ func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.T
 		occommon.ApplyCABundlesToDeployment,
 		common.AddConfigMapValues(tektontrigger.ConfigDefaults, triggersData),
 		replaceDeploymentArgs("-el-events", "enable"),
+		// mTLS for Prometheus scraping.
+		occommon.AnnotateMetricsServingCert(tektonTriggersControllerDeployment),
+		occommon.RenameServicePort(tektonTriggersControllerDeployment, occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort),
+		occommon.ApplyMetricsTLS("Deployment", tektonTriggersControllerDeployment,
+			occommon.MetricsServingCertSecretName(tektonTriggersControllerDeployment)),
 	}
 
 	// Inject APIServer TLS profile env vars into the webhook and core interceptors


### PR DESCRIPTION
Secure component metrics endpoints with mutual TLS on OpenShift. Each reconciler syncs the Prometheus client CA bundle from kube-system/extension-apiserver-authentication into the component namespace as a metrics-client-ca ConfigMap.

OpenShift's serving-cert controller is triggered via annotation on each metrics Service to provision a per-component TLS Secret. Two new manifest transformers (InjectMetricsServingCert, ApplyMetricsTLS) wire the Secret and ConfigMap as volumes and inject METRICS_PROMETHEUS_TLS_* env vars so that the knative/pkg prometheus.Server enables mTLS with require client auth.

ServiceMonitor resources are updated with scheme: https, scrapeClass tls-client-certificate-auth, and tlsConfig.serverName. The existing UpdateServiceMonitorTargetNamespace transformer is extended to also patch the namespace segment inside serverName at runtime.

Relates-To: SRVKP-8172


Assisted-by: Claude Sonnet 4.6 (via Cursor)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Tekton Operator now enables mTLS between Prometheus and all Tekton
component metrics endpoints on OpenShift. Each component namespace
receives a synced client-CA ConfigMap and a serving-cert Secret so
that the knative/pkg prometheus.Server can enforce mutual TLS on its
/metrics endpoint.
```
