### PR TITLE
fix(release): drop --preserve-import-paths from PAC release params

### DIFF
--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -57,7 +57,11 @@ spec:
     - name: releaseAsLatest
       value: "{{ release_as_latest }}"
     - name: koExtraArgs
-      value: "--preserve-import-paths"
+      # Empty: use ko's default --base-import-paths (hash-based image names),
+      # matching the canonical published image paths. Do NOT set
+      # --preserve-import-paths: it pushes to ghcr.io/tektoncd/operator/github.com/...
+      # long paths (private, non-canonical) and breaks the published manifests.
+      value: ""
     - name: serviceAccountImagesPath
       value: credentials
     - name: runTests

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -67,7 +67,11 @@ spec:
     - name: releaseAsLatest
       value: "true"
     - name: koExtraArgs
-      value: "--preserve-import-paths"
+      # Empty: use ko's default --base-import-paths (hash-based image names),
+      # matching the canonical published image paths. Do NOT set
+      # --preserve-import-paths: it pushes to ghcr.io/tektoncd/operator/github.com/...
+      # long paths (private, non-canonical) and breaks the published manifests.
+      value: ""
     - name: serviceAccountImagesPath
       value: credentials
     - name: runTests


### PR DESCRIPTION
# Changes

`.tekton/release.yaml` and `.tekton/release-patch.yaml` explicitly set `koExtraArgs: "--preserve-import-paths"`, which **overrides** the pipeline default that was corrected in #3400 (where `tekton/operator-release-pipeline.yaml` was changed to `koExtraArgs: ""`).

Because the PAC PipelineRuns pass the param explicitly, the #3400 default never takes effect. `--preserve-import-paths` makes `ko` push images to non-canonical long paths:

```
ghcr.io/tektoncd/operator/github.com/tektoncd/operator/cmd/kubernetes/operator
```

These long-path packages are **created private by default** and do not match the canonical, public image names used by historical releases. The result is broken published release manifests — this happened for **v0.79.1** (fixed manually) and reproduced again for **v0.80.0**.

Setting `koExtraArgs: ""` restores ko's default `--base-import-paths` hash-based names:

```
ghcr.io/tektoncd/operator/operator-303303c315a48490ba6517859ef65b77
ghcr.io/tektoncd/operator/webhook-f2bb711aa8f0c0892856a4cbf6d9ddd8
...
```

which match the canonical public paths and avoid the need for any post-release image mirroring / manifest patching. This closes the leftover TODO from the v0.79.1 image-path fix.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```