### PR TITLE
chore: switch base image to ghcr.io/tektoncd/plumbing/static-base

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a
 baseImageOverrides:
   github.com/tektoncd/operator/cmd/openshift/operator: registry.access.redhat.com/ubi9/ubi-minimal
   github.com/tektoncd/operator/cmd/openshift/webhook: registry.access.redhat.com/ubi9/ubi-minimal

--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -57,7 +57,11 @@ spec:
     - name: releaseAsLatest
       value: "{{ release_as_latest }}"
     - name: koExtraArgs
-      value: "--preserve-import-paths"
+      # Empty: use ko's default --base-import-paths (hash-based image names),
+      # matching the canonical published image paths. Do NOT set
+      # --preserve-import-paths: it pushes to ghcr.io/tektoncd/operator/github.com/...
+      # long paths (private, non-canonical) and breaks the published manifests.
+      value: ""
     - name: serviceAccountImagesPath
       value: credentials
     - name: runTests

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -67,7 +67,11 @@ spec:
     - name: releaseAsLatest
       value: "true"
     - name: koExtraArgs
-      value: "--preserve-import-paths"
+      # Empty: use ko's default --base-import-paths (hash-based image names),
+      # matching the canonical published image paths. Do NOT set
+      # --preserve-import-paths: it pushes to ghcr.io/tektoncd/operator/github.com/...
+      # long paths (private, non-canonical) and breaks the published manifests.
+      value: ""
     - name: serviceAccountImagesPath
       value: credentials
     - name: runTests


### PR DESCRIPTION
# Changes

Switch `defaultBaseImage` in `.ko.yaml` to the Tekton-maintained static base image
(`ghcr.io/tektoncd/plumbing/static-base`), built and published from
[tektoncd/plumbing](https://github.com/tektoncd/plumbing/tree/main/tekton/images/static-base).

This image:
- Supports all four target architectures (amd64, arm64, s390x, ppc64le)
- Is rebuilt daily from Alpine packages via apko
- Includes CA certs, timezone data, and nonroot user (UID 65532)
- Is ~300KB per arch

Related: tektoncd/pipeline#9557, tektoncd/plumbing#3434

Replaces `cgr.dev/chainguard/static`. OpenShift image overrides (UBI) are unchanged.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow commit message best practices

/kind cleanup

# Release Notes

```release-note
NONE
```