### PR TITLE
fix(helm): fix appVersion prefix and k8s min version handling

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -29,12 +29,14 @@ jobs:
 
       - name: Update Chart version with release tag
         run: |
-          # Extract tag name, stripping leading 'v' (e.g. v0.79.0 -> 0.79.0)
+          # Extract tag name (e.g. v0.80.0) and chart version without leading 'v' (e.g. 0.80.0).
+          # chart 'version' follows plain semver (no 'v' prefix).
+          # chart 'appVersion' must match the container image tag which carries the 'v' prefix.
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           sed -i "s/^version: \"devel\"/version: \"${VERSION}\"/" charts/tekton-operator/Chart.yaml
-          sed -i "s/^appVersion: \"devel\"/appVersion: \"${VERSION}\"/" charts/tekton-operator/Chart.yaml
-          echo "Updated Chart.yaml to version ${VERSION}"
+          sed -i "s/^appVersion: \"devel\"/appVersion: \"${TAG}\"/" charts/tekton-operator/Chart.yaml
+          echo "Updated Chart.yaml: chart version=${VERSION}, appVersion=${TAG}"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0

--- a/charts/tekton-operator/templates/_helpers.tpl
+++ b/charts/tekton-operator/templates/_helpers.tpl
@@ -135,6 +135,13 @@ tekton-operator
 {{- end -}}
 
 
+{{- define "tekton-operator.kubernetesMinVersionEnv" -}}
+{{- if .Values.kubernetesMinVersion }}
+- name: KUBERNETES_MIN_VERSION
+  value: {{ .Values.kubernetesMinVersion | quote }}
+{{- end }}
+{{- end }}
+
 {{- define "tekton-operator.webhook-proxy-image" -}}
 {{- $tag := default .Chart.AppVersion .Values.webhookProxy.image.tag -}}
 {{- $image := "" -}}

--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
               {{- end }}
             - name: CONFIG_OBSERVABILITY_NAME
               value: {{ include "tekton-operator.fullname" . }}-observability
+            {{- include "tekton-operator.kubernetesMinVersionEnv" . | nindent 12 }}
             {{- range .Values.operator.additionalEnvs }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -127,6 +128,11 @@ spec:
               {{- end }}
             - name: CONFIG_OBSERVABILITY_NAME
               value: {{ include "tekton-operator.fullname" . }}-observability
+            {{- include "tekton-operator.kubernetesMinVersionEnv" . | nindent 12 }}
+            {{- range .Values.operator.additionalEnvs }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
           args:
             - "-controllers"
             - "tektoninstallerset"
@@ -213,6 +219,11 @@ spec:
               value: {{ .Values.webhook.httpsWebhookPort | quote }}
             - name: METRICS_DOMAIN
               value: {{ .Values.service.metricsDomain }}
+            {{- include "tekton-operator.kubernetesMinVersionEnv" . | nindent 12 }}
+            {{- range .Values.webhook.additionalEnvs }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
           image: {{ include "tekton-operator.webhook-image" . }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           name: {{ include "tekton-operator.operator-name" . -}}-webhook

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -82,7 +82,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -146,7 +145,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for ManualApprovalGate
@@ -282,7 +280,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -320,7 +317,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -389,7 +385,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               version:
                 description: The version of the installed release
@@ -524,7 +519,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -724,7 +718,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -749,7 +742,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -874,7 +866,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonChain
@@ -1185,7 +1176,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1210,7 +1200,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -1321,7 +1310,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -1365,7 +1353,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1409,7 +1396,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1461,7 +1447,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1567,7 +1552,6 @@ spec:
                   keep-pod-on-cancel:
                     type: boolean
                   max-result-size:
-                    format: int32
                     type: integer
                   metrics.count.enable-reason:
                     type: boolean
@@ -1607,7 +1591,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1644,7 +1627,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -1756,7 +1738,6 @@ spec:
                                         of side effects a webhook may have.
                                       type: string
                                     timeoutSeconds:
-                                      format: int32
                                       type: integer
                                   type: object
                                 type: object
@@ -1846,7 +1827,6 @@ spec:
                                         of side effects a webhook may have.
                                       type: string
                                     timeoutSeconds:
-                                      format: int32
                                       type: integer
                                   type: object
                                 type: object
@@ -1909,7 +1889,6 @@ spec:
                     description: |-
                       Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
                       Missed jobs executions will be counted as failed ones.
-                    format: int64
                     type: integer
                 required:
                 - disabled
@@ -1928,7 +1907,6 @@ spec:
                   db_name:
                     type: string
                   db_port:
-                    format: int64
                     type: integer
                   db_secret_name:
                     type: string
@@ -1980,7 +1958,6 @@ spec:
                   logs_api:
                     type: boolean
                   logs_buffer_size:
-                    format: int64
                     type: integer
                   logs_path:
                     type: string
@@ -2018,7 +1995,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2043,7 +2019,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -2058,7 +2033,6 @@ spec:
                   prometheus_histogram:
                     type: boolean
                   prometheus_port:
-                    format: int64
                     type: integer
                   route_enabled:
                     description: Route configuration for Results API service exposure
@@ -2075,7 +2049,6 @@ spec:
                       pass it as environment variables to the "tekton-results-api" deployment under "api" container
                     type: string
                   server_port:
-                    format: int64
                     type: integer
                   storage_emulator_host:
                     type: string
@@ -2133,7 +2106,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2197,7 +2169,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2245,7 +2216,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2308,7 +2278,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               profile:
                 description: The profile installed
@@ -2423,7 +2392,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -2463,7 +2431,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -2532,7 +2499,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonDashboard
@@ -2690,7 +2656,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -2793,7 +2758,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               uiUrl:
                 description: The URL route for UI which needs to be exposed
@@ -2914,7 +2878,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
             type: object
         type: object
@@ -3028,7 +2991,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3111,7 +3073,6 @@ spec:
               keep-pod-on-cancel:
                 type: boolean
               max-result-size:
-                format: int32
                 type: integer
               metrics.count.enable-reason:
                 type: boolean
@@ -3151,7 +3112,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3188,7 +3148,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -3291,7 +3250,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonPipeline
@@ -3405,7 +3363,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3422,7 +3379,6 @@ spec:
               db_name:
                 type: string
               db_port:
-                format: int64
                 type: integer
               db_secret_name:
                 type: string
@@ -3474,7 +3430,6 @@ spec:
               logs_api:
                 type: boolean
               logs_buffer_size:
-                format: int64
                 type: integer
               logs_path:
                 type: string
@@ -3512,7 +3467,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3537,7 +3491,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -3552,7 +3505,6 @@ spec:
               prometheus_histogram:
                 type: boolean
               prometheus_port:
-                format: int64
                 type: integer
               route_enabled:
                 description: Route configuration for Results API service exposure
@@ -3569,7 +3521,6 @@ spec:
                   pass it as environment variables to the "tekton-results-api" deployment under "api" container
                 type: string
               server_port:
-                format: int64
                 type: integer
               storage_emulator_host:
                 type: string
@@ -3636,7 +3587,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonResult
@@ -3746,7 +3696,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3791,7 +3740,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3856,7 +3804,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name
@@ -3965,7 +3912,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -4008,7 +3954,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4074,7 +4019,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonPruner
@@ -4184,7 +4128,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4252,7 +4195,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tekton-scheduler:
                 description: The current installer set name for TektonScheduler
@@ -4348,7 +4290,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4413,7 +4354,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonMulticlusterProxyAAE
@@ -4523,7 +4463,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -4561,7 +4500,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4623,7 +4561,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               syncerServiceInstallerSet:
                 description: The current installer set name for SyncerService

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -82,7 +82,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -146,7 +145,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for ManualApprovalGate
@@ -282,7 +280,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -320,7 +317,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -389,7 +385,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               version:
                 description: The version of the installed release
@@ -496,7 +491,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -585,7 +579,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               version:
                 description: The version of the installed release
@@ -720,7 +713,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -920,7 +912,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -945,7 +936,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -1070,7 +1060,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonChain
@@ -1381,7 +1370,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1406,7 +1394,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -1517,7 +1504,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -1561,7 +1547,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1605,7 +1590,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1657,7 +1641,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1763,7 +1746,6 @@ spec:
                   keep-pod-on-cancel:
                     type: boolean
                   max-result-size:
-                    format: int32
                     type: integer
                   metrics.count.enable-reason:
                     type: boolean
@@ -1803,7 +1785,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -1840,7 +1821,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -1952,7 +1932,6 @@ spec:
                                         of side effects a webhook may have.
                                       type: string
                                     timeoutSeconds:
-                                      format: int32
                                       type: integer
                                   type: object
                                 type: object
@@ -2042,7 +2021,6 @@ spec:
                                         of side effects a webhook may have.
                                       type: string
                                     timeoutSeconds:
-                                      format: int32
                                       type: integer
                                   type: object
                                 type: object
@@ -2105,7 +2083,6 @@ spec:
                     description: |-
                       Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
                       Missed jobs executions will be counted as failed ones.
-                    format: int64
                     type: integer
                 required:
                 - disabled
@@ -2124,7 +2101,6 @@ spec:
                   db_name:
                     type: string
                   db_port:
-                    format: int64
                     type: integer
                   db_secret_name:
                     type: string
@@ -2176,7 +2152,6 @@ spec:
                   logs_api:
                     type: boolean
                   logs_buffer_size:
-                    format: int64
                     type: integer
                   logs_path:
                     type: string
@@ -2214,7 +2189,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2239,7 +2213,6 @@ spec:
                           defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                         type: number
                       replicas:
-                        format: int32
                         type: integer
                       statefulset-ordinals:
                         description: if is true, enable StatefulsetOrdinals mode
@@ -2254,7 +2227,6 @@ spec:
                   prometheus_histogram:
                     type: boolean
                   prometheus_port:
-                    format: int64
                     type: integer
                   route_enabled:
                     description: Route configuration for Results API service exposure
@@ -2271,7 +2243,6 @@ spec:
                       pass it as environment variables to the "tekton-results-api" deployment under "api" container
                     type: string
                   server_port:
-                    format: int64
                     type: integer
                   storage_emulator_host:
                     type: string
@@ -2329,7 +2300,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2393,7 +2363,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2441,7 +2410,6 @@ spec:
                                 side effects a webhook may have.
                               type: string
                             timeoutSeconds:
-                              format: int32
                               type: integer
                           type: object
                         type: object
@@ -2504,7 +2472,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               profile:
                 description: The profile installed
@@ -2667,7 +2634,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -2770,7 +2736,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               uiUrl:
                 description: The URL route for UI which needs to be exposed
@@ -2891,7 +2856,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
             type: object
         type: object
@@ -3005,7 +2969,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3088,7 +3051,6 @@ spec:
               keep-pod-on-cancel:
                 type: boolean
               max-result-size:
-                format: int32
                 type: integer
               metrics.count.enable-reason:
                 type: boolean
@@ -3128,7 +3090,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3165,7 +3126,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -3268,7 +3228,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonPipeline
@@ -3382,7 +3341,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3399,7 +3357,6 @@ spec:
               db_name:
                 type: string
               db_port:
-                format: int64
                 type: integer
               db_secret_name:
                 type: string
@@ -3451,7 +3408,6 @@ spec:
               logs_api:
                 type: boolean
               logs_buffer_size:
-                format: int64
                 type: integer
               logs_path:
                 type: string
@@ -3489,7 +3445,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3514,7 +3469,6 @@ spec:
                       defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
                     type: number
                   replicas:
-                    format: int32
                     type: integer
                   statefulset-ordinals:
                     description: if is true, enable StatefulsetOrdinals mode
@@ -3529,7 +3483,6 @@ spec:
               prometheus_histogram:
                 type: boolean
               prometheus_port:
-                format: int64
                 type: integer
               route_enabled:
                 description: Route configuration for Results API service exposure
@@ -3546,7 +3499,6 @@ spec:
                   pass it as environment variables to the "tekton-results-api" deployment under "api" container
                 type: string
               server_port:
-                format: int64
                 type: integer
               storage_emulator_host:
                 type: string
@@ -3613,7 +3565,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonResult
@@ -3723,7 +3674,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3768,7 +3718,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -3833,7 +3782,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name
@@ -3942,7 +3890,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -3985,7 +3932,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4051,7 +3997,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonPruner
@@ -4161,7 +4106,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4229,7 +4173,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tekton-scheduler:
                 description: The current installer set name for TektonScheduler
@@ -4325,7 +4268,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4390,7 +4332,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               tektonInstallerSet:
                 description: The current installer set name for TektonMulticlusterProxyAAE
@@ -4500,7 +4441,6 @@ spec:
                             of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                             it is not set, which means tolerate the taint forever (do not evict). Zero and
                             negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
                           type: integer
                         value:
                           description: |-
@@ -4538,7 +4478,6 @@ spec:
                             effects a webhook may have.
                           type: string
                         timeoutSeconds:
-                          format: int32
                           type: integer
                       type: object
                     type: object
@@ -4600,7 +4539,6 @@ spec:
                 description: |-
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
-                format: int64
                 type: integer
               syncerServiceInstallerSet:
                 description: The current installer set name for SyncerService

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -3,6 +3,12 @@
 ## Override the full name of this Helm release
 nameOverride: ""
 
+## Minimum Kubernetes version required to run the operator.
+## Mirrors the KUBERNETES_MIN_VERSION env var honored by knative/pkg.
+## Default aligns with the knative/pkg minimum vendored by this release (v1.34.0).
+## Override to a lower version (e.g. "v1.28.0") only for non-production / testing clusters.
+kubernetesMinVersion: "v1.34.0"
+
 ## Choose between the vanilla Kubernetes flavor and the Openshift flavor of this Helm chart
 ## Container images, RBAC resources and operator settings will be adjusted automatically,
 ## unless explicitly overridden by a Helm value.
@@ -71,6 +77,8 @@ webhook:
   hostNetwork: false
   dnsPolicy: ""
   httpsWebhookPort: 8443
+  # Additional environment variables for the tekton-operator-webhook container
+  additionalEnvs: []
   image:
     # Container image for Tekton operator webhook. Default value depends on the flavor (k8s/openshift).
     repository: ""

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -79,6 +79,13 @@ HEADER
   echo "  Updated: ${dest_dir}/${dest_file}"
 }
 
+# strip_int_formats removes "format: int32" and "format: int64" lines from CRD schemas.
+# Kubernetes does not recognize these OpenAPI format strings and emits warnings on apply;
+# dropping them is safe because the Kubernetes API server performs no validation based on them.
+strip_int_formats() {
+  grep -v '^\s*format: int\(32\|64\)$'
+}
+
 # assemble_helm_crds assembles a Helm chart CRD file from multiple generated CRDs
 assemble_helm_crds() {
   local output_file="$1"
@@ -89,7 +96,7 @@ assemble_helm_crds() {
   echo "${condition}" > "$output_file"
   for crd_file in "${crd_files[@]}"; do
     echo "---" >> "$output_file"
-    inject_labels "${GENERATED_DIR}/${crd_file}" | strip_leading_separator >> "$output_file"
+    inject_labels "${GENERATED_DIR}/${crd_file}" | strip_leading_separator | strip_int_formats >> "$output_file"
   done
   echo '{{- end -}}' >> "$output_file"
 


### PR DESCRIPTION
## Summary

- Fix `appVersion` in the Helm release workflow to use the full tag with `v` prefix (e.g. `v0.80.0`), so image tags resolved from `.Chart.AppVersion` match the published container images. Without this, the Helm chart pulls images tagged `0.80.0` which do not exist, causing `ImagePullBackOff` on every install.
- Expose `KUBERNETES_MIN_VERSION` as `kubernetesMinVersion` in `values.yaml` (default `v1.34.0`, aligned with vendored knative/pkg). Inject it into all three containers (`tekton-operator-lifecycle`, `tekton-operator-cluster-operations`, `webhook`) via a shared `_helpers.tpl` helper. Previously only `lifecycle` received `additionalEnvs`; the other two containers crashed on clusters below k8s 1.34.
- Strip `format: int32/int64` lines from Helm CRD templates via `sync-helm-crds.sh` to eliminate `unrecognized format` warnings from the Kubernetes API server on `helm install`.

## Test plan

- [x] `helm lint` passes with zero failures
- [x] `helm template` confirms `KUBERNETES_MIN_VERSION: v1.34.0` injected in all three containers
- [x] Install on **kind k8s 1.34** with defaults — all pods `Running`, zero warnings
- [x] Install on **kind k8s 1.32** with defaults — expected version error confirmed
- [x] Install on **kind k8s 1.32** with `--set kubernetesMinVersion=v1.32.0` — all pods `Running`
- [x] No `unrecognized format "int32/int64"` warnings on CRD apply

Fixes #3482
Fixes #3483

Made with [Cursor](https://cursor.com)