### PR TITLE
feat(helm): publish chart to OCI registry on release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -8,6 +8,7 @@ jobs:
   release:
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
@@ -37,8 +38,25 @@ jobs:
           sed -i "s/^version: \"devel\"/version: \"${VERSION}\"/" charts/tekton-operator/Chart.yaml
           sed -i "s/^appVersion: \"devel\"/appVersion: \"${TAG}\"/" charts/tekton-operator/Chart.yaml
           echo "Updated Chart.yaml: chart version=${VERSION}, appVersion=${TAG}"
+          echo "CHART_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to OCI registry
+        run: |
+          helm package charts/tekton-operator \
+            --version "${CHART_VERSION}" \
+            --destination /tmp/
+          helm push "/tmp/tekton-operator-${CHART_VERSION}.tgz" \
+            oci://ghcr.io/tektoncd/operator/charts
+          echo "Pushed ghcr.io/tektoncd/operator/charts/tekton-operator:${CHART_VERSION}"


### PR DESCRIPTION
## Summary

- Add OCI publishing step to the `helm-release` workflow so the Tekton Operator Helm chart is available at `oci://ghcr.io/tektoncd/operator/charts/tekton-operator` on every release, in addition to the existing GitHub Pages Helm repository.
- Adds `packages: write` permission to the job.
- Uses `docker/login-action` (SHA-pinned, consistent with repo security posture) for `ghcr.io` authentication.

## Motivation

The chart is currently only distributed via `git+https://github.com/tektoncd/operator@charts?ref=main`, which Flux CD's `HelmRepository` cannot consume (it requires `https://` index or `oci://`). Users forced to use a `GitRepository` source pointing to the git tag get `version: "devel"` from the raw `Chart.yaml`, which Flux rejects as invalid semver.

Publishing to OCI allows Flux users to use the standard pattern:

```yaml
apiVersion: source.toolkit.fluxcd.io/v1beta2
kind: HelmRepository
metadata:
  name: tekton-operator
  namespace: flux-system
spec:
  type: oci
  url: oci://ghcr.io/tektoncd/operator/charts
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
spec:
  chart:
    spec:
      chart: tekton-operator
      version: "0.80.0"
```

Closes #3493

## Test plan

- [ ] Merge and cherry-pick onto `release-v0.80.x`
- [ ] Delete and recreate `v0.80.0` tag to trigger the workflow
- [ ] Verify package appears at `https://github.com/orgs/tektoncd/packages/container/package/operator%2Fcharts%2Ftekton-operator`
- [ ] Verify `helm pull oci://ghcr.io/tektoncd/operator/charts/tekton-operator --version 0.80.0` succeeds
- [ ] Verify Flux CD `HelmRepository` with `type: oci` installs successfully

Made with [Cursor](https://cursor.com)