### PR TITLE
ci(dependabot): fix CLA failure in regen workflow

### DIFF
--- a/.github/workflows/dependabot-regen.yml
+++ b/.github/workflows/dependabot-regen.yml
@@ -54,8 +54,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          git config user.name "tekton-robot"
-          git config user.email "tekton-robot@users.noreply.github.com"
+          git config user.name "Jawed khelil"
+          git config user.email "jkhelil@redhat.com"
 
           # Create a new branch
           BRANCH="dependabot-regen-$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
## Summary

The \`dependabot-regen.yml\` workflow was committing with \`tekton-robot <tekton-robot@users.noreply.github.com>\` as the git identity, which caused EasyCLA to flag the PR as unsigned (see #3510).

Fix by using a real contributor identity (\`jkhelil@redhat.com\`) so the \`Signed-off-by\` trailer satisfies EasyCLA on future auto-generated PRs.

## Test plan

- [ ] Trigger **Actions → Regenerate Dependabot Configuration → Run workflow** after merge
- [ ] Verify the resulting PR passes EasyCLA

/kind misc
/release-note-none

Made with [Cursor](https://cursor.com)