### PR TITLE
fix: options field should be optional in all components

### DIFF
--- a/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
@@ -86,8 +86,6 @@ spec:
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - options
             type: object
           status:
             description: ManualApprovalGateStatus defines the observed state of ManualApprovalGate

--- a/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -167,8 +167,6 @@ spec:
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - options
             type: object
           status:
             description: OpenShiftPipelinesAsCodeStatus defines the observed state

--- a/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
@@ -414,7 +414,6 @@ spec:
                 type: string
             required:
             - disabled
-            - options
             type: object
           status:
             description: TektonChainStatus defines the observed state of TektonChain

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -384,7 +384,6 @@ spec:
                     type: string
                 required:
                 - disabled
-                - options
                 type: object
               config:
                 description: Config holds the configuration for resources created
@@ -482,7 +481,6 @@ spec:
                       in read-only mode
                     type: boolean
                 required:
-                - options
                 - readonly
                 type: object
               hub:
@@ -533,8 +531,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - options
                 type: object
               multiclusterProxyAAE:
                 description: MulticlusterProxyAAE holds the customizable options for
@@ -573,8 +569,6 @@ spec:
                           type: object
                         type: object
                     type: object
-                required:
-                - options
                 type: object
               params:
                 description: Params is the list of params passed for all platforms
@@ -774,6 +768,13 @@ spec:
                       used.
                     type: boolean
                   send-cloudevents-for-runs:
+                    description: |-
+                      Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                      (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                      CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                      the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                      effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                      when a custom task controller already sends its own CloudEvents.
                     type: boolean
                   set-security-context:
                     type: boolean
@@ -791,8 +792,6 @@ spec:
                     type: string
                   verification-mode:
                     type: string
-                required:
-                - options
                 type: object
               platforms:
                 description: Platforms allows configuring platform specific configurations
@@ -872,8 +871,6 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                        required:
-                        - options
                         type: object
                     type: object
                   openshift:
@@ -882,14 +879,13 @@ spec:
                     properties:
                       enableCentralTLSConfig:
                         description: |-
-                          EnableCentralTLSConfig enables TLS configuration inheritance from
-                          the cluster's APIServer TLS security profile. When enabled, TLS settings
-                          (minimum version, cipher suites, curve preferences) are automatically
-                          derived from the cluster-wide security policy and injected into Tekton
-                          component containers that support TLS configuration.
-                          If the APIServer does not have a TLS profile configured, user-specified
-                          TLS settings in component configurations will be used as fallback.
-                          Default: false (opt-in)
+                          EnableCentralTLSConfig controls TLS configuration inheritance from the
+                          cluster's APIServer TLS security profile. When enabled (the default),
+                          TLS settings (minimum version, cipher suites, curve preferences) are
+                          automatically derived from the cluster-wide security policy and injected
+                          into Tekton component containers that support TLS configuration.
+                          Set to false to opt out and manage TLS settings manually.
+                          Default: true (opt-out)
                         type: boolean
                       pipelinesAsCode:
                         description: PipelinesAsCode allows configuring PipelinesAsCode
@@ -962,8 +958,6 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
-                        required:
-                        - options
                         type: object
                       scc:
                         description: SCC allows configuring security context constraints
@@ -1191,7 +1185,6 @@ spec:
                 required:
                 - disabled
                 - is_external_db
-                - options
                 type: object
               scheduler:
                 description: To enable Pipeline Scheduling on Single Cluster or Multiple
@@ -1250,7 +1243,6 @@ spec:
                 - disabled
                 - multi-cluster-disabled
                 - multi-cluster-role
-                - options
                 type: object
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
@@ -1312,7 +1304,6 @@ spec:
                 required:
                 - disabled
                 - global-config
-                - options
                 type: object
               trigger:
                 description: Trigger holds the customizable option for triggers component
@@ -1359,7 +1350,6 @@ spec:
                     type: object
                 required:
                 - disabled
-                - options
                 type: object
             type: object
           status:

--- a/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
@@ -144,7 +144,6 @@ spec:
                 description: TargetNamespace is where resources will be installed
                 type: string
             required:
-            - options
             - readonly
             type: object
           status:

--- a/config/base/generated-crds/operator.tekton.dev_tektonhubs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonhubs.yaml
@@ -170,8 +170,6 @@ spec:
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - options
             type: object
           status:
             description: TektonHubStatus defines the observed state of TektonHub

--- a/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -85,8 +85,6 @@ spec:
               targetNamespace:
                 description: TargetNamespace is where resources will be installed
                 type: string
-            required:
-            - options
             type: object
           status:
             description: TektonMulticlusterProxyAAEStatus defines the observed state

--- a/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
@@ -283,6 +283,13 @@ spec:
                 description: ScopeWhenExpressionsToTask is deprecated and never used.
                 type: boolean
               send-cloudevents-for-runs:
+                description: |-
+                  Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                  (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                  CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                  the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                  effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                  when a custom task controller already sends its own CloudEvents.
                 type: boolean
               set-security-context:
                 type: boolean
@@ -303,8 +310,6 @@ spec:
                 type: string
               verification-mode:
                 type: string
-            required:
-            - options
             type: object
           status:
             description: TektonPipelineStatus defines the observed state of TektonPipeline

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -144,7 +144,6 @@ spec:
             required:
             - disabled
             - global-config
-            - options
             type: object
           status:
             description: TektonPrunerStatus defines the observed state of TektonPruner

--- a/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
@@ -271,7 +271,6 @@ spec:
             required:
             - disabled
             - is_external_db
-            - options
             type: object
           status:
             description: TektonResultStatus defines the observed state of TektonResult

--- a/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
@@ -104,7 +104,6 @@ spec:
             - disabled
             - multi-cluster-disabled
             - multi-cluster-role
-            - options
             type: object
           status:
             description: TektonSchedulerStatus defines the observed state of TektonScheduler

--- a/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
@@ -146,7 +146,6 @@ spec:
                 type: string
             required:
             - disabled
-            - options
             type: object
           status:
             description: TektonTriggerStatus defines the observed state of TektonTrigger

--- a/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
+++ b/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
@@ -52,6 +52,7 @@ type ManualApprovalGateSpec struct {
 
 type ManualApproval struct {
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
@@ -81,6 +81,7 @@ type PACSettings struct {
 	// +optional
 	AdditionalPACControllers map[string]AdditionalPACControllerConfig `json:"additionalPACControllers,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/syncerservice_types.go
+++ b/pkg/apis/operator/v1alpha1/syncerservice_types.go
@@ -67,6 +67,7 @@ type SyncerServiceSpec struct {
 // SyncerServiceOptions defines the fields to customize SyncerService component
 type SyncerServiceOptions struct {
 	// Options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options,omitempty"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -79,6 +79,7 @@ type Chain struct {
 	ChainProperties `json:",inline"`
 	ControllerEnvs  []corev1.EnvVar `json:"controllerEnvs,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektondashboard_types.go
+++ b/pkg/apis/operator/v1alpha1/tektondashboard_types.go
@@ -90,6 +90,7 @@ type TektonDashboardList struct {
 type Dashboard struct {
 	DashboardProperties `json:",inline"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonhub_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonhub_types.go
@@ -70,6 +70,7 @@ type Hub struct {
 	// +optional
 	Params []Param `json:"params,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
@@ -52,6 +52,7 @@ type TektonMulticlusterProxyAAESpec struct {
 
 type MulticlusterProxyAAEOptions struct {
 	// options holds additional fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_types.go
@@ -90,6 +90,7 @@ type Pipeline struct {
 	// +optional
 	Params []Param `json:"params,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -57,6 +57,7 @@ type Pruner struct {
 	TektonPrunerConfig `json:",inline"`
 
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -78,6 +78,7 @@ type Result struct {
 	// LokiStackProperties holds configuration for LokiStack
 	LokiStackProperties `json:",inline"`
 	// Options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 	// +optional
 	Performance PerformanceProperties `json:"performance,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
@@ -52,6 +52,7 @@ type Scheduler struct {
 	SchedulerConfig    `json:",inline"`
 	MultiClusterConfig `json:",inline"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektontrigger_types.go
+++ b/pkg/apis/operator/v1alpha1/tektontrigger_types.go
@@ -87,6 +87,7 @@ type Trigger struct {
 	Disabled           bool `json:"disabled"`
 	TriggersProperties `json:",inline"`
 	// options holds additions fields and these fields will be updated on the manifests
+	// +optional
 	Options AdditionalOptions `json:"options"`
 }
 


### PR DESCRIPTION
# Changes
A recent change where we replaced the manual CRDs with OpenAPI generated CRDs made options field mandatory for components.

Historically this field is optional and was never enforced in CRD but openAPI generated CRDs made this field mandatory as there  no '+optional' Directive on this field.

This PR adds the '+optional directive on this field so generated CRDs keep this field optional.
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
