### PR TITLE
ci(dependabot): remove unsupported cooldown fields from github-actions

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -39,9 +39,6 @@ ecosystems:
       - release-note-none
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,6 @@ updates:
         - release-note-none
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       schedule:
@@ -60,9 +57,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.80.x
@@ -106,9 +100,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.79.x
@@ -152,9 +143,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.78.x
@@ -198,9 +186,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.77.x
@@ -244,9 +229,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.76.x
@@ -290,9 +272,6 @@ updates:
             - version-update:semver-minor
       cooldown:
         default-days: 7
-        semver-major-days: 30
-        semver-minor-days: 7
-        semver-patch-days: 3
     - package-ecosystem: gomod
       directory: /
       target-branch: release-v0.75.x


### PR DESCRIPTION
## Summary

The \`semver-major-days\`, \`semver-minor-days\` and \`semver-patch-days\` cooldown fields are not supported for the \`github-actions\` ecosystem, causing Dependabot validation errors on every entry:

\`\`\`
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
\`\`\`

These fields are semver-specific and only valid for package managers like \`gomod\`. GitHub Actions uses git tags/SHAs, not semver.

Fix by keeping only \`default-days\` in the \`github-actions\` ecosystem cooldown config and regenerating \`dependabot.yml\`.

## Test plan
- [ ] Verify no Dependabot configuration errors after merge

/kind misc
/release-note-none

Made with [Cursor](https://cursor.com)