### PR TITLE
fix(helm): add openshift-pipelines.org RBAC to kubernetes chart

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-rbac.yaml
+++ b/charts/tekton-operator/templates/kubernetes-rbac.yaml
@@ -436,6 +436,21 @@ rules:
       - delete
       - update
       - patch
+  - apiGroups:
+      - openshift-pipelines.org
+    resources:
+      - approvaltasks
+      - approvaltasks/status
+    verbs:
+      - add
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - patch
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
# Changes

The Helm chart's `kubernetes-rbac.yaml` was missing permissions for the
`openshift-pipelines.org` API group (`approvaltasks` resources) in the
operator's `ClusterRole`. This caused an RBAC escalation error when
creating a `ManualApprovalGate` CR on Kubernetes:

```
clusterroles.rbac.authorization.k8s.io "manual-approval-gate-controller-cluster-access"
is forbidden: user "system:serviceaccount:tekton-operator:tekton-operator"
is attempting to grant RBAC permissions not currently held:
{APIGroups:["openshift-pipelines.org"], Resources:["approvaltasks"], ...}
```

Kubernetes prevents a subject from granting permissions it does not already
hold. The operator's service account was missing the `openshift-pipelines.org`
rule, so it could not create the `ClusterRole` required by ManualApprovalGate.

The kustomize base (`config/base/role.yaml`) and the OperatorHub CSV already
had these permissions — only the Helm chart was missing them.

Fixes #3519

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix ManualApprovalGate installation failure on Kubernetes when using the
Helm chart. The operator ClusterRole was missing openshift-pipelines.org
RBAC permissions required to create the ManualApprovalGate controller
ClusterRole.
```

Made with [Cursor](https://cursor.com)