### PR TITLE
fix(manualapprovalgate): inject TLS env vars into MAG webhook

### DIFF
--- a/pkg/reconciler/openshift/manualapprovalgate/extension.go
+++ b/pkg/reconciler/openshift/manualapprovalgate/extension.go
@@ -21,38 +21,71 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/client/clientset/versioned"
-	operatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
+	tektonConfiginformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonconfig"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	"knative.dev/pkg/logging"
+)
+
+const (
+	// magWebhookDeployment is the name of the MAG webhook Deployment as defined in
+	// the upstream manual-approval-gate config (config/kubernetes/500-webhook.yaml).
+	magWebhookDeployment = "manual-approval-gate-webhook"
+	// magWebhookContainerName is the container name inside the MAG webhook Deployment.
+	magWebhookContainerName = "manual-approval"
 )
 
 func OpenShiftExtension(ctx context.Context) common.Extension {
-	ext := openshiftExtension{
-		operatorClientSet: operatorclient.Get(ctx),
+	return &openshiftExtension{
+		tektonConfigLister: tektonConfiginformer.Get(ctx).Lister(),
 	}
-	return ext
 }
 
 type openshiftExtension struct {
-	operatorClientSet versioned.Interface
+	tektonConfigLister occommon.TektonConfigLister
+	resolvedTLSConfig  *occommon.TLSEnvVars
 }
 
-func (oe openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
-	return []mf.Transformer{}
+func (oe *openshiftExtension) Transformers(comp v1alpha1.TektonComponent) []mf.Transformer {
+	var trns []mf.Transformer
+
+	// Inject APIServer TLS profile env vars into the MAG webhook so that it
+	// applies the cluster-wide TLS version and cipher suite policy (PQC readiness).
+	// The MAG webhook uses the Knative webhook framework (sharedmain.MainWithConfig),
+	// which calls knativetls.DefaultConfigFromEnv("WEBHOOK_"), so it reads the
+	// WEBHOOK_TLS_* env vars.
+	if oe.resolvedTLSConfig != nil {
+		trns = append(trns,
+			occommon.InjectTLSEnvVars(oe.resolvedTLSConfig, "Deployment", magWebhookDeployment, []string{magWebhookContainerName}, occommon.WebhookEnvVarPrefix),
+		)
+	}
+
+	return trns
 }
 
-func (oe openshiftExtension) PreReconcile(ctx context.Context, mag v1alpha1.TektonComponent) error {
+func (oe *openshiftExtension) PreReconcile(ctx context.Context, _ v1alpha1.TektonComponent) error {
+	logger := logging.FromContext(ctx)
+
+	resolvedTLS, err := occommon.ResolveCentralTLSToEnvVars(ctx, oe.tektonConfigLister)
+	if err != nil {
+		return err
+	}
+	oe.resolvedTLSConfig = resolvedTLS
+	if oe.resolvedTLSConfig != nil {
+		logger.Infof("Injecting central TLS config into MAG webhook: MinVersion=%s", oe.resolvedTLSConfig.MinVersion)
+	}
+
 	return nil
 }
 
-func (oe openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
+func (oe *openshiftExtension) PostReconcile(context.Context, v1alpha1.TektonComponent) error {
 	return nil
 }
 
-func (oe openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
+func (oe *openshiftExtension) Finalize(context.Context, v1alpha1.TektonComponent) error {
 	return nil
 }
 
-func (oe openshiftExtension) GetPlatformData() string {
+func (oe *openshiftExtension) GetPlatformData() string {
 	return ""
 }

--- a/pkg/reconciler/openshift/manualapprovalgate/extension_test.go
+++ b/pkg/reconciler/openshift/manualapprovalgate/extension_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manualapprovalgate
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	occommon "github.com/tektoncd/operator/pkg/reconciler/openshift/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// makeMAGDeployment returns an unstructured MAG Deployment for transformer tests.
+func makeMAGDeployment(t *testing.T, deploymentName, containerName string) unstructured.Unstructured {
+	t.Helper()
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: "openshift-pipelines",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: containerName},
+					},
+				},
+			},
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+	if err != nil {
+		t.Fatalf("failed to convert deployment to unstructured: %v", err)
+	}
+	u := unstructured.Unstructured{Object: obj}
+	u.SetKind("Deployment")
+	u.SetAPIVersion("apps/v1")
+	return u
+}
+
+func makeMAGWebhookDeployment(t *testing.T) unstructured.Unstructured {
+	t.Helper()
+	return makeMAGDeployment(t, magWebhookDeployment, magWebhookContainerName)
+}
+
+func TestMAGTransformers_NoTLSConfig(t *testing.T) {
+	ext := &openshiftExtension{
+		resolvedTLSConfig: nil,
+	}
+
+	transformers := ext.Transformers(&v1alpha1.ManualApprovalGate{})
+
+	u := makeMAGWebhookDeployment(t)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != magWebhookContainerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s set when resolvedTLSConfig is nil", e.Name)
+			}
+		}
+	}
+}
+
+func TestMAGTransformers_WithTLSConfig_InjectsEnvVarsIntoWebhook(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.2",
+		CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_128_GCM_SHA256",
+	}
+	// MAG webhook uses the Knative webhook framework → reads WEBHOOK_TLS_* env vars.
+	assertMAGTLSInjected(t, &openshiftExtension{resolvedTLSConfig: tlsConfig}, magWebhookDeployment, magWebhookContainerName, occommon.WebhookEnvVarPrefix, tlsConfig)
+}
+
+func TestMAGTransformers_WithTLSConfig_DoesNotInjectIntoUnknownDeployment(t *testing.T) {
+	tlsConfig := &occommon.TLSEnvVars{
+		MinVersion:   "1.3",
+		CipherSuites: "TLS_AES_128_GCM_SHA256",
+	}
+	ext := &openshiftExtension{resolvedTLSConfig: tlsConfig}
+	transformers := ext.Transformers(&v1alpha1.ManualApprovalGate{})
+
+	// An unrelated deployment must not receive TLS env vars.
+	u := makeMAGDeployment(t, "some-other-deployment", "some-container")
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+	transformed, err := manifest.Transform(transformers...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	result := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, result); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+	for _, c := range result.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == occommon.TLSMinVersionEnvVar || e.Name == occommon.TLSCipherSuitesEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSMinVersionEnvVar ||
+				e.Name == occommon.WebhookEnvVarPrefix+occommon.TLSCipherSuitesEnvVar {
+				t.Errorf("unexpected TLS env var %s injected into unrelated deployment", e.Name)
+			}
+		}
+	}
+}
+
+// assertMAGTLSInjected runs the Transformers against a single-resource manifest and
+// checks that TLS env vars are present in the named container.
+func assertMAGTLSInjected(t *testing.T, ext *openshiftExtension, deploymentName, containerName, envVarPrefix string, tlsConfig *occommon.TLSEnvVars) {
+	t.Helper()
+
+	u := makeMAGDeployment(t, deploymentName, containerName)
+	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{u}))
+	if err != nil {
+		t.Fatalf("failed to build manifest: %v", err)
+	}
+
+	transformed, err := manifest.Transform(ext.Transformers(&v1alpha1.ManualApprovalGate{})...)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+
+	d := &appsv1.Deployment{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(transformed.Resources()[0].Object, d); err != nil {
+		t.Fatalf("failed to convert back: %v", err)
+	}
+
+	envMap := map[string]string{}
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != containerName {
+			continue
+		}
+		for _, e := range c.Env {
+			envMap[e.Name] = e.Value
+		}
+	}
+
+	minVersionKey := envVarPrefix + occommon.TLSMinVersionEnvVar
+	cipherSuitesKey := envVarPrefix + occommon.TLSCipherSuitesEnvVar
+
+	if got := envMap[minVersionKey]; got != tlsConfig.MinVersion {
+		t.Errorf("[%s/%s] %s = %q, want %q", deploymentName, containerName, minVersionKey, got, tlsConfig.MinVersion)
+	}
+	if got := envMap[cipherSuitesKey]; got != tlsConfig.CipherSuites {
+		t.Errorf("[%s/%s] %s = %q, want %q", deploymentName, containerName, cipherSuitesKey, got, tlsConfig.CipherSuites)
+	}
+}


### PR DESCRIPTION
# Changes

The Manual Approval Gate (MAG) webhook deployment (`manual-approval-gate-webhook`) was not receiving TLS environment variables (`WEBHOOK_TLS_MIN_VERSION`, `WEBHOOK_TLS_CIPHER_SUITES`, `WEBHOOK_TLS_CURVE_PREFERENCES`) from the operator, making it inconsistent with all other Tekton webhook components.

## Root Cause

The OpenShift extension for `manualapprovalgate` (`pkg/reconciler/openshift/manualapprovalgate/extension.go`) had an empty stub implementation — no TLS profile resolution, no transformers — while all other webhook components (operator-webhook, pipelines-webhook, triggers-webhook, pac-webhook) were already covered by the SRVKP-9462 epic.

## Fix

Updated the MAG OpenShift extension to follow the same pattern used by PAC and Triggers:

- `PreReconcile` now calls `occommon.ResolveCentralTLSToEnvVars` to fetch the cluster TLS profile from the shared APIServer lister
- `Transformers` now calls `occommon.InjectTLSEnvVars` with `WebhookEnvVarPrefix` (`WEBHOOK_`) for the `manual-approval-gate-webhook` deployment / `manual-approval` container
- The `WEBHOOK_` prefix is required because the MAG webhook uses the Knative webhook framework (`sharedmain.MainWithConfig`), which reads `WEBHOOK_TLS_*` env vars

**Files changed:**
- `pkg/reconciler/openshift/manualapprovalgate/extension.go`: Add TLS injection following PAC/Triggers pattern
- `pkg/reconciler/openshift/manualapprovalgate/extension_test.go`: Add unit tests (no TLS config, inject into webhook, do not inject into unrelated deployments)

Fixes SRVKP-12613

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix Manual Approval Gate webhook not receiving cluster TLS configuration
(TLS_MIN_VERSION, TLS_CIPHER_SUITES, TLS_CURVE_PREFERENCES), making it
consistent with all other Tekton webhook components.
```

Made with [Cursor](https://cursor.com)