### PR TITLE
fix: resolve manifest list digest instead of platform-specific digest

### DIFF
--- a/hack/openshift/update-image-sha.sh
+++ b/hack/openshift/update-image-sha.sh
@@ -26,10 +26,10 @@ find_latest_version() {
   echo "$version"
 }
 
-# Get SHA digest for an image:tag
-get_image_sha() {
+# Get manifest list digest for an image:tag (multi-arch)
+get_manifest_list_digest() {
   local image_url=$1
-  skopeo inspect --raw docker://${image_url} | jq -r '.manifests[0].digest // .digest'
+  skopeo inspect --no-tags docker://${image_url} | jq -r '.Digest'
 }
 
 # Update image SHA in YAML files
@@ -59,7 +59,7 @@ main() {
     echo "  Latest version: $latest_version"
 
     image_url="${image_registry}:${latest_version}"
-    image_sha=$(get_image_sha "$image_url")
+    image_sha=$(get_manifest_list_digest "$image_url")
     echo "  SHA: $image_sha"
 
     update_yaml_files "$image_registry" "$image_sha"


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fix `get_image_sha()` in `hack/openshift/update-image-sha.sh` to resolve the manifest list digest instead of a platform-specific digest.
The function was using `.manifests[0].digest` which picks the first platform entry (amd64), causing the operator CSV to pin task images (buildah, s2i, skopeo,ubi-minimal) to amd64-only digests. This breaks ARM64/multi-arch clusters with `exec format error`.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
