### PR TITLE
ci(e2e): fix ko >=v0.19 SBOM push failure on plain-HTTP registry

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -29,6 +29,9 @@ jobs:
           k8s-version: v1.34.x
     env:
       KO_DOCKER_REPO: registry.local:5000/tekton
+      # registry.local:5000 is a plain-HTTP KinD registry; tell ko to skip TLS
+      # so that both image pushes and SBOM writes (ko >=v0.19) use plain HTTP.
+      KO_FLAGS: --insecure-registry
       CLUSTER_DOMAIN: c${{ github.run_id }}.local
       ARTIFACTS: ${{ github.workspace }}/artifacts
 


### PR DESCRIPTION
# Changes

ko v0.19 unconditionally attempts HTTPS when writing SBOMs, which causes
the E2E job to fail with:

```
http: server gave HTTP response to HTTPS client
```

against the plain-HTTP KinD registry (`registry.local:5000`).

**Root cause**: `ko-build/setup-ko` (without a pinned `version:`) picked up
ko v0.19.1, which introduced mandatory SBOM writes via cosign. cosign uses
HTTPS by default and has no knowledge that `registry.local:5000` is a plain
HTTP endpoint, so every SBOM push fails.

**Fix**: set `KO_FLAGS=--insecure-registry` in the `e2e-matrix.yml` job env.
This flag is already forwarded to `ko apply` via `$(KO_FLAGS)` in the
Makefile `apply` target — no Makefile change is required. The flag is scoped
to the CI job only; local `make apply` against production registries (quay.io,
ghcr.io) is unaffected.

The fix was verified locally by reproducing the failure against a custom-hostname
plain-HTTP registry and confirming success with the flag set.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)