### PR TITLE
ci: add CI summary job to release-v0.75.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,30 +16,86 @@ defaults:
 
 permissions:
   contents: read
-  checks: write # Used to annotate code in the PR
+  checks: write  # Used to annotate code in the PR
 
 jobs:
+  changes:
+    name: categorize changes
+    runs-on: ubuntu-latest
+    outputs:
+      non-docs: ${{ steps.detect.outputs.non-docs }}
+      yaml: ${{ steps.detect.outputs.yaml }}
+    steps:
+    - name: Get base depth
+      id: base-depth
+      run: echo "base-depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
+    - name: detect
+      id: detect
+      run: |
+        git fetch origin ${{ github.base_ref }}
+
+        # Store git diff command for reuse
+        GIT_DIFF_CMD="git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+
+        # Disable pipefail to avoid SIGPIPE (exit 141) when commands like head/grep exit early
+        # SIGPIPE occurs when git diff tries to write but the reading end of the pipe has closed
+        set +o pipefail
+
+        # Show changed files for debugging (limit to first 50 for readability)
+        echo "Changed files (first 50):"
+        $GIT_DIFF_CMD | head -50
+        FILE_COUNT=$($GIT_DIFF_CMD | wc -l)
+        echo "Total files changed: $FILE_COUNT"
+
+        # If no files are changed at all, skip detection
+        # Use git diff output directly to avoid bash variable size limits with large PRs
+        if [[ $FILE_COUNT -gt 0 ]]; then
+          # We only care about grep's exit status (did it find matches?), not the pipe status
+          NON_DOCS=$($GIT_DIFF_CMD | grep -Ev '\.md$' > /dev/null && echo 'true' || echo 'false')
+          YAML=$($GIT_DIFF_CMD | grep -E '\.ya?ml$' > /dev/null && echo 'true' || echo 'false')
+          echo "non-docs=${NON_DOCS}" | tee -a $GITHUB_OUTPUT
+          echo "yaml=${YAML}" | tee -a $GITHUB_OUTPUT
+        fi
+
+        # Re-enable pipefail for subsequent commands
+        set -o pipefail
+
   build:
     name: build
+    needs: [changes]
     runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.non-docs == 'true' }}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
     - name: build
       run: |
         go build -v ./...
   linting:
-    needs: [build]
+    needs: [changes]
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
     - name: gofmt
+      if: ${{ needs.changes.outputs.non-docs == 'true' }}
       run: |
         gofmt_out=$(gofmt -d $(find * -name '*.go' ! -path 'vendor/*' ! -path 'third_party/*'))
         if [[ -n "$gofmt_out" ]]; then
@@ -47,16 +103,19 @@ jobs:
         fi
         echo "$gofmt_out"
     - name: golangci-lint
+      if: ${{ needs.changes.outputs.non-docs == 'true' }}
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837  # v6.5.0
       with:
         version: v1.63.4
         only-new-issues: true
         args: --timeout=10m
     - name: yamllint
+      if: ${{ needs.changes.outputs.yaml == 'true' }}
       run: |
         apt update && apt install -y yamllint
         yamllint -c .yamllint $(find . -path ./vendor -prune -o -type f -regex ".*y[a]ml" -print | tr '\n' ' ')
     - name: check-license
+      if: ${{ needs.changes.outputs.non-docs == 'true' }}
       run: |
         go install github.com/google/go-licenses@v1.0.0
         go-licenses check ./...
@@ -65,10 +124,13 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
     - name: build
       run: |
         make test-unit-verbose-and-race
@@ -77,10 +139,13 @@ jobs:
     name: Check generated code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
     - name: generated
       run: |
         ./hack/verify-codegen.sh
@@ -89,11 +154,14 @@ jobs:
     name: Multi-arch build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
-    - uses: ko-build/setup-ko@v0.8
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
     - name: ko-resolve
       run: |
           cat <<EOF > .ko.yaml
@@ -104,8 +172,39 @@ jobs:
             github.com/tektoncd/operator/cmd/openshift/proxy-webhook: registry.access.redhat.com/ubi9/ubi-minimal
           EOF
 
-          KO_DOCKER_REPO=example.com make TARGET=kubernetes resolve
-          KO_DOCKER_REPO=example.com make TARGET=openshift resolve
+          # Use ko from setup-ko action to avoid Go version mismatch
+          KO_BIN=$(which ko) KO_DOCKER_REPO=example.com make TARGET=kubernetes resolve
+          KO_BIN=$(which ko) KO_DOCKER_REPO=example.com make TARGET=openshift resolve
   e2e-tests:
     needs: [build]
     uses: ./.github/workflows/e2e-matrix.yml
+  ci-summary:
+    name: CI summary
+    needs: [build, linting, tests, generated, multi-arch-build, e2e-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - name: Check CI results
+      run: |
+        results=(
+          "build=${{ needs.build.result }}"
+          "linting=${{ needs.linting.result }}"
+          "tests=${{ needs.tests.result }}"
+          "generated=${{ needs.generated.result }}"
+          "multi-arch-build=${{ needs.multi-arch-build.result }}"
+          "e2e-tests=${{ needs.e2e-tests.result }}"
+        )
+        failed=0
+        for r in "${results[@]}"; do
+          name="${r%%=*}"
+          result="${r#*=}"
+          echo "${name}: ${result}"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            failed=1
+          fi
+        done
+        if [ "$failed" -eq 1 ]; then
+          echo ""
+          echo "Some CI jobs failed or were cancelled"
+          exit 1
+        fi

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,7 +1,8 @@
 name: Tekton Integration
 # Adapted from https://github.com/mattmoor/mink/blob/master/.github/workflows/minkind.yaml
 
-on: [workflow_call]
+on:
+  - workflow_call
 
 defaults:
   run:
@@ -15,28 +16,34 @@ jobs:
     name: e2e tests
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # Keep running if one leg fails.
+      fail-fast: false  # Keep running if one leg fails.
       matrix:
         k8s-name:
         - k8s-oldest
-        - k8s-plus-one
+        - k8s-latest
 
         include:
         - k8s-name: k8s-oldest
           k8s-version: v1.28.x
-        - k8s-name: k8s-plus-one
+        - k8s-name: k8s-latest
           k8s-version: v1.29.x
     env:
       KO_DOCKER_REPO: registry.local:5000/tekton
+      # registry.local:5000 is a plain-HTTP KinD registry; tell ko to skip TLS
+      # so that both image pushes and SBOM writes (ko >=v0.19) use plain HTTP.
+      KO_FLAGS: --insecure-registry
       CLUSTER_DOMAIN: c${{ github.run_id }}.local
       ARTIFACTS: ${{ github.workspace }}/artifacts
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
       with:
         go-version-file: "go.mod"
-    - uses: ko-build/setup-ko@v0.8
+        check-latest: true
+      env:
+        GOTOOLCHAIN: auto
+    - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
 
     - name: Install Dependencies
       working-directory: ./
@@ -62,12 +69,12 @@ jobs:
           --e2e-env ./test/e2e-tests-kind.env
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
       with:
         name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}
         path: ${{ env.ARTIFACTS }}
 
-    - uses: chainguard-dev/actions/kind-diag@main
+    - uses: chainguard-dev/actions/kind-diag@7d647f470c4d3692286221bd17ca78206976a61c  # v1.5.11
       if: ${{ failure() }}
       with:
         artifact-name: ${{ matrix.k8s-version }}-${{ matrix.feature-flags }}-logs


### PR DESCRIPTION
# Changes

Add the `CI summary` aggregation job to the CI workflow on `release-v0.75.x`.

This required status check is configured in branch protection but does not
exist on this release branch, so any PR targeting it (notably dependabot
updates) is permanently blocked in tide waiting for a check that never
reports. This job mirrors the one already present on `release-v0.77.x` and
newer branches.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```