### PR TITLE
ci(dependabot): group GitHub Actions updates into a single PR

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -37,6 +37,13 @@ ecosystems:
       - github_action
       - kind/misc
       - release-note-none
+    groups:
+      # Collapse all GitHub Actions bumps into a single weekly PR per branch.
+      # These are low-risk version bumps and were previously opened one PR per
+      # action, flooding the queue (especially on release branches).
+      github-actions:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
   - package-ecosystem: gomod

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         - github_action
         - kind/misc
         - release-note-none
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -55,6 +59,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -98,6 +106,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -141,6 +153,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -184,6 +200,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -227,6 +247,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod
@@ -270,6 +294,10 @@ updates:
           update-types:
             - version-update:semver-major
             - version-update:semver-minor
+      groups:
+        github-actions:
+            patterns:
+                - '*'
       cooldown:
         default-days: 7
     - package-ecosystem: gomod


### PR DESCRIPTION
# Changes

Group all GitHub Actions version bumps into a single weekly dependabot PR
per branch, instead of one PR per action.

Previously every `github-actions` bump opened its own PR across `main` and
all six active release branches, flooding the review/merge queue. This adds
a `github-actions` group (`patterns: ["*"]`) in the dependabot config.

Edited in `.github/dependabot.config.yml` (the source of truth) and
regenerated `.github/dependabot.yml` via `./hack/generate-dependabot.sh`.

`gomod` is intentionally left ungrouped: go module bumps carry more risk and
are easier to review/bisect individually.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```