### PR TITLE
ci(e2e): fix ko >=v0.19 SBOM push failure on plain-HTTP registry

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -29,6 +29,9 @@ jobs:
           k8s-version: v1.34.x
     env:
       KO_DOCKER_REPO: registry.local:5000/tekton
+      # registry.local:5000 is a plain-HTTP KinD registry; tell ko to skip TLS
+      # so that both image pushes and SBOM writes (ko >=v0.19) use plain HTTP.
+      KO_FLAGS: --insecure-registry
       CLUSTER_DOMAIN: c${{ github.run_id }}.local
       ARTIFACTS: ${{ github.workspace }}/artifacts
 


### PR DESCRIPTION
## Changes

Cherry-pick of the ko SBOM/HTTPS e2e fix onto `release-v0.77.x`.

`release-v0.77.x` is the only active release branch still missing this fix (0.76, 0.78, 0.79, 0.80 already have it). Without it, every e2e run on this branch fails with:

```
Error: ... writing sbom: Get "https://registry.local:5000/v2/": http: server gave HTTP response to HTTPS client
make: *** [Makefile:146: apply] Error 1
```

ko v0.19 unconditionally attempts HTTPS when writing SBOMs. Setting `KO_FLAGS=--insecure-registry` in the e2e-matrix env block makes both image pushes and SBOM writes use plain HTTP for the local KinD registry (`registry.local:5000`). The flag is already forwarded to `ko apply` via `$(KO_FLAGS)` in the Makefile, so no Makefile change is needed.

Cherry-picked from 84c7e7fe08ee (release-v0.78.x).

## Submitter Checklist

- [x] Includes tests if functionality changed/added (CI-only change)
- [x] Includes docs if changes are user-facing
- [x] Commit messages follow [commit messaging standards](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
- [x] Release notes block below

/kind misc

```release-note
NONE
```