### PR TITLE
fix(manualapprovalgate): propagate TLS profile hash via TektonConfig

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -217,9 +217,47 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 		}
 	}
 
+	// Propagate platform-data-hash to any existing ManualApprovalGate CR.
+	// ManualApprovalGate is a standalone CR (not created by TektonConfig — see
+	// https://github.com/tektoncd/operator/issues/3656), so it never receives
+	// platform-data-hash through the normal child-CR path. We update it here
+	// (same PostReconcile layer as PAC) so that the MAG controller re-applies
+	// the webhook deployment with updated TLS env vars when the cluster TLS
+	// profile changes.
+	oe.propagateMAGPlatformData(ctx)
+
 	// execute console plugin reconciler
 	// TLS config was already resolved and cached in PreReconcile via SetTLSConfig.
 	return oe.consolePluginReconciler.reconcile(ctx, configInstance)
+}
+
+// propagateMAGPlatformData writes the current TLS profile hash into the
+// platform-data-hash annotation of every existing ManualApprovalGate CR.
+// It is a best-effort operation — failures are logged but do not block the
+// TektonConfig reconciliation.
+func (oe openshiftExtension) propagateMAGPlatformData(ctx context.Context) {
+	platformData := oe.GetPlatformData()
+	if platformData == "" {
+		return
+	}
+	logger := logging.FromContext(ctx)
+	magList, err := oe.operatorClientSet.OperatorV1alpha1().ManualApprovalGates().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.Warnf("failed to list ManualApprovalGate CRs for platform-data-hash propagation: %v", err)
+		return
+	}
+	for i := range magList.Items {
+		mag := &magList.Items[i]
+		if mag.Annotations[v1alpha1.PlatformDataHashKey] == platformData {
+			continue
+		}
+		patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, v1alpha1.PlatformDataHashKey, platformData)
+		if _, patchErr := oe.operatorClientSet.OperatorV1alpha1().ManualApprovalGates().Patch(
+			ctx, mag.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{},
+		); patchErr != nil {
+			logger.Warnf("failed to patch platform-data-hash on ManualApprovalGate %s: %v", mag.Name, patchErr)
+		}
+	}
 }
 
 func (oe openshiftExtension) GetPlatformData() string {


### PR DESCRIPTION
## Summary

`ManualApprovalGate` is a standalone CR (not created or owned by TektonConfig). As a result it was never part of the `platform-data-hash` propagation chain, so when the cluster TLS profile changed (e.g. Intermediate → Modern), the MAG webhook deployment stayed stale — still showing `WEBHOOK_TLS_MIN_VERSION: 1.2` with 9 ciphers instead of TLS 1.3 with 3 ciphers.

## Root cause

The `InstallerSetClient` detects TLS changes by including `platform-data-hash` in the InstallerSet hash computation. TektonConfig writes this annotation onto every CR it owns (`TektonPipeline`, `TektonChain`, `TektonResult`, etc.) during `PostReconcile`. MAG was never wired into this flow because it was introduced as a standalone CRD without the TektonConfig integration (see #3656).

## Fix

Added `propagateMAGPlatformData()` called from `OpenShiftExtension.PostReconcile()`. It:

1. Computes the current TLS profile hash via `GetPlatformData()`
2. Lists all existing `ManualApprovalGate` CRs
3. Writes the hash into `operator.tekton.dev/platform-data-hash` on each CR (skipping if already up to date)

The existing MAG controller informer fires on the annotation change, triggers a reconcile, and the webhook deployment is re-applied with the correct TLS env vars. **No changes to the MAG controller or reconciler are needed.**

## Safety

| Scenario | Behaviour |
|---|---|
| No MAG CR installed | `List` returns empty — loop is a no-op |
| MAG CRD not present | `List` returns error — logged as warning, `PostReconcile` continues |
| First-time hash write | InstallerSet hash changes → one-time reconcile → correct TLS applied |
| Hash already current | Annotation unchanged → no API call → no reconcile triggered |

## Long-term fix

Proper integration of MAG as a full TektonConfig child (ownerRef, spec field, shared package) is tracked in #3656. This PR is the minimal correct stopgap that follows the same architectural pattern as PAC propagation in `PostReconcile`.

Relates-To: SRVKP-9613
Closes #3656 (partially — the immediate TLS symptom; full child integration deferred)

Made with [Cursor](https://cursor.com)