### PR TITLE
fix(helm): correct logging CM, add webhook replicas, add extraObjects

### DIFF
--- a/charts/tekton-operator/templates/config.yaml
+++ b/charts/tekton-operator/templates/config.yaml
@@ -44,12 +44,13 @@ data:
           "callerEncoder": ""
         }
       }
-  loglevel.controller: {{ .Values.operator.logLevel }}
-  loglevel.webhook: {{ .Values.webhook.logLevel }}
+  loglevel.tekton-operator-lifecycle: {{ .Values.operator.logLevel | quote }}
+  loglevel.tekton-operator-cluster-operations: {{ .Values.operator.logLevel | quote }}
+  loglevel.{{ include "tekton-operator.fullname" . }}-webhook: {{ .Values.webhook.logLevel | quote }}
   zap-logger-config: |
     {
-      "level": "debug",
-      "development": true,
+      "level": {{ .Values.operator.logLevel | quote }},
+      "development": false,
       "sampling": {
         "initial": 100,
         "thereafter": 100

--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "tekton-operator.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas }}
   selector:
     matchLabels:
       {{- include "tekton-operator.operator.selectorLabels" . | nindent 6 }}
@@ -176,7 +176,7 @@ metadata:
   labels:
     {{- include "tekton-operator.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ max 1 (.Values.webhook.replicas | int) }}
   selector:
     matchLabels:
       {{- include "tekton-operator.webhook.selectorLabels" . | nindent 6 }}

--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               value: tekton-pipelines
               {{- end }}
               {{- end }}
+            - name: CONFIG_LOGGING_NAME
+              value: {{ include "tekton-operator.fullname" . }}-config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: {{ include "tekton-operator.fullname" . }}-observability
             {{- include "tekton-operator.kubernetesMinVersionEnv" . | nindent 12 }}
@@ -126,6 +128,8 @@ spec:
               value: tekton-pipelines
               {{- end }}
               {{- end }}
+            - name: CONFIG_LOGGING_NAME
+              value: {{ include "tekton-operator.fullname" . }}-config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: {{ include "tekton-operator.fullname" . }}-observability
             {{- include "tekton-operator.kubernetesMinVersionEnv" . | nindent 12 }}

--- a/charts/tekton-operator/templates/extra-objects.yaml
+++ b/charts/tekton-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -585,4 +585,4 @@ spec:
     storage: true
     subresources:
       status: {}
----
+{{- end -}}

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -34,6 +34,10 @@ rbac:
 
 ## Configuration for the tekton-operator pod
 operator:
+  # Number of replicas for the operator Deployment. Knative leader election is
+  # active by default, so >=2 runs active/standby (no duplicate writes). A
+  # config-leader-election ConfigMap is optional; defaults apply if absent.
+  replicas: 1
   # Internal name of the operator. Default value depends on the flavor (k8s/openshift).
   operatorName: ""
   image:
@@ -74,6 +78,10 @@ pruner:
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:
+  # Number of replicas for the webhook Deployment. Floored at 1: a webhook
+  # with 0 pods times out admission calls under failurePolicy: Fail and can
+  # wedge operations on the matched CRs.
+  replicas: 1
   hostNetwork: false
   dnsPolicy: ""
   httpsWebhookPort: 8443
@@ -131,3 +139,16 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+## Extra Kubernetes manifests to deploy alongside the operator (rendered as-is).
+## Useful for resources the chart intentionally does not template, e.g. a TektonConfig CR.
+## Note: if you supply a TektonConfig here, set operator.autoInstallComponents to false
+## to avoid racing the operator's own auto-install, which creates TektonConfig/config.
+extraObjects: []
+# extraObjects:
+#   - apiVersion: operator.tekton.dev/v1alpha1
+#     kind: TektonConfig
+#     metadata:
+#       name: config
+#     spec:
+#       profile: all


### PR DESCRIPTION
# Changes

Community Helm chart (`charts/tekton-operator/`).

## Features

- `webhook.replicas` — webhook Deployment replica count is configurable (default 1, floored at 1).
- `operator.replicas` — operator Deployment replica count is configurable (default 1; leader election is active, so >=2 runs active/standby).
- `extraObjects` — render arbitrary user-supplied manifests alongside the operator (e.g. a TektonConfig CR).

## Fixes

- **Logging ConfigMap used dead keys and a hardcoded debug level.** `loglevel.controller`/`loglevel.webhook` matched nothing; replaced with the operator's real logger names (`tekton-operator-lifecycle`, `tekton-operator-cluster-operations`, `<fullname>-webhook`). Default level is now `info` via `operator.logLevel` (was hardcoded `debug`/development). Operator containers now set `CONFIG_LOGGING_NAME` so they consume this ConfigMap. `loglevel.*` values are quoted to avoid YAML type coercion.
- **openshift-crds.yaml broke helm template/install/lint (pre-existing on main).** Missing `{{- end -}}` on an `{{- if }}` block caused `unexpected EOF` for all flavors, since helm parses every file at load. Added the closing tag.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
      *(chart-only change; `make lint` / `make test` cover Go packages and do not exercise the chart. Verified with `helm lint` and `helm template` across default, custom-logLevel, custom-operatorName, divergent release-name, replicas (operator + webhook), extraObjects, and both k8s/openshift flavors.)*
- [ ] Includes tests
      *(No chart test framework exists in this repo. Validation is via `helm lint` / `helm template` rendering.)*
- [x] Includes docs (if user facing)
      *(values.yaml comments document all new/changed values, including the `autoInstallComponents` warning on `extraObjects` and the leader-election note on `operator.replicas`.)*
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
The Helm chart's logging ConfigMap now uses the correct logger names
(tekton-operator-lifecycle, tekton-operator-cluster-operations,
<fullname>-webhook) instead of the inert controller/webhook keys. The
default log level changes from debug to info (configurable via
operator.logLevel). The operator containers now set CONFIG_LOGGING_NAME so
they consume the chart's logging ConfigMap.

The webhook Deployment replica count is now configurable via
webhook.replicas (default 1, floored at 1 to avoid wedging admission).

The operator Deployment replica count is now configurable via
operator.replicas (default 1). Leader election is active by default, so
>=2 runs active/standby.

A new extraObjects value allows rendering arbitrary Kubernetes manifests
alongside the operator (e.g. a TektonConfig CR).

fix: openshift-crds.yaml no longer breaks helm template/install/lint with
an "unexpected EOF" parse error (missing {{- end -}}).
```