### PR TITLE
chore: bump component versions to latest patch releases

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,6 +1,6 @@
 chains:
   github: tektoncd/chains
-  version: v0.26.3
+  version: v0.26.5
 dashboard:
   github: tektoncd/dashboard
   version: v0.66.0
@@ -15,7 +15,7 @@ multicluster-proxy-aae:
   version: v0.1.1
 pipeline:
   github: tektoncd/pipeline
-  version: v1.9.3
+  version: v1.9.5
 pipelines-as-code:
   github: tektoncd/pipelines-as-code
   version: v0.42.2
@@ -27,7 +27,7 @@ results:
   version: v0.18.0
 scheduler:
   github: konflux-ci/tekton-kueue
-  version: v0.3.0
+  version: v0.3.1
 syncer-service:
   github: openshift-pipelines/syncer-service
   version: v0.1.0


### PR DESCRIPTION
# Changes

Bump component versions in components.yaml to their latest patch releases.

| Component | Old Version | New Version |
|-----------|-------------|-------------|
| chains | v0.26.3 | v0.26.5 |
| pipeline | v1.9.3 | v1.9.5 |
| scheduler | v0.3.0 | v0.3.1 |

# Submitter Checklist

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```