### PR TITLE
fix(ci): use main's tooling for release branch bumps

### DIFF
--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -34,37 +34,43 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
-        ref: ${{ matrix.branch }}
+        ref: main
         persist-credentials: false
     - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
       with:
         go-version-file: "go.mod"
-    - name: run operator-tool bump-bugfix
+    - name: Build operator tool and cache scripts from main
       run: |
-        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-        make components/bump-bugfix 2> bump-output.txt || true
+        go build -o /tmp/operator-tool ./cmd/tool
+        cp .github/scripts/generate-bump-message.sh /tmp/generate-bump-message.sh
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ matrix.branch }}
+        persist-credentials: false
+    - name: run operator-tool bump-bugfix
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        /tmp/operator-tool bump --bugfix components.yaml 2> bump-output.txt || true
         cat bump-output.txt >&2
     - name: generate commit message and PR body
       id: generate-message
       run: |
         if [[ -f bump-output.txt ]]; then
-          ./.github/scripts/generate-bump-message.sh bump-output.txt commit-message.txt pr-body.txt
-          if [[ -f commit-message.txt ]]; then
-            COMMIT_MSG=$(cat commit-message.txt)
-            PR_TITLE=$(head -n1 commit-message.txt)
-            echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-            echo "${COMMIT_MSG}" >> $GITHUB_OUTPUT
+          /tmp/generate-bump-message.sh bump-output.txt commit-message.txt pr-body.txt
+        fi
+
+        if [[ -f commit-message.txt ]]; then
+          COMMIT_MSG=$(cat commit-message.txt)
+          PR_TITLE=$(head -n1 commit-message.txt)
+          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
+          echo "${COMMIT_MSG}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "pr_title=${PR_TITLE}" >> $GITHUB_OUTPUT
+          if [[ -f pr-body.txt ]]; then
+            echo "pr_body<<EOF" >> $GITHUB_OUTPUT
+            cat pr-body.txt >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
-            echo "pr_title=${PR_TITLE}" >> $GITHUB_OUTPUT
-            if [[ -f pr-body.txt ]]; then
-              echo "pr_body<<EOF" >> $GITHUB_OUTPUT
-              cat pr-body.txt >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "commit_message=chore: bump payload versions" >> $GITHUB_OUTPUT
-            echo "pr_title=chore: bump payload versions" >> $GITHUB_OUTPUT
-            echo "pr_body=Automated component version bump for ${MATRIX_BRANCH}" >> $GITHUB_OUTPUT
           fi
         else
           echo "commit_message=chore: bump payload versions" >> $GITHUB_OUTPUT


### PR DESCRIPTION

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The bump-payload-on-releases workflow was failing on older release branches (e.g. release-v0.74.x) because the generate-bump-message.sh script does not exist on those branches. The workflow now checks out main first to build the operator tool binary and cache the script, then checks out the release branch for the actual bump. This ensures consistent tooling regardless of branch age.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
