### PR TITLE
feat(helm): configurable replicas (webhook + operator) and extraObjects

### DIFF
--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "tekton-operator.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas }}
   selector:
     matchLabels:
       {{- include "tekton-operator.operator.selectorLabels" . | nindent 6 }}

--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -172,7 +172,7 @@ metadata:
   labels:
     {{- include "tekton-operator.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.webhook.replicas }}
+  replicas: {{ max 1 (.Values.webhook.replicas | int) }}
   selector:
     matchLabels:
       {{- include "tekton-operator.webhook.selectorLabels" . | nindent 6 }}

--- a/charts/tekton-operator/templates/deployment.yaml
+++ b/charts/tekton-operator/templates/deployment.yaml
@@ -172,7 +172,7 @@ metadata:
   labels:
     {{- include "tekton-operator.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
       {{- include "tekton-operator.webhook.selectorLabels" . | nindent 6 }}

--- a/charts/tekton-operator/templates/extra-objects.yaml
+++ b/charts/tekton-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -34,6 +34,10 @@ rbac:
 
 ## Configuration for the tekton-operator pod
 operator:
+  # Number of replicas for the operator Deployment. Knative leader election is
+  # active by default, so >=2 runs active/standby (no duplicate writes). A
+  # config-leader-election ConfigMap is optional; defaults apply if absent.
+  replicas: 1
   # Internal name of the operator. Default value depends on the flavor (k8s/openshift).
   operatorName: ""
   image:

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -74,6 +74,8 @@ pruner:
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:
+  # Number of replicas for the webhook Deployment.
+  replicas: 1
   hostNetwork: false
   dnsPolicy: ""
   httpsWebhookPort: 8443

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -135,3 +135,16 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+## Extra Kubernetes manifests to deploy alongside the operator (rendered as-is).
+## Useful for resources the chart intentionally does not template, e.g. a TektonConfig CR.
+## Note: if you supply a TektonConfig here, set operator.autoInstallComponents to false
+## to avoid racing the operator's own auto-install, which creates TektonConfig/config.
+extraObjects: []
+# extraObjects:
+#   - apiVersion: operator.tekton.dev/v1alpha1
+#     kind: TektonConfig
+#     metadata:
+#       name: config
+#     spec:
+#       profile: all

--- a/charts/tekton-operator/values.yaml
+++ b/charts/tekton-operator/values.yaml
@@ -74,7 +74,9 @@ pruner:
 
 ## Configuration for the tekton-operator-webhook pod
 webhook:
-  # Number of replicas for the webhook Deployment.
+  # Number of replicas for the webhook Deployment. Floored at 1: a webhook
+  # with 0 pods times out admission calls under failurePolicy: Fail and can
+  # wedge operations on the matched CRs.
   replicas: 1
   hostNetwork: false
   dnsPolicy: ""


### PR DESCRIPTION
# Changes

Feature additions to the community Helm chart (`charts/tekton-operator/`). Each is a separate commit for independent review/cherry-pick. Split out from the bug-fix PR #3661 to keep review focused.

## 1. feat(helm): make webhook Deployment replicas configurable, floored at 1

The webhook Deployment hardcoded `replicas: 1`. Expose it via `webhook.replicas` (default `1`), guarded with `max 1` so an explicit `0` renders `1`. A webhook scaled to `0` has no endpoints, so admission calls time out; under `failurePolicy: Fail` this wedges operations on the matched CRs.

## 2. feat(helm): add extraObjects for user-supplied manifests

Render arbitrary manifests from `values.extraObjects` (standard pattern, e.g. argoproj/argo-cd). Useful for resources the chart deliberately does not template, most notably a TektonConfig CR. Defaults to `[]` (renders nothing).

## 3. feat(helm): make operator Deployment replicas configurable

The operator Deployment hardcoded `replicas: 1`. Expose it via `operator.replicas` (default `1`). Unlike the webhook, scaling up is safe here: the operator runs on knative `sharedmain`, which **enables leader election by default** (`WithHADisabled` is never called), so `>=2` replicas run active/standby — no duplicate writes. A `config-leader-election` ConfigMap is optional; knative falls back to defaults when it is absent.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
      *(chart-only change; `make lint` / `make test` cover Go packages and do not exercise the chart. Verified with `helm lint` / `helm template`. Note: full-chart templating also requires the CRD parse fix from #3661, which is a pre-existing bug on `main`.)*
- [ ] Includes tests
      *(No chart test framework exists in this repo. Validation is via `helm lint` / `helm template` rendering.)*
- [x] Includes docs (if user facing)
      *(values.yaml comments document all new values, including the leader-election note on `operator.replicas` and the `autoInstallComponents` warning on `extraObjects`.)*
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
The webhook Deployment replica count is now configurable via
webhook.replicas (default 1, floored at 1 to avoid wedging admission).

The operator Deployment replica count is now configurable via
operator.replicas (default 1). Leader election is active by default, so
>=2 runs active/standby.

A new extraObjects value allows rendering arbitrary Kubernetes manifests
alongside the operator (e.g. a TektonConfig CR).
```