### PR TITLE
ci(coverage): add Codecov integration with OIDC auth

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,27 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
+
+ignore:
+  - "**/zz_generated*.go"
+  - "pkg/client/**"
+  - "pkg/apis/**"
+  - "hack/**"
+  - "cmd/**"
+  - "test/**"
+  - "config/**"
+  - "charts/**"
+  - "third_party/**"
+  - "vendor/**"
+  - "docs/**"
+  - "operatorhub/**"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Harden runner
@@ -58,6 +59,14 @@ jobs:
         with:
           name: code-coverage
           path: ${{ github.workspace }}/src/github.com/tektoncd/operator/coverage.txt
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
+        with:
+          files: ${{ github.workspace }}/src/github.com/tektoncd/operator/coverage.txt
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: true
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Changes

Add Codecov integration to track and gate coverage on PRs

**`.codecov.yaml`** (new file):
- 5% project coverage drop threshold (auto target against `main`)
- Patch gating disabled — PRs only fail on overall project threshold
- Excludes generated, vendor, test, docs, and operatorhub directories

**`.github/workflows/go-coverage.yml`** (updated):
- Adds `codecov/codecov-action@v6.0.2` upload step with OIDC auth
- No `CODECOV_TOKEN` secret required — uses GitHub OIDC JWT
- Tagged with `unit-tests` flag for future flag analytics
- `fail_ci_if_error: true` so upload failures surface in CI
- Keeps the existing `fgrosse/go-coverage-report` PR comment step

Jira: https://redhat.atlassian.net/browse/SRVKP-12309

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) — CI only change, no tests needed
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) — not user facing
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)