### PR TITLE
fix(pruner): ensure enforcedConfigLevel is always defaulted and DeepCopy is correct

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpruner_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_defaults.go
@@ -35,5 +35,8 @@ func (p *Pruner) SetDefaults() {
 	if p.GlobalConfig == nil {
 		p.GlobalConfig = &config.GlobalConfig{}
 		p.GlobalConfig.SetDefaults()
+	} else if p.GlobalConfig.EnforcedConfigLevel == nil {
+		v := config.EnforcedConfigLevelGlobal
+		p.GlobalConfig.EnforcedConfigLevel = &v
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -111,5 +111,8 @@ func (p *Pruner) IsDisabled() bool {
 
 func (in *TektonPrunerConfig) DeepCopyInto(out *TektonPrunerConfig) {
 	*out = *in
-	return
+	if in.GlobalConfig != nil {
+		out.GlobalConfig = new(config.GlobalConfig)
+		*out.GlobalConfig = *in.GlobalConfig
+	}
 }


### PR DESCRIPTION

# Changes
  - Fix `enforcedConfigLevel` silently vanishing from the pruner global config
    when a user provides a partial `global-config` (e.g. only `ttlSecondsAfterFinished`)
  - Fix `DeepCopyInto` shallow copy bug that prevented the defaulting webhook
    from detecting changes made by `SetDefaults`

  ## Problem

  When a user provides any `global-config` field without explicitly setting
  `enforcedConfigLevel`, the v0.79.1 `SetDefaults` skips defaulting entirely
  because `GlobalConfig` is non-nil. Combined with `omitempty` struct tags in
  the vendored pruner, `enforcedConfigLevel` is omitted from the ConfigMap.
  The pruner controller then falls back to the internal default (`resource`
  level), which never consults namespace-level ConfigMaps — all selector-based
  pruning rules silently stop working.

  On top of this, `DeepCopyInto` for `TektonPrunerConfig` does `*out = *in`,
  which copies the `*GlobalConfig` pointer instead of the struct. The Knative
  defaulting webhook deep-copies the object before calling `SetDefaults`, then
  compares it with the original to generate a patch. Because both copies share
  the same pointer, the webhook always sees no difference (`PatchBytes: null`)
  and never applies the defaults.

  ## Root Cause

  Commit 774867c changed `GlobalConfig` from a value type to a pointer and
  guarded `SetDefaults()` with `if p.GlobalConfig == nil` to prevent
  `historyLimit` from resetting to 100 when set to null. The side effect was
  that `enforcedConfigLevel` was never filled in for partial configs. The
  existing `DeepCopyInto` was not updated for the pointer type change.

  ## Fix

  **`tektonpruner_defaults.go`**: Always fill in `enforcedConfigLevel` when
  nil, without touching other fields:

  ```go
  if p.GlobalConfig == nil {
      p.GlobalConfig = &config.GlobalConfig{}
      p.GlobalConfig.SetDefaults()
  } else if p.GlobalConfig.EnforcedConfigLevel == nil {
      v := config.EnforcedConfigLevelGlobal
      p.GlobalConfig.EnforcedConfigLevel = &v
  }

  tektonpruner_types.go: Deep-copy the GlobalConfig pointer:

  func (in *TektonPrunerConfig) DeepCopyInto(out *TektonPrunerConfig) {
      *out = *in
      if in.GlobalConfig != nil {
          out.GlobalConfig = new(config.GlobalConfig)
          *out.GlobalConfig = *in.GlobalConfig
      }
  }
```
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
