### PR TITLE
fix(release): bump pinned ko/koparse image for go 1.26.4

### DIFF
--- a/.github/dependabot.config.yml
+++ b/.github/dependabot.config.yml
@@ -66,3 +66,22 @@ ecosystems:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+  # Keeps the pinned ko/koparse image digests in tekton/build-publish-images-manifests.yaml
+  # in sync so they don't silently drift behind the Go toolchain version required by go.mod
+  # (see https://github.com/tektoncd/chains/pull/1784 for the class of failure this prevents:
+  # "go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)" during release builds).
+  - package-ecosystem: docker
+    directory: /tekton
+    schedule:
+      interval: weekly
+    labels:
+      - ok-to-test
+      - dependencies
+      - kind/misc
+      - release-note-none
+    groups:
+      all:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,21 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.80.x
@@ -90,6 +105,27 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.80.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.79.x
@@ -137,6 +173,27 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.79.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.78.x
@@ -184,6 +241,27 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.78.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.77.x
@@ -231,6 +309,27 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.77.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.76.x
@@ -278,6 +377,27 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.76.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7
     - package-ecosystem: github-actions
       directory: /
       target-branch: release-v0.75.x
@@ -325,3 +445,24 @@ updates:
         semver-major-days: 30
         semver-minor-days: 7
         semver-patch-days: 3
+    - package-ecosystem: docker
+      directory: /tekton
+      target-branch: release-v0.75.x
+      schedule:
+        interval: weekly
+      labels:
+        - ok-to-test
+        - dependencies
+        - kind/misc
+        - release-note-none
+      ignore:
+        - dependency-name: '*'
+          update-types:
+            - version-update:semver-major
+            - version-update:semver-minor
+      groups:
+        all:
+            patterns:
+                - '*'
+      cooldown:
+        default-days: 7

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -99,7 +99,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/${KUBE_DISTRO}-docker-config.json
 
   - name: rewrite-devel-in-source
-    image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:ce22d9774f8d4594847af63cd7d654dc15ae8a21634c6279b3720122a7977c31
     script: |
       #!/usr/bin/env sh
       set -ex
@@ -120,7 +120,7 @@ spec:
       fi
 
   - name: run-kustomize-ko
-    image: ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36@sha256:1756ca55a09b360028695792e638a7cc366292d7aef44c926a8cb765085664c8
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:ce22d9774f8d4594847af63cd7d654dc15ae8a21634c6279b3720122a7977c31
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -182,7 +182,7 @@ spec:
       sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
       sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
   - name: koparse
-    image: ghcr.io/tektoncd/plumbing/koparse@sha256:194c2ab9dce5f778ed757af13c626d6b85f15452e2c2902c79b0d0f5a0adf4d1
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:54e552e06f53bc1eee6dc0ff03b9c8737dd07d466cf302c208c580dba05db49c
     script: |
       set -ex
 

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -99,7 +99,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/${KUBE_DISTRO}-docker-config.json
 
   - name: rewrite-devel-in-source
-    image: ghcr.io/tektoncd/plumbing/ko@sha256:ce22d9774f8d4594847af63cd7d654dc15ae8a21634c6279b3720122a7977c31
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:7561ceb48cbc9492b855da5560586274c1dd4bab403746db0fe56fb06bb32020
     script: |
       #!/usr/bin/env sh
       set -ex
@@ -120,7 +120,7 @@ spec:
       fi
 
   - name: run-kustomize-ko
-    image: ghcr.io/tektoncd/plumbing/ko@sha256:ce22d9774f8d4594847af63cd7d654dc15ae8a21634c6279b3720122a7977c31
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:7561ceb48cbc9492b855da5560586274c1dd4bab403746db0fe56fb06bb32020
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -182,7 +182,7 @@ spec:
       sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.yaml
       sed -i -E -e 's/(app.kubernetes.io\/version): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(operator.tekton.dev\/release): "?devel"?/\1: "$(params.versionTag)"/g' -e 's/(version): "?devel"?/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/${FILENAME_PREFIX}release.notags.yaml
   - name: koparse
-    image: ghcr.io/tektoncd/plumbing/koparse@sha256:54e552e06f53bc1eee6dc0ff03b9c8737dd07d466cf302c208c580dba05db49c
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:6cf5d09b76e47c1f75f1e00195d6332cb94c467446a3fdf508a686f8aaeae90e
     script: |
       set -ex
 

--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -147,11 +147,15 @@ spec:
       # probably get it wrong), we'll just targz up the whole vendor tree and
       # include it. As of 9/20/2019, this amounts to about 11MB of additional
       # data in each image.
+      # ko >= v0.19.0 rejects kodata symlinks that resolve outside the
+      # kodata root (ko-build/ko#1619), so the tarball is copied into
+      # each kodata/ directory instead of being symlinked from a
+      # shared tmpdir.
       TMPDIR=$(mktemp -d)
       tar cfz ${TMPDIR}/source.tar.gz vendor/
       for d in cmd/${KUBE_DISTRO}/*; do
         if [ -d ${d}/kodata/ ]; then
-          ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
+          cp ${TMPDIR}/source.tar.gz ${d}/kodata/
         fi
       done
 


### PR DESCRIPTION
# Changes

`tekton/build-publish-images-manifests.yaml` pinned the ko/kustomize
build steps to `ghcr.io/tektoncd/plumbing/ko-gcloud:v20240920-6c2a999d36`,
which ships Go 1.22.1. `go.mod` now requires `go 1.26.4` (CVE-2026-27145
stdlib fix), and no `ko-gcloud` digest published yet ships Go >= 1.26.4.

- Switch the `rewrite-devel-in-source` and `run-kustomize-ko` steps to
  the plain `ko` image instead, which already ships Go 1.26.4 and
  includes every tool they actually use (`ko`, `kustomize`, `git`)
  without needing the gcloud/kubectl/yq extras that `ko-gcloud` bundles.
- Bump the `koparse` step to its current digest.
- Add a `docker` package-ecosystem entry for `/tekton` to
  `.github/dependabot.config.yml` (regenerated `.github/dependabot.yml`
  via `./hack/generate-dependabot.sh`) so these pinned image digests are
  kept in sync with `go.mod` going forward instead of silently drifting
  behind the required Go toolchain version.

Verified by pulling both the old and new images and confirming
`go version` inside each, and that the new `ko` image has `tar`, `sed`,
`awk`, `git`, `kustomize`, and `ko` available.

## Follow-up fix: kodata symlink rejected by ko >= v0.19

The `ko` image now pinned here (aligned with `tektoncd/pipeline`'s digest)
ships `ko` v0.19.1, which enforces that `kodata/` symlinks must not resolve
outside the kodata root (ko-build/ko#1619). The `run-kustomize-ko` step
symlinks `cmd/${KUBE_DISTRO}/*/kodata/source.tar.gz` to a tarball in an
external `mktemp -d` directory, which this newer `ko` now rejects:

```
Error: error processing import paths ...: tarring kodata: kodata symlink
"cmd/<distro>/operator/kodata/source.tar.gz" resolves to "/tmp/tmp.XXXXXX/source.tar.gz"
which is outside the kodata root "cmd/<distro>/operator/kodata"
```

We hit this exact failure in `tektoncd/chains`' release pipeline after a
similar Go 1.26.4-driven `ko` digest bump
([tektoncd/chains#1791](https://github.com/tektoncd/chains/pull/1791)),
and the same unfixed pattern also exists upstream in
`tektoncd/pipeline`'s `tekton/publish.yaml`
([tektoncd/pipeline#10418](https://github.com/tektoncd/pipeline/pull/10418)).
Since this PR moves operator onto the same `ko` v0.19.1 digest, it would hit
the identical error on the next real release, so the fix is included here.

Fix: copy the tarball into each `cmd/${KUBE_DISTRO}/*/kodata/` directory
instead of symlinking to it from a shared tmpdir. `ko` already dereferences
symlinks and embeds the resolved file's bytes into the image layer when
tarring kodata, so this has no effect on final image size — only the
symlink itself was rejected, not the underlying content.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)
