### PR TITLE
feat(dependabot): add branch prefix to PR titles for release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,8 @@ updates:
       target-branch: release-v0.80.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.80.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -85,6 +87,8 @@ updates:
       target-branch: release-v0.80.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.80.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -110,6 +114,8 @@ updates:
       target-branch: release-v0.80.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.80.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -131,6 +137,8 @@ updates:
       target-branch: release-v0.79.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.79.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -153,6 +161,8 @@ updates:
       target-branch: release-v0.79.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.79.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -178,6 +188,8 @@ updates:
       target-branch: release-v0.79.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.79.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -199,6 +211,8 @@ updates:
       target-branch: release-v0.78.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.78.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -221,6 +235,8 @@ updates:
       target-branch: release-v0.78.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.78.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -246,6 +262,8 @@ updates:
       target-branch: release-v0.78.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.78.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -267,6 +285,8 @@ updates:
       target-branch: release-v0.77.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.77.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -289,6 +309,8 @@ updates:
       target-branch: release-v0.77.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.77.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -314,6 +336,8 @@ updates:
       target-branch: release-v0.77.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.77.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -335,6 +359,8 @@ updates:
       target-branch: release-v0.76.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.76.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -357,6 +383,8 @@ updates:
       target-branch: release-v0.76.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.76.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -382,6 +410,8 @@ updates:
       target-branch: release-v0.76.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.76.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -403,6 +433,8 @@ updates:
       target-branch: release-v0.75.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.75.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -425,6 +457,8 @@ updates:
       target-branch: release-v0.75.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.75.x] '
       labels:
         - ok-to-test
         - dependencies
@@ -450,6 +484,8 @@ updates:
       target-branch: release-v0.75.x
       schedule:
         interval: weekly
+      commit-message:
+        prefix: '[release-v0.75.x] '
       labels:
         - ok-to-test
         - dependencies

--- a/hack/generate-dependabot.go
+++ b/hack/generate-dependabot.go
@@ -50,6 +50,11 @@ type Ecosystem struct {
 	Cooldown         *Cooldown                `yaml:"cooldown,omitempty"`
 }
 
+// CommitMessage configures the prefix for Dependabot commit messages and PR titles
+type CommitMessage struct {
+	Prefix string `yaml:"prefix"`
+}
+
 // DependabotConfig represents the generated dependabot.yml structure
 type DependabotConfig struct {
 	Version int      `yaml:"version"`
@@ -62,6 +67,7 @@ type Update struct {
 	Directory        string                   `yaml:"directory"`
 	TargetBranch     string                   `yaml:"target-branch,omitempty"`
 	Schedule         map[string]interface{}   `yaml:"schedule"`
+	CommitMessage    *CommitMessage           `yaml:"commit-message,omitempty"`
 	Labels           []string                 `yaml:"labels"`
 	Ignore           []map[string]interface{} `yaml:"ignore,omitempty"`
 	Groups           map[string]interface{}   `yaml:"groups,omitempty"`
@@ -169,6 +175,7 @@ func generateDependabotConfig(config Config) DependabotConfig {
 				Directory:        ecosystem.Directory,
 				TargetBranch:     branch,
 				Schedule:         ecosystem.Schedule,
+				CommitMessage:    &CommitMessage{Prefix: "[" + branch + "] "},
 				Labels:           ecosystem.Labels,
 				Ignore:           ignore,
 				Groups:           ecosystem.Groups,


### PR DESCRIPTION
Dependabot PRs targeting release branches currently have generic titles that don't indicate which branch they target. Adding a [release-vX.Y.x] prefix to commit messages makes it immediately clear which branch a Dependabot PR is for, improving triage and review.

Ported from tektoncd/cli#3017


Assisted-by: Claude Opus 4.6 (via Claude Code)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
