### PR TITLE
fix(rbac): add bind/escalate verbs for k8s install

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-rbac.yaml
+++ b/charts/tekton-operator/templates/kubernetes-rbac.yaml
@@ -155,6 +155,8 @@ rules:
       - delete
       - list
       - watch
+      - bind
+      - escalate
   - apiGroups:
       - ""
     resources:

--- a/config/base/role.yaml
+++ b/config/base/role.yaml
@@ -127,6 +127,8 @@ rules:
   - delete
   - list
   - watch
+  - bind
+  - escalate
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
# Changes

The Kubernetes install manifests (Helm chart `charts/tekton-operator/templates/kubernetes-rbac.yaml`
and kustomize base `config/base/role.yaml`) were missing the `bind`/`escalate`
verbs on `clusterroles`/`roles` that the OpenShift manifests
(`openshift-rbac.yaml` / `config/openshift/base/role.yaml`) already have.

Without these verbs, Kubernetes RBAC's self-escalation protection blocks the
`tekton-operator` ServiceAccount from creating the `pipelines-as-code-aggregate`
ClusterRole (since it grants permissions, e.g. on `pipelinesascode.tekton.dev/repositories`,
that the operator's own ClusterRole doesn't directly hold). This causes the
static InstallerSet for Pipelines-as-Code to fail, so its ServiceAccounts and
Deployments are never created and PAC pods stay pending.

This aligns the Kubernetes RBAC with the OpenShift RBAC by granting
`bind`/`escalate` on `clusterroles`/`roles`, the same pattern used to fix a
similar RBAC gap in #3519.

## Verification

Reproduced the reported failure by installing the `v0.80.0` Helm chart on a
kind cluster and enabling Pipelines-as-Code via `TektonConfig`:

```
openshiftpipelinesascode-main-static-gkbc6   False   Install failed with message: clusterroles.rbac.authorization.k8s.io "pipelines-as-code-aggregate" is forbidden: ...
```

After granting `bind`/`escalate` on the operator's ClusterRole, the same
InstallerSet applied successfully and all Pipelines-as-Code deployments came
up:

```
pipelines-as-code-controller   1/1   Ready
pipelines-as-code-watcher      1/1   Ready
pipelines-as-code-webhook      1/1   Ready
```

Fixes #3682

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
Fix missing RBAC permissions in the Kubernetes Helm chart and install
manifests that prevented the operator from installing Pipelines-as-Code
on Kubernetes.
```

Made with [Cursor](https://cursor.com)