### PR TITLE
Hub template removal 

### DIFF
--- a/operatorhub/kubernetes/manifests/bases/tektoncd-operator.clusterserviceversion.template.yaml.tmpl
+++ b/operatorhub/kubernetes/manifests/bases/tektoncd-operator.clusterserviceversion.template.yaml.tmpl
@@ -51,14 +51,6 @@ spec:
       name: tektontriggers.operator.tekton.dev
       version: v1alpha1
     - description: |
-        TektonHub installs Tekton Hub on a cluster. The operator installs Tekton Hub on a cluster
-        if an instance of this CRD is created on your cluster with name `hub`. At present, the operator honors only
-        one CustomResource instance with the name `hub` to ensure only one set of Tekton Hub exists on a cluster.
-      displayName: TektonHubs
-      kind: TektonHub
-      name: tektonhubs.operator.tekton.dev
-      version: v1alpha1
-    - description: |
         TektonInstallerSet internal CRD used by other component reconcilers to create kubernetes resources from their
         release manifests
       displayName: TektonInstallerSets

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
@@ -19,7 +19,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonhubs.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev"]'
+    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev"]'
     repository: https://github.com/tektoncd/operator
     support: Red Hat
   labels:
@@ -159,27 +159,6 @@ spec:
       displayName: Tekton Results
       kind: TektonResult
       name: tektonresults.operator.tekton.dev
-      resources:
-      - kind: tektoninstallersets
-        name: ''
-        version: v1alpha1
-      specDescriptors:
-      - description: Namespace where Addons installed
-        displayName: Target Namespace
-        path: targetNamespace
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
-      statusDescriptors:
-      - description: The version of Addons installed
-        displayName: Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
-      version: v1alpha1
-    - description: Represents an installation of latest version of Hub
-      displayName: Tekton Hub
-      kind: TektonHub
-      name: tektonhubs.operator.tekton.dev
       resources:
       - kind: tektoninstallersets
         name: ''
@@ -399,8 +378,7 @@ spec:
     - Tekton Triggers: {{ with index .Versions "triggers"}}{{ .Version }}{{end}}
     - Pipelines as Code: {{ with index .Versions "pipelines-as-code"}}{{ .Version }}{{end}}
     - Tekton Chains: {{ with index .Versions "chains"}}{{ .Version }}{{end}}
-    - Tekton Hub (tech-preview): {{ with index .Versions "hub"}}{{ .Version }}{{end}}
-    - Tekton Results: {{ with index .Versions "results"}}{{ .Version }}{{end}}
+    - Tekton Results (tech-preview): {{ with index .Versions "results"}}{{ .Version }}{{end}}
     - Manual Approval Gate (tech-preview): {{ with index .Versions "manual-approval-gate"}}{{ .Version }}{{end}}
     - Tekton Pruner: {{ with index .Versions "pruner"}}{{ .Version }}{{end}}
     - Tekton Scheduler (tech-preview): {{ with index .Versions "scheduler"}}{{ .Version }}{{end}}


### PR DESCRIPTION


# Changes


Follow-up to #3494. The CSV template source files (`.tmpl`) still contained
hardcoded TektonHub references. When the bump automation ran and regenerated
the CSV output files from these templates, hub entries were re-introduced
(see #3715).
Removed TektonHub owned-CRD entries, internal-objects annotation reference,
and version line from both OperatorHub CSV templates.

**Bump itself is not happening, since the bump script iterates `components.yaml` of which hub is already removed.
You can see in Makefile:
`COMPONENT ?= components.yaml`

and then

```
##@ Bump Components Version

.PHONY: components/bump  
components/bump: $(OPERATORTOOL) ## Bump the version of a component 
	@go run ./cmd/tool bump ${COMPONENT}
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
