### PR TITLE
ci(bump-payload): anchor regex in bump-payload branch filter

### DIFF
--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - id: set-matrix
       run: |
-        SUPPORTED_BRANCHES=$(git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | grep -v 'v0.2[0-9].*\|v0.5[0-9]\.*\|v0.6[0-7]\.*' | awk '{ print $2 }' | cut -d/ -f3- | jq -cRs 'split("\n")[:-1]')
+        SUPPORTED_BRANCHES=$(git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | awk '{ print $2 }' | cut -d/ -f3- | grep '^release-v[0-9]\+\.[0-9]\+' | grep -v '^release-v0\.2[0-9]\|^release-v0\.5[0-9]\|^release-v0\.6[0-7]' | jq -cRs 'split("\n")[:-1]')
         echo "Supported Branches: ${SUPPORTED_BRANCHES}"
         echo "branches=${SUPPORTED_BRANCHES}" >> $GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION

# Changes
The release-* glob in git ls-remote matched branches with "release-" anywhere in their path, causing dependabot and bot-bump-payload branches to enter the build matrix and open spurious PRs. Add a positive anchored grep to keep only branches starting with release-v and anchor the negative filter patterns as well.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Before changes `SUPPORTED_BRANCHES`
```bash
$ git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | grep -v 'v0.2[0-9].*\|v0.5[0-9]\.*\|v0.6[0-7]\.*' | awk '{ print $2 }' | cut -d/ -f3- | jq -cRs 'split("\n")[:-1]'
["bot-bump-payload-bot-bump-payload-dependabot/github_actions/release-v0.79.x/chainguard-dev/actions/kind-diag-1.6.25","bot-bump-payload-bot-bump-payload-dependabot/go_modules/release-v0.80.x/github.com/tektoncd/pipeline-1.12.2","bot-bump-payload-dependabot/github_actions/release-v0.79.x/chainguard-dev/actions/kind-diag-1.6.25","bot-bump-payload-dependabot/go_modules/release-v0.77.x/github.com/openshift-pipelines/tektoncd-pruner-0.0.0","bot-bump-payload-dependabot/go_modules/release-v0.80.x/github.com/tektoncd/pipeline-1.12.2","dependabot/go_modules/release-v0.77.x/github.com/openshift-pipelines/tektoncd-pruner-0.0.0","dependabot/go_modules/release-v0.80.x/github.com/tektoncd/pruner-0.4.1","release-v0.68.x","release-v0.69.x","release-v0.70.x","release-v0.71.x","release-v0.72.x","release-v0.73.x","release-v0.74.x","release-v0.75.x","release-v0.76.x","release-v0.77.x","release-v0.78.x","release-v0.79.x","release-v0.80.x"]
```
This caused unnecessary PRs such as #3719, #3721, #3723 and #3725 on branches which had `release-v0.2[0-9].*\|v0.5[0-9]\.*\|v0.6[0-7]\.*'` *anywhere* in the branch name.
We add anchors to the regex to only get the actual release branches. 

After changes `SUPPORTED_BRANCHES`
```bash
$ git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | awk '{ print $2 }' | cut -d/ -f3- | grep '^release-v[0-9]\+\.[0-9]\+' | grep -v '^release-v0\.2[0-9]\|^release-v0\.5[0-9]\|^release-v0\.6[0-7]' | jq -cRs 'split("\n")[:-1]'
["release-v0.68.x","release-v0.69.x","release-v0.70.x","release-v0.71.x","release-v0.72.x","release-v0.73.x","release-v0.74.x","release-v0.75.x","release-v0.76.x","release-v0.77.x","release-v0.78.x","release-v0.79.x","release-v0.80.x"]
```


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
