### PR TITLE
fix(networkpolicy): allow all egress for API server access

### DIFF
--- a/config/kubernetes/base/networkpolicy.yaml
+++ b/config/kubernetes/base/networkpolicy.yaml
@@ -50,9 +50,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  - ports:
-    - protocol: TCP
-      port: 443
+  # NP cannot select host-network endpoints and API server port is configurable.
+  - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -84,6 +83,5 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  - ports:
-    - protocol: TCP
-      port: 443
+  # NP cannot select host-network endpoints and API server port is configurable.
+  - {}

--- a/config/openshift/base/networkpolicy.yaml
+++ b/config/openshift/base/networkpolicy.yaml
@@ -51,9 +51,8 @@ spec:
       port: 5353
     - protocol: TCP
       port: 5353
-  - ports:
-    - protocol: TCP
-      port: 6443
+  # NP cannot select host-network endpoints and API server port is configurable.
+  - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -85,6 +84,5 @@ spec:
       port: 5353
     - protocol: TCP
       port: 5353
-  - ports:
-    - protocol: TCP
-      port: 6443
+  # NP cannot select host-network endpoints and API server port is configurable.
+  - {}

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -45,20 +45,20 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | `tekton-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-triggers` |
 | `triggers-controller` | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
-| | egress | TCP/443 (K8s) or 6443 (OpenShift) | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `triggers-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `triggers-core-interceptors` | ingress | TCP/8443 | All namespaces (EventListeners) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | | egress | TCP/80, 443 | Any (external APIs e.g. GitHub) |
 | `tekton-proxy-webhook-default-deny` | deny all | — | All pods with `name: tekton-operator` (proxy-webhook) in the Pipeline target namespace |
 | `proxy-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 The `proxy-webhook` policies apply to the TektonPipeline target namespace (e.g.
 `tekton-pipelines` or `openshift-pipelines`), where the operator deploys the
@@ -73,7 +73,6 @@ NetworkPolicies as part of the operator's own install manifests/bundle (see
 |---|---|---|
 | DNS port | 53 | 5353 |
 | DNS namespace | `kube-system` | `openshift-dns` |
-| API server port | 443 | 6443 |
 | Prometheus namespace label | `kubernetes.io/metadata.name: monitoring` | `openshift.io/cluster-monitoring: "true"` |
 
 ## Operator's own namespace
@@ -95,10 +94,10 @@ the operator's bundle never affects unrelated pods that might share the namespac
 |---|---|---|---|
 | `tekton-operator` / `openshift-pipelines-operator` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `tekton-operator-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 **OpenShift caveat**: `openshift-operators` is a shared namespace where OLM installs
 operators from OperatorHub, many of which ship no NetworkPolicy of their own. To

--- a/pkg/reconciler/common/networkpolicy/networkpolicy.go
+++ b/pkg/reconciler/common/networkpolicy/networkpolicy.go
@@ -123,16 +123,11 @@ func DNSEgressRule(p PlatformParams) networkingv1.NetworkPolicyEgressRule {
 	}
 }
 
-// APIServerEgressRule allows egress to the API server on the platform-specific port (443 on
-// Kubernetes, 6443 on OpenShift). No To restriction — API server is behind a ClusterIP service.
-func APIServerEgressRule(p PlatformParams) networkingv1.NetworkPolicyEgressRule {
-	tcp := corev1.ProtocolTCP
-	apiPort := intstr.FromInt32(p.APIServerPort)
-	return networkingv1.NetworkPolicyEgressRule{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &tcp, Port: &apiPort},
-		},
-	}
+// APIServerEgressRule allows all egress so pods can reach the API server.
+// NetworkPolicy cannot select host-network endpoints, and the API server
+// port is configurable, so we must allow unrestricted egress.
+func APIServerEgressRule() networkingv1.NetworkPolicyEgressRule {
+	return networkingv1.NetworkPolicyEgressRule{}
 }
 
 // InternetEgressRule allows egress on TCP 80 and 443 to any destination.

--- a/pkg/reconciler/common/networkpolicy/networkpolicy_test.go
+++ b/pkg/reconciler/common/networkpolicy/networkpolicy_test.go
@@ -177,25 +177,13 @@ func TestInternetEgressRule(t *testing.T) {
 	}
 }
 
-func TestAPIServerEgressRule_Kubernetes(t *testing.T) {
-	params := networkpolicy.KubernetesPlatformDefaults()
-	rule := networkpolicy.APIServerEgressRule(params)
-	if len(rule.Ports) != 1 || rule.Ports[0].Port.IntVal != 443 {
-		t.Fatalf("expected port 443 for Kubernetes, got %v", rule.Ports)
+func TestAPIServerEgressRule(t *testing.T) {
+	rule := networkpolicy.APIServerEgressRule()
+	if len(rule.Ports) != 0 {
+		t.Errorf("expected no port restriction (allow all), got %v", rule.Ports)
 	}
 	if len(rule.To) != 0 {
-		t.Errorf("expected no To restriction for API server egress, got %v", rule.To)
-	}
-}
-
-func TestAPIServerEgressRule_OpenShift(t *testing.T) {
-	params := networkpolicy.OpenShiftPlatformDefaults()
-	rule := networkpolicy.APIServerEgressRule(params)
-	if len(rule.Ports) != 1 || rule.Ports[0].Port.IntVal != 6443 {
-		t.Fatalf("expected port 6443 for OpenShift, got %v", rule.Ports)
-	}
-	if len(rule.To) != 0 {
-		t.Errorf("expected no To restriction for API server egress, got %v", rule.To)
+		t.Errorf("expected no To restriction (allow all), got %v", rule.To)
 	}
 }
 

--- a/pkg/reconciler/common/networkpolicy/platform.go
+++ b/pkg/reconciler/common/networkpolicy/platform.go
@@ -25,8 +25,6 @@ type PlatformParams struct {
 	// DNSPort is the DNS resolver pod port. Kubernetes CoreDNS uses 53; OpenShift DNS
 	// uses 5353 (OVN-K8s enforces NetworkPolicy after DNAT, so pod port applies).
 	DNSPort int32
-	// APIServerPort is the kubernetes.default.svc port: 443 on Kubernetes, 6443 on OpenShift.
-	APIServerPort int32
 }
 
 // KubernetesPlatformDefaults returns PlatformParams for vanilla Kubernetes.
@@ -36,7 +34,6 @@ func KubernetesPlatformDefaults() PlatformParams {
 		DNSResolverPodLabel:      map[string]string{"k8s-app": "kube-dns"},
 		PrometheusNamespaceLabel: map[string]string{"kubernetes.io/metadata.name": "monitoring"},
 		DNSPort:                  53,
-		APIServerPort:            443,
 	}
 }
 
@@ -47,6 +44,5 @@ func OpenShiftPlatformDefaults() PlatformParams {
 		DNSResolverPodLabel:      map[string]string{"dns.operator.openshift.io/daemonset-dns": "default"},
 		PrometheusNamespaceLabel: map[string]string{"openshift.io/cluster-monitoring": "true"},
 		DNSPort:                  5353,
-		APIServerPort:            6443,
 	}
 }

--- a/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
@@ -58,7 +58,7 @@ func proxyWebhookDefaultPolicies(params networkpolicy.PlatformParams) []networki
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					networkpolicy.APIServerEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
 				},
 			},
 		},

--- a/pkg/reconciler/kubernetes/tektontrigger/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektontrigger/networkpolicies.go
@@ -48,7 +48,7 @@ func triggersDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					networkpolicy.APIServerEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
 				},
 			},
 		},
@@ -66,7 +66,7 @@ func triggersDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					networkpolicy.APIServerEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
 				},
 			},
 		},
@@ -91,7 +91,7 @@ func triggersDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					networkpolicy.APIServerEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
 					// Allow egress to external APIs (e.g. GitHub) for file fetching and validation.
 					networkpolicy.InternetEgressRule(),
 				},


### PR DESCRIPTION
NetworkPolicy cannot select host-network endpoints, and the API server port is configurable (SDN sometime have different port), so allow unrestricted egress. Remove APIServerPort from PlatformParams. Admin network policy could improve this later but would break third-party SDNs.


Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
