### PR TITLE
fix(chart): set preserveUnknownFields: false on CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,16 @@ generated: | vendor ; $(info $(M) update generated files) ## Update generated fi
 	$Q ./hack/update-codegen.sh
 
 ##@ CRD Generation
+# Inject preserveUnknownFields: false (the explicit default) right after
+# controller-gen writes generated-crds/: the apiserver fills this field in
+# server-side, so omitting it makes ArgoCD server-side-apply flag every CRD
+# as OutOfSync. Done here, not in sync-helm-crds.sh, so a bare
+# `make generate-crds` cannot silently drop the field from the kustomize
+# source of truth.
 .PHONY: generate-crds
 generate-crds: | $(CONTROLLER_GEN) ; $(info $(M) generating CRDs from Go types…) ## Generate CRD manifests from Go types
 	$Q $(CONTROLLER_GEN) crd:allowDangerousTypes=true paths="./pkg/apis/operator/v1alpha1/..." output:crd:artifacts:config=config/base/generated-crds
+	$Q for f in config/base/generated-crds/*.yaml; do grep -q '^  preserveUnknownFields:' $$f || perl -i -pe 's/^spec:\n/spec:\n  preserveUnknownFields: false\n/' $$f; done
 
 .PHONY: sync-helm-crds
 sync-helm-crds: generate-crds ; $(info $(M) syncing CRDs to config and Helm chart…) ## Sync generated CRDs to config/ and Helm chart

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -10,6 +10,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: ManualApprovalGate
@@ -167,6 +168,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode
@@ -402,6 +404,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonChain
@@ -885,6 +888,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonConfig
@@ -2312,6 +2316,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonDashboard
@@ -2527,6 +2532,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonInstallerSet
@@ -2641,6 +2647,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPipeline
@@ -3042,6 +3049,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonResult
@@ -3378,6 +3386,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonTrigger
@@ -3611,6 +3620,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPruner
@@ -3825,6 +3835,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonScheduler
@@ -4000,6 +4011,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonMulticlusterProxyAAE
@@ -4157,6 +4169,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: SyncerService

--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -10,6 +10,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: ManualApprovalGate
@@ -655,6 +656,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode
@@ -1378,6 +1380,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonChain
@@ -2350,6 +2353,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonConfig
@@ -4452,6 +4456,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonDashboard
@@ -4667,6 +4672,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonInstallerSet
@@ -4781,6 +4787,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPipeline
@@ -5652,6 +5659,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonResult
@@ -6541,6 +6549,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonTrigger
@@ -7244,6 +7253,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPruner
@@ -8067,6 +8077,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonScheduler
@@ -8742,6 +8753,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonMulticlusterProxyAAE
@@ -9386,6 +9398,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: SyncerService

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -10,6 +10,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: ManualApprovalGate
@@ -167,6 +168,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode
@@ -402,6 +404,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonAddon
@@ -576,6 +579,3763 @@ spec:
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
                 type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonchains.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonChain
+    listKind: TektonChainList
+    plural: tektonchains
+    singular: tektonchain
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonChain is the Schema for the tektonchain API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonChainSpec defines the desired state of TektonChain
+            properties:
+              artifacts.oci.format:
+                description: oci artifacts config
+                type: string
+              artifacts.oci.signer:
+                type: string
+              artifacts.oci.storage:
+                type: string
+              artifacts.pipelinerun.enable-deep-inspection:
+                type: string
+              artifacts.pipelinerun.format:
+                description: pipelinerun artifacts config
+                type: string
+              artifacts.pipelinerun.signer:
+                type: string
+              artifacts.pipelinerun.storage:
+                type: string
+              artifacts.taskrun.format:
+                description: taskrun artifacts config
+                type: string
+              artifacts.taskrun.signer:
+                type: string
+              artifacts.taskrun.storage:
+                type: string
+              builddefinition.buildtype:
+                type: string
+              builder.id:
+                description: builder config
+                type: string
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonChain
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              controllerEnvs:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              disabled:
+                description: enable or disable chains feature
+                type: boolean
+              generateSigningSecret:
+                description: generate signing key
+                type: boolean
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              signers.kms.auth.address:
+                type: string
+              signers.kms.auth.oidc.path:
+                type: string
+              signers.kms.auth.oidc.role:
+                type: string
+              signers.kms.auth.spire.audience:
+                type: string
+              signers.kms.auth.spire.sock:
+                type: string
+              signers.kms.auth.token:
+                type: string
+              signers.kms.auth.token-path:
+                type: string
+              signers.kms.kmsref:
+                description: kms signer config
+                type: string
+              signers.x509.fulcio.address:
+                type: string
+              signers.x509.fulcio.enabled:
+                description: x509 signer config
+                type: boolean
+              signers.x509.fulcio.issuer:
+                type: string
+              signers.x509.fulcio.provider:
+                type: string
+              signers.x509.identity.token.file:
+                type: string
+              signers.x509.tuf.mirror.url:
+                type: string
+              storage.docdb.mongo-server-url:
+                type: string
+              storage.docdb.mongo-server-url-dir:
+                type: string
+              storage.docdb.url:
+                type: string
+              storage.gcs.bucket:
+                description: storage configs
+                type: string
+              storage.grafeas.notehint:
+                type: string
+              storage.grafeas.noteid:
+                type: string
+              storage.grafeas.projectid:
+                type: string
+              storage.oci.repository:
+                type: string
+              storage.oci.repository.insecure:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              transparency.enabled:
+                type: string
+              transparency.url:
+                type: string
+            required:
+            - disabled
+            type: object
+          status:
+            description: TektonChainStatus defines the observed state of TektonChain
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonChain
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonconfigs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonConfig
+    listKind: TektonConfigList
+    plural: tektonconfigs
+    singular: tektonconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonConfig is the Schema for the TektonConfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonConfigSpec defines the desired state of TektonConfig
+            properties:
+              addon:
+                description: Addon holds the addons config
+                properties:
+                  enablePipelinesAsCode:
+                    description: |-
+                      Deprecated, will be removed in further release
+                      EnablePAC field defines whether to install PAC
+                    type: boolean
+                  params:
+                    description: Params is the list of params passed for Addon customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              chain:
+                description: Chain holds the customizable option for chains component
+                properties:
+                  artifacts.oci.format:
+                    description: oci artifacts config
+                    type: string
+                  artifacts.oci.signer:
+                    type: string
+                  artifacts.oci.storage:
+                    type: string
+                  artifacts.pipelinerun.enable-deep-inspection:
+                    type: string
+                  artifacts.pipelinerun.format:
+                    description: pipelinerun artifacts config
+                    type: string
+                  artifacts.pipelinerun.signer:
+                    type: string
+                  artifacts.pipelinerun.storage:
+                    type: string
+                  artifacts.taskrun.format:
+                    description: taskrun artifacts config
+                    type: string
+                  artifacts.taskrun.signer:
+                    type: string
+                  artifacts.taskrun.storage:
+                    type: string
+                  builddefinition.buildtype:
+                    type: string
+                  builder.id:
+                    description: builder config
+                    type: string
+                  controllerEnvs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  disabled:
+                    description: enable or disable chains feature
+                    type: boolean
+                  generateSigningSecret:
+                    description: generate signing key
+                    type: boolean
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  signers.kms.auth.address:
+                    type: string
+                  signers.kms.auth.oidc.path:
+                    type: string
+                  signers.kms.auth.oidc.role:
+                    type: string
+                  signers.kms.auth.spire.audience:
+                    type: string
+                  signers.kms.auth.spire.sock:
+                    type: string
+                  signers.kms.auth.token:
+                    type: string
+                  signers.kms.auth.token-path:
+                    type: string
+                  signers.kms.kmsref:
+                    description: kms signer config
+                    type: string
+                  signers.x509.fulcio.address:
+                    type: string
+                  signers.x509.fulcio.enabled:
+                    description: x509 signer config
+                    type: boolean
+                  signers.x509.fulcio.issuer:
+                    type: string
+                  signers.x509.fulcio.provider:
+                    type: string
+                  signers.x509.identity.token.file:
+                    type: string
+                  signers.x509.tuf.mirror.url:
+                    type: string
+                  storage.docdb.mongo-server-url:
+                    type: string
+                  storage.docdb.mongo-server-url-dir:
+                    type: string
+                  storage.docdb.url:
+                    type: string
+                  storage.gcs.bucket:
+                    description: storage configs
+                    type: string
+                  storage.grafeas.notehint:
+                    type: string
+                  storage.grafeas.noteid:
+                    type: string
+                  storage.grafeas.projectid:
+                    type: string
+                  storage.oci.repository:
+                    type: string
+                  storage.oci.repository.insecure:
+                    type: boolean
+                  transparency.enabled:
+                    type: string
+                  transparency.url:
+                    type: string
+                required:
+                - disabled
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonConfig
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              dashboard:
+                description: Dashboard holds the customizable options for dashboards
+                  component
+                properties:
+                  external-logs:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  readonly:
+                    description: Readonly when set to true configures the Tekton dashboard
+                      in read-only mode
+                    type: boolean
+                required:
+                - readonly
+                type: object
+              hub:
+                description: Hub holds the hub config
+                properties:
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: Params is the list of params passed for Hub customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              multiclusterProxyAAE:
+                description: MulticlusterProxyAAE holds the customizable options for
+                  the multicluster-proxy-aae component
+                properties:
+                  options:
+                    description: options holds additional fields and these fields
+                      will be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                type: object
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy resources for the operand namespace.
+                  This field is propagated to TektonTrigger, which is the only component with
+                  NetworkPolicy reconciliation implemented. Other components (Pipeline, Chains,
+                  Results, Dashboard) do not yet act on this field.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              params:
+                description: Params is the list of params passed for all platforms
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              pipeline:
+                description: Pipeline holds the customizable option for pipeline component
+                properties:
+                  await-sidecar-readiness:
+                    type: boolean
+                  bundles-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  cluster-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  coschedule:
+                    type: string
+                  default-affinity-assistant-pod-template:
+                    type: string
+                  default-cloud-events-sink:
+                    type: string
+                  default-forbidden-env:
+                    type: string
+                  default-managed-by-label-value:
+                    type: string
+                  default-max-matrix-combinations-count:
+                    type: string
+                  default-pod-template:
+                    type: string
+                  default-resolver-type:
+                    type: string
+                  default-service-account:
+                    type: string
+                  default-task-run-workspace-binding:
+                    type: string
+                  default-timeout-minutes:
+                    type: integer
+                  disable-affinity-assistant:
+                    description: |-
+                      Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                      This field is removed from pipeline component.
+                      Keeping here to maintain API compatibility during upgrades.
+                    type: boolean
+                  disable-creds-init:
+                    type: boolean
+                  disable-inline-spec:
+                    type: string
+                  embedded-status:
+                    type: string
+                  enable-api-fields:
+                    type: string
+                  enable-bundles-resolver:
+                    type: boolean
+                  enable-cel-in-whenexpression:
+                    type: boolean
+                  enable-cluster-resolver:
+                    type: boolean
+                  enable-custom-tasks:
+                    type: boolean
+                  enable-git-resolver:
+                    type: boolean
+                  enable-hub-resolver:
+                    type: boolean
+                  enable-param-enum:
+                    type: boolean
+                  enable-provenance-in-status:
+                    type: boolean
+                  enable-step-actions:
+                    type: boolean
+                  enable-tekton-oci-bundles:
+                    description: |-
+                      not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                      this field is removed from pipeline component
+                      keeping here to maintain the API compatibility
+                    type: boolean
+                  enforce-nonfalsifiability:
+                    type: string
+                  git-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  hub-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  keep-pod-on-cancel:
+                    type: boolean
+                  max-result-size:
+                    type: integer
+                  metrics.count.enable-reason:
+                    type: boolean
+                  metrics.pipelinerun.duration-type:
+                    type: string
+                  metrics.pipelinerun.level:
+                    type: string
+                  metrics.taskrun.duration-type:
+                    type: string
+                  metrics.taskrun.level:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: The params to customize different components of Pipelines
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  require-git-ssh-secret-known-hosts:
+                    type: boolean
+                  results-from:
+                    type: string
+                  running-in-environment-with-injected-sidecars:
+                    type: boolean
+                  scope-when-expressions-to-task:
+                    description: ScopeWhenExpressionsToTask is deprecated and never
+                      used.
+                    type: boolean
+                  send-cloudevents-for-runs:
+                    description: |-
+                      Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                      (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                      CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                      the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                      effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                      when a custom task controller already sends its own CloudEvents.
+                    type: boolean
+                  set-security-context:
+                    type: boolean
+                  traces.credentialsSecret:
+                    description: CredentialsSecret is the name of the secret containing
+                      credentials for the tracing endpoint
+                    type: string
+                  traces.enabled:
+                    description: Enabled controls whether tracing is enabled or not
+                    type: boolean
+                  traces.endpoint:
+                    description: Endpoint is the URL for the OpenTelemetry trace collector
+                    type: string
+                  trusted-resources-verification-no-match-policy:
+                    type: string
+                  verification-mode:
+                    type: string
+                type: object
+              platforms:
+                description: Platforms allows configuring platform specific configurations
+                properties:
+                  kubernetes:
+                    description: Kubernetes allows configuring kubernetes specific
+                      components and configurations
+                    properties:
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  openshift:
+                    description: OpenShift allows configuring openshift specific components
+                      and configurations
+                    properties:
+                      enableCentralTLSConfig:
+                        description: |-
+                          EnableCentralTLSConfig controls TLS configuration inheritance from the
+                          cluster's APIServer TLS security profile. When enabled (the default),
+                          TLS settings (minimum version, cipher suites, curve preferences) are
+                          automatically derived from the cluster-wide security policy and injected
+                          into Tekton component containers that support TLS configuration.
+                          Set to false to opt out and manage TLS settings manually.
+                          Default: true (opt-out)
+                        type: boolean
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      scc:
+                        description: SCC allows configuring security context constraints
+                          used by workloads
+                        properties:
+                          default:
+                            description: |-
+                              Default contains the default SCC that will be attached to the service
+                              account used for workloads (`pipeline` SA by default) and defined in
+                              PipelineProperties.OptionalPipelineProperties.DefaultServiceAccount
+                            type: string
+                          maxAllowed:
+                            description: |-
+                              MaxAllowed specifies the highest SCC that can be requested for in a
+                              namespace or in the Default field.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              profile:
+                type: string
+              pruner:
+                description: Pruner holds the prune config
+                properties:
+                  disabled:
+                    description: enable or disable pruner feature
+                    type: boolean
+                  keep:
+                    description: |-
+                      The number of resource to keep
+                      You dont want to delete all the pipelinerun/taskrun's by a cron
+                    type: integer
+                  keep-since:
+                    description: |-
+                      KeepSince keeps the resources younger than the specified value
+                      Its value is taken in minutes
+                    type: integer
+                  prune-per-resource:
+                    description: apply the prune job to the individual resources
+                    type: boolean
+                  resources:
+                    description: The resources which need to be pruned
+                    items:
+                      type: string
+                    type: array
+                  schedule:
+                    description: How frequent pruning should happen
+                    type: string
+                  startingDeadlineSeconds:
+                    description: |-
+                      Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
+                      Missed jobs executions will be counted as failed ones.
+                    type: integer
+                required:
+                - disabled
+                type: object
+              result:
+                description: Result holds the customize option for results component
+                properties:
+                  auth_disable:
+                    type: boolean
+                  auth_impersonate:
+                    type: boolean
+                  db_enable_auto_migration:
+                    type: boolean
+                  db_host:
+                    type: string
+                  db_name:
+                    type: string
+                  db_port:
+                    type: integer
+                  db_secret_name:
+                    type: string
+                  db_secret_password_key:
+                    type: string
+                  db_secret_user_key:
+                    type: string
+                  db_sslmode:
+                    type: string
+                  db_sslrootcert:
+                    type: string
+                  disabled:
+                    description: enable or disable Result Component
+                    type: boolean
+                  gcs_bucket_name:
+                    type: string
+                  gcs_creds_secret_key:
+                    type: string
+                  gcs_creds_secret_name:
+                    type: string
+                  is_external_db:
+                    type: boolean
+                  log_level:
+                    type: string
+                  logging_plugin_api_url:
+                    type: string
+                  logging_plugin_ca_cert:
+                    type: string
+                  logging_plugin_forwarder_delay_duration:
+                    type: integer
+                  logging_plugin_multipart_regex:
+                    type: string
+                  logging_plugin_namespace_key:
+                    type: string
+                  logging_plugin_proxy_path:
+                    type: string
+                  logging_plugin_query_limit:
+                    type: integer
+                  logging_plugin_query_params:
+                    type: string
+                  logging_plugin_static_labels:
+                    type: string
+                  logging_plugin_tls_verification_disable:
+                    type: boolean
+                  logging_plugin_token_path:
+                    type: string
+                  logging_pvc_name:
+                    type: string
+                  logs_api:
+                    type: boolean
+                  logs_buffer_size:
+                    type: integer
+                  logs_path:
+                    type: string
+                  logs_type:
+                    type: string
+                  loki_stack_name:
+                    type: string
+                  loki_stack_namespace:
+                    type: string
+                  options:
+                    description: Options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  prometheus_histogram:
+                    type: boolean
+                  prometheus_port:
+                    type: integer
+                  route_enabled:
+                    description: Route configuration for Results API service exposure
+                    type: boolean
+                  route_host:
+                    type: string
+                  route_path:
+                    type: string
+                  route_tls_termination:
+                    type: string
+                  secret_name:
+                    description: |-
+                      name of the secret used to get S3 credentials and
+                      pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                    type: string
+                  server_port:
+                    type: integer
+                  storage_emulator_host:
+                    type: string
+                  tls_hostname_override:
+                    type: string
+                required:
+                - disabled
+                - is_external_db
+                type: object
+              scheduler:
+                description: To enable Pipeline Scheduling on Single Cluster or Multiple
+                  Clusters
+                properties:
+                  config.yaml:
+                    description: |-
+                      This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                      match the key here
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    description: enable or disable TektonScheduler Component
+                    type: boolean
+                  multi-cluster-disabled:
+                    type: boolean
+                  multi-cluster-role:
+                    description: |-
+                      MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                      can be one of Hub or Spoke
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - config.yaml
+                - disabled
+                - multi-cluster-disabled
+                - multi-cluster-role
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              targetNamespaceMetadata:
+                description: holds target namespace metadata
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              tektonpruner:
+                description: New EventBasedPruner which provides more granular control
+                  over TaskRun and PipelineRuns
+                properties:
+                  disabled:
+                    description: enable or disable TektonPruner Component
+                    type: boolean
+                  global-config:
+                    x-kubernetes-preserve-unknown-fields: true
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - global-config
+                type: object
+              trigger:
+                description: Trigger holds the customizable option for triggers component
+                properties:
+                  default-service-account:
+                    type: string
+                  disabled:
+                    description: enable or disable Trigger Component
+                    type: boolean
+                  enable-api-fields:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                type: object
+            type: object
+          status:
+            description: TektonConfigStatus defines the observed state of TektonConfig
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              profile:
+                description: The profile installed
+                type: string
+              tektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektoninstallersets.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonInstallerSet
+    listKind: TektonInstallerSetList
+    plural: tektoninstallersets
+    singular: tektoninstallerset
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
+            properties:
+              manifests:
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonpipelines.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonPipeline
+    listKind: TektonPipelineList
+    plural: tektonpipelines
+    singular: tektonpipeline
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPipeline is the Schema for the tektonpipelines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
+            properties:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the proxy-webhook
+                  workload deployed by TektonPipeline.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                description: |-
+                  Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                  (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                  CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                  the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                  effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                  when a custom task controller already sends its own CloudEvents.
+                type: boolean
+              set-security-context:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
+                type: string
+            type: object
+          status:
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonresults.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonResult
+    listKind: TektonResultList
+    plural: tektonresults
+    singular: tektonresult
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonResult is the Schema for the tektonresults API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonResultSpec defines the desired state of TektonResult
+            properties:
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                type: integer
+              storage_emulator_host:
+                type: string
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              tls_hostname_override:
+                type: string
+            required:
+            - disabled
+            - is_external_db
+            type: object
+          status:
+            description: TektonResultStatus defines the observed state of TektonResult
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektontriggers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonTrigger
+    listKind: TektonTriggerList
+    plural: tektontriggers
+    singular: tektontrigger
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonTrigger is the Schema for the tektontriggers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
+              disabled:
+                description: enable or disable Trigger Component
+                type: boolean
+              enable-api-fields:
+                type: string
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonTrigger
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            type: object
+          status:
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonpruners.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPruner is the Schema for the TektonPruner API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              disabled:
+                description: enable or disable TektonPruner Component
+                type: boolean
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - global-config
+            type: object
+          status:
+            description: TektonPrunerStatus defines the observed state of TektonPruner
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonschedulers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonScheduler
+    listKind: TektonSchedulerList
+    plural: tektonschedulers
+    singular: tektonscheduler
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonScheduler is the Schema for the TektonScheduler API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config.yaml:
+                description: |-
+                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                  match the key here
+                x-kubernetes-preserve-unknown-fields: true
+              disabled:
+                description: enable or disable TektonScheduler Component
+                type: boolean
+              multi-cluster-disabled:
+                type: boolean
+              multi-cluster-role:
+                description: |-
+                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                  can be one of Hub or Spoke
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - config.yaml
+            - disabled
+            - multi-cluster-disabled
+            - multi-cluster-role
+            type: object
+          status:
+            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tekton-scheduler:
+                description: The current installer set name for TektonScheduler
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonmulticlusterproxyaaes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: TektonMulticlusterProxyAAE
+    listKind: TektonMulticlusterProxyAAEList
+    plural: tektonmulticlusterproxyaaes
+    singular: tektonmulticlusterproxyaae
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additional fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: syncerservices.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  preserveUnknownFields: false
+  group: operator.tekton.dev
+  names:
+    kind: SyncerService
+    listKind: SyncerServiceList
+    plural: syncerservices
+    singular: syncerservice
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SyncerService is the Schema for the syncerservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: SyncerServiceStatus defines the observed state of SyncerService
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
+                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -10,6 +10,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: ManualApprovalGate
@@ -655,6 +656,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode
@@ -1378,6 +1380,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonAddon
@@ -1572,6 +1575,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonChain
@@ -2544,6 +2548,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonConfig
@@ -4646,6 +4651,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonInstallerSet
@@ -4760,6 +4766,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPipeline
@@ -5631,6 +5638,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonResult
@@ -6520,6 +6528,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonTrigger
@@ -7223,6 +7232,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPruner
@@ -8046,6 +8056,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonScheduler
@@ -8721,6 +8732,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonMulticlusterProxyAAE
@@ -9365,6 +9377,7 @@ metadata:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: SyncerService

--- a/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: ManualApprovalGate

--- a/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: openshiftpipelinesascodes.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: OpenShiftPipelinesAsCode

--- a/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: SyncerService

--- a/config/base/generated-crds/operator.tekton.dev_tektonaddons.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonaddons.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonaddons.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonAddon

--- a/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonChain

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonConfig

--- a/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektondashboards.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektondashboards.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonDashboard

--- a/config/base/generated-crds/operator.tekton.dev_tektoninstallersets.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektoninstallersets.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonInstallerSet

--- a/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonMulticlusterProxyAAE

--- a/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPipeline

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonPruner

--- a/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonResult

--- a/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonScheduler

--- a/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
@@ -6,6 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
 spec:
+  preserveUnknownFields: false
   group: operator.tekton.dev
   names:
     kind: TektonTrigger

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -86,6 +86,21 @@ strip_int_formats() {
   grep -v '^\s*format: int\(32\|64\)$'
 }
 
+# inject_preserve_unknown_false adds `preserveUnknownFields: false` under spec.
+# Kube fills this in server-side on v1 CRDs where omitted; making it explicit
+# prevents ArgoCD server-side-apply from flagging every CRD as OutOfSync.
+inject_preserve_unknown_false() {
+  while IFS= read -r line; do
+    if [[ "$line" == "  preserveUnknownFields:"* ]]; then
+      continue
+    fi
+    printf '%s\n' "$line"
+    if [ "$line" = "spec:" ]; then
+      printf '  preserveUnknownFields: false\n'
+    fi
+  done
+}
+
 # assemble_helm_crds assembles a Helm chart CRD file from multiple generated CRDs
 assemble_helm_crds() {
   local output_file="$1"
@@ -131,8 +146,22 @@ write_config_crd "${GENERATED_DIR}/operator.tekton.dev_openshiftpipelinesascodes
 
 echo ""
 
-# Step 2: Assemble Helm chart CRDs
-echo "Step 2: Assembling Helm chart CRD files..."
+# Step 2: Inject preserveUnknownFields: false into every generated CRD in-place.
+echo "Step 2: Injecting preserveUnknownFields: false into generated CRDs..."
+
+# Kube fills `spec.preserveUnknownFields: false` in server-side on v1 CRDs where
+# omitted, causing ArgoCD server-side-apply to flag every CRD as OutOfSync.
+# Injecting it here covers both kustomize consumers (which read generated-crds/
+# directly) and the Helm chart pipeline (assembled below), and keeps the field
+# sticky across future `make generate-crds` runs.
+for crd_file in "${GENERATED_DIR}"/*.yaml; do
+  inject_preserve_unknown_false < "$crd_file" > "${crd_file}.tmp" && mv "${crd_file}.tmp" "$crd_file"
+done
+
+echo ""
+
+# Step 3: Assemble Helm chart CRDs
+echo "Step 3: Assembling Helm chart CRD files..."
 
 assemble_helm_crds \
   "${HELM_DIR}/kubernetes-crds.yaml" \
@@ -168,8 +197,8 @@ assemble_helm_crds \
   "operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" \
   "operator.tekton.dev_syncerservices.yaml"
 
-# Step 3: Validate CRD sizes (etcd has a 256KB object size limit)
-echo "Step 3: Validating CRD sizes..."
+# Step 4: Validate CRD sizes (etcd has a 256KB object size limit)
+echo "Step 4: Validating CRD sizes..."
 
 MAX_SIZE=262144 # 256KB
 FAILED=0


### PR DESCRIPTION
# Changes

ArgoCD 3.0+ flags CRDs as `OutOfSync` because `kube-apiserver` fills in `spec.preserveUnknownFields: false` server-side on v1 CRDs where the field is omitted (ArgoCD 2.x ignored this diff by default; the built-in ignore was removed in 3.0 — see the [3.0 upgrade notes](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/#removing-default-ignores-of-preserveunknownfields-for-crd)). Adding the field explicitly in Git makes the live-vs-source diff disappear on all versions. Note ArgoCD's own docs suggest removing the field or adding an `ignoreDifferences` entry as the canonical fix; the explicit `false` here is a workable alternative that also keeps the field visible for non-ArgoCD consumers.

- Adds the field to all 14 CRDs in `config/base/generated-crds/` (kustomize path) and all 13 CRDs in each of `kubernetes-crds.yaml` and `openshift-crds.yaml` (Helm chart path).
- Wires the injection into the `generate-crds` Makefile target (right after controller-gen writes `config/base/generated-crds/`) so every regeneration preserves the field — a bare `make generate-crds` can no longer drop it from the kustomize source of truth, and the Helm bundles assembled by `hack/sync-helm-crds.sh` inherit it.

# Submitter Checklist

These are criteria that every PR should meet, please check them off as you review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```

---

**AI assistance:** developed with [opencode](https://opencode.ai) (GLM model) under my direction; every commit carries an `Assisted-by:` trailer per the [AI contribution policy](https://github.com/tektoncd/community/blob/main/ai-contribution-policy.md). I drove scoping and decisions, reviewed every change, and verified each push — chart rendering plus the `generate-crds`/`sync-helm-crds` round-trip.

