### PR TITLE
feat(tektonpipeline): add NetworkPolicy for pipeline core components 

### DIFF
--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -47,24 +47,25 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | `pipeline-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-pipelines` |
 | `pipeline-controller` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
-| | egress | all | API server (NP cannot select host-network endpoints) |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `pipeline-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `pipeline-events-controller` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | TCP/80, 443 | Any (CloudEvents sinks) |
 | `pipeline-resolvers` | ingress | TCP/8080 | Pipeline controller pods |
 | | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | | egress | TCP/80, 443 | Any (git HTTPS, OCI registries, Tekton Hub, http resolver) |
 | | egress | TCP/22 | Any (git clone over SSH) |
 | `tekton-proxy-webhook-default-deny` | deny all | — | All pods with `name: tekton-operator` (proxy-webhook) |
 | `proxy-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 ### TektonTrigger
 
@@ -73,15 +74,15 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | `tekton-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-triggers` |
 | `triggers-controller` | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `triggers-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `triggers-core-interceptors` | ingress | TCP/8443 | All namespaces (EventListeners) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | | egress | TCP/80, 443 | Any (external APIs e.g. GitHub) |
 
 ### Console Plugin (OpenShift only)
@@ -130,10 +131,10 @@ the operator's bundle never affects unrelated pods that might share the namespac
 |---|---|---|---|
 | `tekton-operator` / `openshift-pipelines-operator` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | `tekton-operator-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 **OpenShift caveat**: `openshift-operators` is a shared namespace where OLM installs
 operators from OperatorHub, many of which ship no NetworkPolicy of their own. To

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -7,8 +7,8 @@ weight: 15
 # NetworkPolicy
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
-Currently TektonTrigger and TektonPipeline (proxy-webhook only) are supported;
-other components will be added later.
+Currently TektonPipeline (core controllers, resolvers, and proxy-webhook) and
+TektonTrigger are supported; other components will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -40,25 +40,49 @@ The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger` a
 When NetworkPolicy is enabled (the default), the following policies are applied
 to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 
+### TektonPipeline
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `pipeline-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-pipelines` |
+| `pipeline-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (NP cannot select host-network endpoints) |
+| `pipeline-webhook` | ingress | TCP/8443 | Any (admission webhook) |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server |
+| `pipeline-events-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server |
+| `pipeline-resolvers` | ingress | TCP/8080 | Pipeline controller pods |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server |
+| | egress | TCP/80, 443 | Any (git HTTPS, OCI registries, Tekton Hub, http resolver) |
+| | egress | TCP/22 | Any (git clone over SSH) |
+| `tekton-proxy-webhook-default-deny` | deny all | — | All pods with `name: tekton-operator` (proxy-webhook) |
+| `proxy-webhook` | ingress | TCP/8443 | Any (admission webhook) |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server |
+
+### TektonTrigger
+
 | Policy | Direction | Port | Source / Destination |
 |---|---|---|---|
 | `tekton-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-triggers` |
 | `triggers-controller` | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | all | API server |
 | `triggers-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | all | API server |
 | `triggers-core-interceptors` | ingress | TCP/8443 | All namespaces (EventListeners) |
 | | ingress | TCP/9000 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | all | API server |
 | | egress | TCP/80, 443 | Any (external APIs e.g. GitHub) |
-| `tekton-proxy-webhook-default-deny` | deny all | — | All pods with `name: tekton-operator` (proxy-webhook) in the Pipeline target namespace |
-| `proxy-webhook` | ingress | TCP/8443 | Any (admission webhook) |
-| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 ### Console Plugin (OpenShift only)
 
@@ -72,6 +96,12 @@ user's browser via the OpenShift Console's proxy, not on this pod.
 
 These are static manifests shipped with the TektonConfig console plugin resources,
 not reconciled via `spec.networkPolicy`.
+
+All policies above are applied to the operand namespace (e.g. `tekton-pipelines`
+or `openshift-pipelines`). They do not cover the operator's own namespace
+(`tekton-operator` / `openshift-operators`), which ships fixed, non-configurable
+NetworkPolicies as part of the operator's own install manifests/bundle (see
+[Operator's own namespace](#operators-own-namespace) below).
 
 ### Platform differences
 
@@ -100,10 +130,10 @@ the operator's bundle never affects unrelated pods that might share the namespac
 |---|---|---|---|
 | `tekton-operator` / `openshift-pipelines-operator` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | all | API server |
 | `tekton-operator-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | all | API server |
 
 **OpenShift caveat**: `openshift-operators` is a shared namespace where OLM installs
 operators from OperatorHub, many of which ship no NetworkPolicy of their own. To

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_validation.go
@@ -36,7 +36,6 @@ var (
 )
 
 func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) {
-
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
@@ -53,11 +52,12 @@ func (tp *TektonPipeline) Validate(ctx context.Context) (errs *apis.FieldError) 
 
 	errs = errs.Also(tp.Spec.Options.validate("spec"))
 
+	errs = errs.Also(tp.Spec.NetworkPolicy.validate("spec.networkPolicy"))
+
 	return errs
 }
 
 func (p *PipelineProperties) validate(path string) (errs *apis.FieldError) {
-
 	if !validatePipelineAllowedApiFields.Has(p.EnableApiFields) {
 		errs = errs.Also(apis.ErrInvalidValue(p.EnableApiFields, fmt.Sprintf("%s.enable-api-fields", path)))
 	}

--- a/pkg/reconciler/common/networkpolicy/networkpolicy.go
+++ b/pkg/reconciler/common/networkpolicy/networkpolicy.go
@@ -143,6 +143,17 @@ func InternetEgressRule() networkingv1.NetworkPolicyEgressRule {
 	}
 }
 
+// SSHEgressRule allows TCP egress on port 22 for git clone over SSH.
+func SSHEgressRule() networkingv1.NetworkPolicyEgressRule {
+	tcp := corev1.ProtocolTCP
+	sshPort := intstr.FromInt32(22)
+	return networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &sshPort},
+		},
+	}
+}
+
 // PrometheusIngressRule allows ingress from the monitoring namespace on the given port.
 func PrometheusIngressRule(p PlatformParams, port intstr.IntOrString) networkingv1.NetworkPolicyIngressRule {
 	tcp := corev1.ProtocolTCP

--- a/pkg/reconciler/common/networkpolicy/networkpolicy_test.go
+++ b/pkg/reconciler/common/networkpolicy/networkpolicy_test.go
@@ -177,6 +177,19 @@ func TestInternetEgressRule(t *testing.T) {
 	}
 }
 
+func TestSSHEgressRule(t *testing.T) {
+	rule := networkpolicy.SSHEgressRule()
+	if len(rule.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(rule.Ports))
+	}
+	if rule.Ports[0].Port.IntVal != 22 {
+		t.Errorf("expected port 22, got %v", rule.Ports[0].Port.IntVal)
+	}
+	if len(rule.To) != 0 {
+		t.Errorf("expected no To restriction for SSH egress, got %v", rule.To)
+	}
+}
+
 func TestAPIServerEgressRule(t *testing.T) {
 	rule := networkpolicy.APIServerEgressRule()
 	if len(rule.Ports) != 0 {

--- a/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -72,18 +73,113 @@ func proxyWebhookDefaultDenyPolicy() networkingv1.NetworkPolicy {
 	return networkpolicy.DefaultDenyPolicy("tekton-proxy-webhook-default-deny", proxyWebhookPodSelector)
 }
 
-// reconcileNetworkPolicies reconciles every NetworkPolicy owned by TektonPipeline as a
-// single CustomSet. Currently that's just the proxy-webhook's; as more workloads gain
-// NetworkPolicy support, append their <workload>DefaultDenyPolicy/<workload>DefaultPolicies
-// results into defaults below rather than renaming or overloading these.
+func pipelineDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(9090)
+	webhookPort := intstr.FromInt32(8443)
+	resolverPort := intstr.FromInt32(8080)
+	tcp := corev1.ProtocolTCP
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-pipelines-controller"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline-webhook"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-pipelines-webhook"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.WebhookIngressRule("", webhookPort),
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline-events-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-events-controller"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline-resolvers"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-pipelines-resolvers"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "tekton-pipelines-controller"},
+							}},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &resolverPort},
+						},
+					},
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+					networkpolicy.InternetEgressRule(),
+					networkpolicy.SSHEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func pipelineDefaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy(
+		"pipeline-default-deny",
+		metav1.LabelSelector{
+			MatchLabels: map[string]string{"app.kubernetes.io/part-of": "tekton-pipelines"},
+		},
+	)
+}
+
 func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, tp *v1alpha1.TektonPipeline) error {
 	if tp.Spec.NetworkPolicy.Disabled {
 		return r.installerSetClient.CleanupCustomSet(ctx, "pipeline-network-policies")
 	}
-	defaults := append(
-		[]networkingv1.NetworkPolicy{proxyWebhookDefaultDenyPolicy()},
-		proxyWebhookDefaultPolicies(r.platformParams)...,
-	)
+	defaults := []networkingv1.NetworkPolicy{
+		proxyWebhookDefaultDenyPolicy(),
+		pipelineDefaultDenyPolicy(),
+	}
+	defaults = append(defaults, proxyWebhookDefaultPolicies(r.platformParams)...)
+	defaults = append(defaults, pipelineDefaultPolicies(r.platformParams)...)
+
 	manifest, err := networkpolicy.Generate(
 		tp.Spec.NetworkPolicy,
 		tp.Spec.GetTargetNamespace(),

--- a/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/networkpolicies.go
@@ -126,6 +126,7 @@ func pipelineDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
 					networkpolicy.APIServerEgressRule(),
+					networkpolicy.InternetEgressRule(),
 				},
 			},
 		},

--- a/test/e2e/common/05_tektonpipeline_networkpolicy_test.go
+++ b/test/e2e/common/05_tektonpipeline_networkpolicy_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,6 +56,11 @@ func TestTektonPipelineNetworkPolicy(t *testing.T) {
 	expectedPolicies := []string{
 		"tekton-proxy-webhook-default-deny",
 		"proxy-webhook",
+		"pipeline-default-deny",
+		"pipeline-controller",
+		"pipeline-webhook",
+		"pipeline-events-controller",
+		"pipeline-resolvers",
 	}
 
 	t.Run("default-policies-created", func(t *testing.T) {
@@ -70,7 +76,8 @@ func TestTektonPipelineNetworkPolicy(t *testing.T) {
 	t.Run("proxy-webhook-functional-with-networkpolicies", func(t *testing.T) {
 		taskRun := createNetworkPolicyProbeTaskRun(crNames.TargetNamespace)
 		createdTaskRun, err := clients.TektonClient.TaskRuns(crNames.TargetNamespace).Create(
-			context.TODO(), taskRun, metav1.CreateOptions{})
+			context.TODO(), taskRun, metav1.CreateOptions{},
+		)
 		if err != nil {
 			t.Fatalf("failed to create TaskRun: %v", err)
 		}
@@ -91,6 +98,99 @@ func TestTektonPipelineNetworkPolicy(t *testing.T) {
 		); err != nil {
 			t.Fatalf("TaskRun did not complete successfully under NetworkPolicy: %v", err)
 		}
+	})
+
+	t.Run("resolvers-functional-with-networkpolicies", func(t *testing.T) {
+		t.Run("cluster-resolver", func(t *testing.T) {
+			task := &pipelinev1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "np-e2e-cluster-task",
+					Namespace: crNames.TargetNamespace,
+				},
+				Spec: pipelinev1.TaskSpec{
+					Steps: []pipelinev1.Step{{
+						Name: "echo", Image: "busybox:stable",
+						Command: []string{"echo"}, Args: []string{"cluster resolver works"},
+					}},
+				},
+			}
+			if _, err := clients.TektonClient.Tasks(crNames.TargetNamespace).Create(
+				context.TODO(), task, metav1.CreateOptions{},
+			); err != nil {
+				t.Fatalf("failed to create Task: %v", err)
+			}
+			defer clients.TektonClient.Tasks(crNames.TargetNamespace).Delete(
+				context.TODO(), task.Name, metav1.DeleteOptions{},
+			)
+
+			tr := &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "np-e2e-cluster-resolver-",
+					Namespace:    crNames.TargetNamespace,
+				},
+				Spec: pipelinev1.TaskRunSpec{
+					TaskRef: &pipelinev1.TaskRef{
+						ResolverRef: pipelinev1.ResolverRef{
+							Resolver: "cluster",
+							Params: []pipelinev1.Param{
+								{Name: "kind", Value: *pipelinev1.NewStructuredValues("task")},
+								{Name: "name", Value: *pipelinev1.NewStructuredValues("np-e2e-cluster-task")},
+								{Name: "namespace", Value: *pipelinev1.NewStructuredValues(crNames.TargetNamespace)},
+							},
+						},
+					},
+				},
+			}
+			created, err := clients.TektonClient.TaskRuns(crNames.TargetNamespace).Create(
+				context.TODO(), tr, metav1.CreateOptions{},
+			)
+			if err != nil {
+				t.Fatalf("failed to create TaskRun: %v", err)
+			}
+			if err := resources.WaitForTaskRunHappy(clients.TektonClient, crNames.TargetNamespace,
+				created.Name, taskRunSucceeded); err != nil {
+				t.Fatalf("cluster resolver TaskRun failed: %v", err)
+			}
+		})
+
+		t.Run("hub-resolver", func(t *testing.T) {
+			tr := &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "np-e2e-hub-resolver-",
+					Namespace:    crNames.TargetNamespace,
+				},
+				Spec: pipelinev1.TaskRunSpec{
+					TaskRef: &pipelinev1.TaskRef{
+						ResolverRef: pipelinev1.ResolverRef{
+							Resolver: "hub",
+							Params: []pipelinev1.Param{
+								{Name: "catalog", Value: *pipelinev1.NewStructuredValues("tekton-catalog-tasks")},
+								{Name: "type", Value: *pipelinev1.NewStructuredValues("artifact")},
+								{Name: "kind", Value: *pipelinev1.NewStructuredValues("task")},
+								{Name: "name", Value: *pipelinev1.NewStructuredValues("git-clone")},
+								{Name: "version", Value: *pipelinev1.NewStructuredValues("0.9")},
+							},
+						},
+					},
+					Workspaces: []pipelinev1.WorkspaceBinding{
+						{Name: "output", EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
+					Params: []pipelinev1.Param{
+						{Name: "url", Value: *pipelinev1.NewStructuredValues("https://github.com/tektoncd/pipeline")},
+					},
+				},
+			}
+			created, err := clients.TektonClient.TaskRuns(crNames.TargetNamespace).Create(
+				context.TODO(), tr, metav1.CreateOptions{},
+			)
+			if err != nil {
+				t.Fatalf("failed to create TaskRun: %v", err)
+			}
+			if err := resources.WaitForTaskRunHappy(clients.TektonClient, crNames.TargetNamespace,
+				created.Name, taskRunSucceeded); err != nil {
+				t.Fatalf("hub resolver TaskRun failed: %v", err)
+			}
+		})
 	})
 
 	t.Run("disable-removes-policies", func(t *testing.T) {
@@ -118,6 +218,16 @@ func TestTektonPipelineNetworkPolicy(t *testing.T) {
 		resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
 		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
 	})
+}
+
+func taskRunSucceeded(tr *pipelinev1.TaskRun) (bool, error) {
+	if tr.IsDone() {
+		if tr.IsSuccessful() {
+			return true, nil
+		}
+		return false, fmt.Errorf("TaskRun %s failed", tr.Name)
+	}
+	return false, nil
 }
 
 // createNetworkPolicyProbeTaskRun creates a minimal TaskRun whose Pod triggers the


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
TektonPipeline now ships default NetworkPolicy resources for pipeline-controller, pipeline-webhook, pipeline-events-controller, and pipeline-resolvers pods, restricting network access to
  only DNS, API server, Prometheus metrics, and webhook traffic. Resolvers additionally allow HTTP/HTTPS and SSH egress for git, bundle, hub, and http resolver types.
```
