### PR TITLE
fix(operator): allow all egress for API server in NetworkPolicy

### DIFF
--- a/config/kubernetes/base/networkpolicy.yaml
+++ b/config/kubernetes/base/networkpolicy.yaml
@@ -50,9 +50,11 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  - ports:
-    - protocol: TCP
-      port: 443
+  # Allow all egress for API server access: NetworkPolicy cannot select host-network
+  # endpoints, and the API server port is configurable (some SDNs use a different
+  # port), so an empty rule (no ports/to) is required here rather than restricting to
+  # TCP/443.
+  - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -84,6 +86,8 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
-  - ports:
-    - protocol: TCP
-      port: 443
+  # Allow all egress for API server access: NetworkPolicy cannot select host-network
+  # endpoints, and the API server port is configurable (some SDNs use a different
+  # port), so an empty rule (no ports/to) is required here rather than restricting to
+  # TCP/443.
+  - {}

--- a/config/openshift/base/networkpolicy.yaml
+++ b/config/openshift/base/networkpolicy.yaml
@@ -51,9 +51,11 @@ spec:
       port: 5353
     - protocol: TCP
       port: 5353
-  - ports:
-    - protocol: TCP
-      port: 6443
+  # Allow all egress for API server access: NetworkPolicy cannot select host-network
+  # endpoints, and the API server port is configurable (some SDNs use a different
+  # port), so an empty rule (no ports/to) is required here rather than restricting to
+  # TCP/6443.
+  - {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -85,6 +87,8 @@ spec:
       port: 5353
     - protocol: TCP
       port: 5353
-  - ports:
-    - protocol: TCP
-      port: 6443
+  # Allow all egress for API server access: NetworkPolicy cannot select host-network
+  # endpoints, and the API server port is configurable (some SDNs use a different
+  # port), so an empty rule (no ports/to) is required here rather than restricting to
+  # TCP/6443.
+  - {}

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -95,10 +95,15 @@ the operator's bundle never affects unrelated pods that might share the namespac
 |---|---|---|---|
 | `tekton-operator` / `openshift-pipelines-operator` | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (see note below) |
 | `tekton-operator-webhook` | ingress | TCP/8443 | Any (admission webhook) |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
-| | egress | TCP/443 or 6443 | API server |
+| | egress | all | API server (see note below) |
+
+The API server egress rule is unrestricted (no port/destination filter) rather than
+scoped to TCP/443 or 6443: NetworkPolicy cannot select host-network endpoints, and the
+API server's port is configurable (some SDNs use a different port), so a port-scoped
+rule would be unreliable across clusters.
 
 **OpenShift caveat**: `openshift-operators` is a shared namespace where OLM installs
 operators from OperatorHub, many of which ship no NetworkPolicy of their own. To


### PR DESCRIPTION
NetworkPolicy cannot select host-network endpoints, and the API server's port is
configurable (some SDNs use a different port than 443/6443), so a port-scoped egress
rule is unreliable across clusters. This mirrors the fix applied to TektonTrigger and
the proxy-webhook in #3755, but for the operator's own static NetworkPolicy manifests
(`tekton-operator` / `openshift-pipelines-operator` and `tekton-operator-webhook`),
which are not Go-reconciled and live in `config/kubernetes/base/networkpolicy.yaml`
and `config/openshift/base/networkpolicy.yaml`.

# Changes

- Replace the port-scoped API server egress rule (`TCP/443` on Kubernetes,
  `TCP/6443` on OpenShift) with an unrestricted egress rule (`- {}`) in both
  platform manifests, with a comment explaining why.
- Update `docs/NetworkPolicy.md` to describe the API server egress rule as
  unrestricted for the operator's own namespace, with a note explaining the
  rationale.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes docs (this is a docs/manifest-only change)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)