### PR TITLE
feat(tektonconfig): add NetworkPolicy for console plugin

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-config/00-console-plugin/pipeline_console_plugin.yaml
@@ -170,3 +170,46 @@ spec:
           port: 443
   i18n:
     loadType: Preload   # options: Preload, Lazy
+
+# NetworkPolicy: default-deny for console plugin pods
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pipelines-console-plugin-deny
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  podSelector:
+    matchLabels:
+      app: pipelines-console-plugin
+  policyTypes:
+  - Ingress
+  - Egress
+
+# NetworkPolicy: allow ingress from OpenShift Console only.
+# The plugin is a static file server (nginx) with no outbound connections —
+# all API calls run in the user's browser via the Console's proxy.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pipelines-console-plugin
+  namespace: openshift-pipelines
+  labels:
+    app.kubernetes.io/part-of: tekton-config
+spec:
+  podSelector:
+    matchLabels:
+      app: pipelines-console-plugin
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-console
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -60,12 +60,18 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
 | | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
-The `proxy-webhook` policies apply to the TektonPipeline target namespace (e.g.
-`tekton-pipelines` or `openshift-pipelines`), where the operator deploys the
-proxy-webhook Deployment. They do not cover the operator's own namespace
-(`tekton-operator` / `openshift-operators`), which ships fixed, non-configurable
-NetworkPolicies as part of the operator's own install manifests/bundle (see
-[Operator's own namespace](#operators-own-namespace) below).
+### Console Plugin (OpenShift only)
+
+The console plugin is a static file server (nginx) — all API calls run in the
+user's browser via the OpenShift Console's proxy, not on this pod.
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `pipelines-console-plugin-deny` | deny all | — | All pods with `app: pipelines-console-plugin` |
+| `pipelines-console-plugin` | ingress | TCP/8443 | `openshift-console` namespace |
+
+These are static manifests shipped with the TektonConfig console plugin resources,
+not reconciled via `spec.networkPolicy`.
 
 ### Platform differences
 


### PR DESCRIPTION
Default-deny plus ingress from openshift-console on port 8443. No egress needed — the pod only serves static assets.


Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
The OpenShift Pipelines console plugin now ships default NetworkPolicy resources restricting ingress to only the OpenShift Console on port 8443. The plugin is a static file server with no
  egress required.
```
