### PR TITLE
feat: Add NetworkPolicy support for chains

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -704,6 +704,23 @@ spec:
               generateSigningSecret:
                 description: generate signing key
                 type: boolean
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonChain
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -1464,9 +1481,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
                   only components with NetworkPolicy reconciliation implemented. Other
-                  components (Chains, Results, Dashboard) do not yet act on this field.
+                  components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -898,6 +898,23 @@ spec:
               generateSigningSecret:
                 description: generate signing key
                 type: boolean
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonChain
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -1658,9 +1675,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
                   only components with NetworkPolicy reconciliation implemented. Other
-                  components (Chains, Results, Dashboard) do not yet act on this field.
+                  components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
@@ -291,6 +291,23 @@ spec:
               generateSigningSecret:
                 description: generate signing key
                 type: boolean
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonChain
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -573,9 +573,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
                   only components with NetworkPolicy reconciliation implemented. Other
-                  components (Chains, Results, Dashboard) do not yet act on this field.
+                  components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -8,7 +8,7 @@ weight: 15
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
 Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
-TektonTrigger, and Pipelines-as-Code are supported; other components
+TektonTrigger, TektonChain, and Pipelines-as-Code are supported; other components
 will be added later.
 
 Configuration is available via `TektonConfig`:
@@ -32,9 +32,9 @@ spec:
               - port: 9000
 ```
 
-The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger` and
-`TektonPipeline`. Users can also configure it directly on the `TektonTrigger` or
-`TektonPipeline` CR.
+The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger`,
+`TektonPipeline`, and `TektonChain`. Users can also configure it directly on the
+individual component CRs.
 
 ## Default Policies
 
@@ -85,6 +85,14 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
 | | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | | egress | TCP/80, 443 | Any (external APIs e.g. GitHub) |
+
+### TektonChain
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `chains-controller-default-deny` | deny all | — | All pods matching Chains controller selector |
+| `chains-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | all | Unrestricted (API server, OCI registries, Sigstore, KMS, storage backends — NP cannot select host-network endpoints) |
 
 ### OpenShift Pipelines-as-Code
 

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -67,6 +67,9 @@ type TektonChainSpec struct {
 	// Config holds the configuration for resources created by TektonChain
 	// +optional
 	Config Config `json:"config,omitempty"`
+	// NetworkPolicy configures NetworkPolicy creation for TektonChain workloads.
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 type Chain struct {

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -50,7 +50,11 @@ func (tc *TektonChain) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// execute common spec validations
 	errs = errs.Also(tc.Spec.CommonSpec.validate("spec"))
 
-	return errs.Also(tc.Spec.ValidateControllerEnv(), tc.Spec.ValidateChainConfig("spec"))
+	return errs.Also(
+		tc.Spec.ValidateControllerEnv(),
+		tc.Spec.ValidateChainConfig("spec"),
+		tc.Spec.NetworkPolicy.validate("spec.networkPolicy"),
+	)
 }
 
 func (tcs *TektonChainSpec) ValidateControllerEnv() (errs *apis.FieldError) {

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -411,5 +412,90 @@ func Test_ValidateTektonChain_ValidControllerEnv(t *testing.T) {
 	err := tc.Validate(context.TODO())
 	if err != nil {
 		t.Errorf("ValidateTektonChain: %v", err)
+	}
+}
+
+func Test_ValidateTektonChain_NetworkPolicyEmpty(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+	err := tc.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("expected no error for empty NetworkPolicy, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonChain_NetworkPolicyDisabled(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			NetworkPolicy: NetworkPolicyConfig{
+				Disabled: true,
+			},
+		},
+	}
+	err := tc.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("expected no error for disabled NetworkPolicy, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonChain_NetworkPolicyValidPolicyName(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			NetworkPolicy: NetworkPolicyConfig{
+				Policies: map[string]networkingv1.NetworkPolicySpec{
+					"my-custom-policy": {},
+				},
+			},
+		},
+	}
+	err := tc.Validate(context.TODO())
+	if err != nil {
+		t.Errorf("expected no error for valid policy name, got: %v", err)
+	}
+}
+
+func Test_ValidateTektonChain_NetworkPolicyInvalidPolicyName(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			NetworkPolicy: NetworkPolicyConfig{
+				Policies: map[string]networkingv1.NetworkPolicySpec{
+					"INVALID_NAME!": {},
+				},
+			},
+		},
+	}
+	err := tc.Validate(context.TODO())
+	if err == nil {
+		t.Error("expected error for invalid policy name, got nil")
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -135,9 +135,9 @@ type TektonConfigSpec struct {
 	// +optional
 	TargetNamespaceMetadata *NamespaceMetadata `json:"targetNamespaceMetadata,omitempty"`
 	// NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-	// This field is propagated to TektonTrigger and TektonPipeline, which are the
+	// This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
 	// only components with NetworkPolicy reconciliation implemented. Other
-	// components (Chains, Results, Dashboard) do not yet act on this field.
+	// components (Results, Dashboard) do not yet act on this field.
 	// +optional
 	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1640,6 +1640,7 @@ func (in *TektonChainSpec) DeepCopyInto(out *TektonChainSpec) {
 	out.CommonSpec = in.CommonSpec
 	in.Chain.DeepCopyInto(&out.Chain)
 	in.Config.DeepCopyInto(&out.Config)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/common/networkpolicy/networkpolicy.go
+++ b/pkg/reconciler/common/networkpolicy/networkpolicy.go
@@ -123,11 +123,16 @@ func DNSEgressRule(p PlatformParams) networkingv1.NetworkPolicyEgressRule {
 	}
 }
 
+// EgressToAll returns an unrestricted egress rule (empty rule = allow all).
+func EgressToAll() networkingv1.NetworkPolicyEgressRule {
+	return networkingv1.NetworkPolicyEgressRule{}
+}
+
 // APIServerEgressRule allows all egress so pods can reach the API server.
 // NetworkPolicy cannot select host-network endpoints, and the API server
 // port is configurable, so we must allow unrestricted egress.
 func APIServerEgressRule() networkingv1.NetworkPolicyEgressRule {
-	return networkingv1.NetworkPolicyEgressRule{}
+	return EgressToAll()
 }
 
 // InternetEgressRule allows egress on TCP 80 and 443 to any destination.

--- a/pkg/reconciler/kubernetes/tektonchain/controller.go
+++ b/pkg/reconciler/kubernetes/tektonchain/controller.go
@@ -26,6 +26,7 @@ import (
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	tektonChainreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonchain"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -66,6 +67,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		metrics, _ := common.NoMetrics()
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		c := &Reconciler{
 			operatorClientSet:  operatorclient.Get(ctx),
 			installerSetClient: client.NewInstallerSetClient(tisClient, operatorVer, chainVer, v1alpha1.KindTektonChain, metrics),
@@ -74,6 +80,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:   tektonPipelineinformer.Get(ctx),
 			operatorVersion:    operatorVer,
 			chainVersion:       chainVer,
+			platformParams:     params,
 		}
 		impl := tektonChainreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektonchain/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonchain/networkpolicies.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonchain
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// chainsControllerPodSelector matches the tekton-chains-controller Deployment's
+// spec.selector.matchLabels shipped in the upstream release manifest.
+var chainsControllerPodSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{
+		"app.kubernetes.io/name":      "controller",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/instance":  "default",
+		"app.kubernetes.io/part-of":   "tekton-chains",
+	},
+}
+
+// chainsControllerDefaultPolicies returns the default NetworkPolicies for the
+// Chains controller workload.
+//
+// Unrestricted egress for all other traffic.
+func chainsControllerDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(9090)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "chains-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: chainsControllerPodSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.EgressToAll(),
+				},
+			},
+		},
+	}
+}
+
+// chainsControllerDefaultDenyPolicy returns a scoped default-deny for the
+// Chains controller pod only.
+func chainsControllerDefaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy("chains-controller-default-deny", chainsControllerPodSelector)
+}
+
+// reconcileNetworkPolicies reconciles every NetworkPolicy owned by TektonChain
+// as a single CustomSet named "chain-network-policies".
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, tc *v1alpha1.TektonChain) error {
+	if tc.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, "chain-network-policies")
+	}
+	defaults := append(
+		[]networkingv1.NetworkPolicy{chainsControllerDefaultDenyPolicy()},
+		chainsControllerDefaultPolicies(r.platformParams)...,
+	)
+	manifest, err := networkpolicy.Generate(
+		tc.Spec.NetworkPolicy,
+		tc.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, tc, "chain-network-policies", &manifest, npPassthroughTransform, nil)
+}
+
+// npPassthroughTransform is a no-op FilterAndTransform used for pre-built
+// manifests where namespace injection is already handled by Generate.
+func npPassthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = npPassthroughTransform

--- a/pkg/reconciler/kubernetes/tektonchain/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonchain/networkpolicies_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonchain
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestChainsControllerDefaultPolicies_Count(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policies := chainsControllerDefaultPolicies(params)
+	if got := len(policies); got != 1 {
+		t.Fatalf("expected 1 policy, got %d", got)
+	}
+	if policies[0].Name != "chains-controller" {
+		t.Errorf("expected policy name %q, got %q", "chains-controller", policies[0].Name)
+	}
+}
+
+func TestChainsControllerDefaultPolicies_PolicyTypes(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policy := chainsControllerDefaultPolicies(params)[0]
+
+	if len(policy.Spec.PolicyTypes) != 2 {
+		t.Fatalf("expected 2 policy types, got %d", len(policy.Spec.PolicyTypes))
+	}
+	hasIngress, hasEgress := false, false
+	for _, pt := range policy.Spec.PolicyTypes {
+		if pt == networkingv1.PolicyTypeIngress {
+			hasIngress = true
+		}
+		if pt == networkingv1.PolicyTypeEgress {
+			hasEgress = true
+		}
+	}
+	if !hasIngress || !hasEgress {
+		t.Errorf("expected both Ingress and Egress policy types, got %v", policy.Spec.PolicyTypes)
+	}
+}
+
+func TestChainsControllerDefaultPolicies_Ingress(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policy := chainsControllerDefaultPolicies(params)[0]
+
+	if len(policy.Spec.Ingress) != 1 {
+		t.Fatalf("expected 1 ingress rule (Prometheus), got %d", len(policy.Spec.Ingress))
+	}
+	rule := policy.Spec.Ingress[0]
+	if len(rule.Ports) != 1 || rule.Ports[0].Port.IntVal != 9090 {
+		t.Errorf("expected ingress port 9090, got %v", rule.Ports)
+	}
+}
+
+func TestChainsControllerDefaultPolicies_EgressUnrestricted(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policy := chainsControllerDefaultPolicies(params)[0]
+
+	if len(policy.Spec.Egress) != 1 {
+		t.Fatalf("expected 1 egress rule (unrestricted), got %d", len(policy.Spec.Egress))
+	}
+	rule := policy.Spec.Egress[0]
+	if len(rule.Ports) != 0 {
+		t.Errorf("expected no port restriction (unrestricted egress), got %v", rule.Ports)
+	}
+	if len(rule.To) != 0 {
+		t.Errorf("expected no destination restriction (unrestricted egress), got %v", rule.To)
+	}
+}
+
+func TestChainsControllerDefaultPolicies_PodSelector(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policy := chainsControllerDefaultPolicies(params)[0]
+
+	labels := policy.Spec.PodSelector.MatchLabels
+	expected := map[string]string{
+		"app.kubernetes.io/name":      "controller",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/instance":  "default",
+		"app.kubernetes.io/part-of":   "tekton-chains",
+	}
+	for k, v := range expected {
+		if labels[k] != v {
+			t.Errorf("expected label %s=%s, got %s=%s", k, v, k, labels[k])
+		}
+	}
+}
+
+func TestChainsControllerDefaultDenyPolicy(t *testing.T) {
+	policy := chainsControllerDefaultDenyPolicy()
+
+	if policy.Name != "chains-controller-default-deny" {
+		t.Errorf("expected name %q, got %q", "chains-controller-default-deny", policy.Name)
+	}
+	if len(policy.Spec.Ingress) != 0 {
+		t.Errorf("expected no ingress rules (deny all), got %d", len(policy.Spec.Ingress))
+	}
+	if len(policy.Spec.Egress) != 0 {
+		t.Errorf("expected no egress rules (deny all), got %d", len(policy.Spec.Egress))
+	}
+	labels := policy.Spec.PodSelector.MatchLabels
+	if labels["app.kubernetes.io/part-of"] != "tekton-chains" {
+		t.Errorf("expected pod selector for tekton-chains, got %v", labels)
+	}
+}
+
+func TestChainsControllerDefaultPolicies_OpenShift(t *testing.T) {
+	params := networkpolicy.OpenShiftPlatformDefaults()
+	policy := chainsControllerDefaultPolicies(params)[0]
+
+	rule := policy.Spec.Ingress[0]
+	if len(rule.From) != 1 || rule.From[0].NamespaceSelector == nil {
+		t.Fatalf("expected Prometheus ingress with NamespaceSelector, got %v", rule.From)
+	}
+	nsLabels := rule.From[0].NamespaceSelector.MatchLabels
+	if nsLabels["openshift.io/cluster-monitoring"] != "true" {
+		t.Errorf("expected OpenShift Prometheus namespace selector, got %v", nsLabels)
+	}
+}

--- a/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
+++ b/pkg/reconciler/kubernetes/tektonchain/tektonchain.go
@@ -31,6 +31,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektonchainreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonchain"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
@@ -78,6 +79,8 @@ type Reconciler struct {
 	// pipelineInformer provides access to a shared informer and lister for
 	// TektonPipelines
 	pipelineInformer pipelineinformer.TektonPipelineInformer
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -620,7 +623,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonChain
 
 	// Mark InstallerSet Ready
 	tc.Status.MarkInstallerSetReady()
-	logger.Infow("InstallerSet not ready", "name", installedTIS.Name, "message", ready.Message)
+	logger.Infow("InstallerSet ready", "name", installedTIS.Name, "message", ready.Message)
+
+	if err := r.reconcileNetworkPolicies(ctx, tc); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		tc.Status.MarkInstallerSetNotReady(msg)
+		return nil
+	}
 
 	if err := r.extension.PostReconcile(ctx, tc); err != nil {
 		errMsg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
@@ -663,6 +676,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 			LabelSelector: labelSelector,
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonChain", err)
+		return err
+	}
+
+	if err := r.installerSetClient.CleanupCustomSet(ctx, "chain-network-policies"); err != nil {
+		logger.Error("failed to cleanup chain network policies installerset: ", err)
 		return err
 	}
 

--- a/pkg/reconciler/shared/tektonconfig/chain/chain.go
+++ b/pkg/reconciler/shared/tektonconfig/chain/chain.go
@@ -112,6 +112,11 @@ func UpdateChain(ctx context.Context, old *v1alpha1.TektonChain, new *v1alpha1.T
 		updated = true
 	}
 
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
+		updated = true
+	}
+
 	if !reflect.DeepEqual(old.Spec.Chain.Options, new.Spec.Chain.Options) {
 		old.Spec.Chain.Options = new.Spec.Chain.Options
 		updated = true
@@ -163,8 +168,9 @@ func GetTektonChainCR(config *v1alpha1.TektonConfig, operatorVersion string) *v1
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Config: config.Spec.Config,
-			Chain:  config.Spec.Chain,
+			Config:        config.Spec.Config,
+			Chain:         config.Spec.Chain,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 }

--- a/test/e2e/common/03_tektonchain_networkpolicy_test.go
+++ b/test/e2e/common/03_tektonchain_networkpolicy_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestTektonChainNetworkPolicy verifies NetworkPolicies are created by default
+// for the Chains controller workload, that the controller keeps working under
+// those policies (a TaskRun completes and Chains can reach the API server to
+// observe it), and that toggling spec.networkPolicy.disabled correctly adds
+// and removes the policies.
+func TestTektonChainNetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownChain(clients, crNames.TektonChain) })
+	defer utils.TearDownChain(clients, crNames.TektonChain)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+	resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonChainExists(clients.TektonChains(), crNames); err != nil {
+		t.Fatalf("TektonChain %q failed to create: %v", crNames.TektonChain, err)
+	}
+	resources.AssertTektonChainCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"chains-controller-default-deny",
+		"chains-controller",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	// A successful TaskRun proves the Chains controller is functional under
+	// NetworkPolicies: the controller watches the API server for TaskRun
+	// completions (egress to API server must work) and Prometheus scrapes
+	// metrics (ingress on port 9090). If the NetworkPolicy blocked API server
+	// access, the controller would crash-loop.
+	t.Run("chains-controller-functional-with-networkpolicies", func(t *testing.T) {
+		taskRun := createChainNPProbeTaskRun(crNames.TargetNamespace)
+		createdTaskRun, err := clients.TektonClient.TaskRuns(crNames.TargetNamespace).Create(
+			context.TODO(), taskRun, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create TaskRun: %v", err)
+		}
+
+		if err := resources.WaitForTaskRunHappy(
+			clients.TektonClient,
+			crNames.TargetNamespace,
+			createdTaskRun.Name,
+			func(tr *pipelinev1.TaskRun) (bool, error) {
+				if tr.IsDone() {
+					if tr.IsSuccessful() {
+						return true, nil
+					}
+					return false, fmt.Errorf("TaskRun failed")
+				}
+				return false, nil
+			},
+		); err != nil {
+			t.Fatalf("TaskRun did not complete successfully under NetworkPolicy: %v", err)
+		}
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		tc, err := clients.TektonChains().Get(context.TODO(), crNames.TektonChain, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonChain: %v", err)
+		}
+		tc.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.TektonChains().Update(context.TODO(), tc, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on TektonChain: %v", err)
+		}
+		resources.AssertTektonChainCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		tc, err := clients.TektonChains().Get(context.TODO(), crNames.TektonChain, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonChain: %v", err)
+		}
+		tc.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.TektonChains().Update(context.TODO(), tc, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on TektonChain: %v", err)
+		}
+		resources.AssertTektonChainCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}
+
+// createChainNPProbeTaskRun creates a minimal TaskRun that completes quickly.
+// Its completion exercises the Chains controller's API server watch (egress)
+// since Chains observes TaskRun completions to sign and attest artifacts.
+func createChainNPProbeTaskRun(namespace string) *pipelinev1.TaskRun {
+	return &pipelinev1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "chain-np-probe-taskrun-",
+			Namespace:    namespace,
+		},
+		Spec: pipelinev1.TaskRunSpec{
+			ServiceAccountName: "default",
+			TaskSpec: &pipelinev1.TaskSpec{
+				Steps: []pipelinev1.Step{
+					{
+						Name:    "echo",
+						Image:   "busybox:stable",
+						Command: []string{"echo"},
+						Args:    []string{"chains controller NetworkPolicy probe"},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Implements NetworkPolicy resources to restrict network access for the Tekton Chains controller.
Adds a `spec.networkPolicy` field to `TektonChainSpec` (propagated from `TektonConfig`) and a new `pkg/reconciler/kubernetes/tektonchain/networkpolicies.go`
that reconciles default-deny + allow policies in the operand namespace.
Default policies for the Chains controller pod:
- **Ingress**: Prometheus metrics scraping on port 9090
- **Egress**: DNS resolution via platform resolver + unrestricted egress (API server, OCI registries, Sigstore, KMS providers, storage backends)
Both platforms (Kubernetes and OpenShift) are supported via the existing `networkpolicy.PlatformParams` helper. Updates generated CRDs/Helm chart output and `docs/NetworkPolicy.md`.
Ref: SRVKP-12056

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Add NetworkPolicy support for the Chains controller. Default policies allow Prometheus metrics ingress on port 9090 and unrestricted egress, to reach the API server, OCI registries, Sigstore services, KMS providers, and various storage backends depending on configuration.
```
