### PR TITLE
ci: run image digest update weekly

### DIFF
--- a/.github/workflows/update-third-party-image-digests.yaml
+++ b/.github/workflows/update-third-party-image-digests.yaml
@@ -3,8 +3,8 @@ name: Update third-party image digests
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch: {}
   schedule:
-  # Run daily at 3AM UTC
-  - cron: '0 3 * * *'
+  # Run every Wednesday at 3AM UTC
+  - cron: '0 3 * * 3'
 
 permissions: {}
 


### PR DESCRIPTION


# Changes
Change the third-party image digest workflow from a daily
schedule to weekly on Wednesday at 3AM UTC, reducing
unnecessary CI execution.
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
