### PR TITLE
ci: sync go.mod when component versions are bumped

### DIFF
--- a/.github/workflows/bump-payload-on-main.yaml
+++ b/.github/workflows/bump-payload-on-main.yaml
@@ -28,6 +28,28 @@ jobs:
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         make components/bump 2> bump-output.txt || true
         cat bump-output.txt >&2
+    - name: sync go.mod with bumped components
+      run: |
+        if [[ ! -f bump-output.txt ]]; then exit 0; fi
+        IN_UPDATES=false
+        UPDATED=false
+        while IFS= read -r line; do
+          if [[ "${line}" == "BUMP_UPDATES_START" ]]; then IN_UPDATES=true; continue; fi
+          if [[ "${line}" == "BUMP_UPDATES_END" ]]; then IN_UPDATES=false; continue; fi
+          if [[ "${IN_UPDATES}" == "true" ]]; then
+            IFS='|' read -r name old_version new_version github <<< "${line}"
+            module="github.com/${github}"
+            if grep -q "^[[:space:]]*${module} " go.mod; then
+              echo "Updating go.mod: ${module} ${old_version} → ${new_version}"
+              go get "${module}@${new_version}"
+              UPDATED=true
+            fi
+          fi
+        done < bump-output.txt
+        if [[ "${UPDATED}" == "true" ]]; then
+          go mod tidy
+          go mod vendor
+        fi
     - name: generate commit message and PR body
       id: generate-message
       run: |

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -53,6 +53,28 @@ jobs:
       run: |
         /tmp/operator-tool bump --bugfix components.yaml 2> bump-output.txt || true
         cat bump-output.txt >&2
+    - name: sync go.mod with bumped components
+      run: |
+        if [[ ! -f bump-output.txt ]]; then exit 0; fi
+        IN_UPDATES=false
+        UPDATED=false
+        while IFS= read -r line; do
+          if [[ "${line}" == "BUMP_UPDATES_START" ]]; then IN_UPDATES=true; continue; fi
+          if [[ "${line}" == "BUMP_UPDATES_END" ]]; then IN_UPDATES=false; continue; fi
+          if [[ "${IN_UPDATES}" == "true" ]]; then
+            IFS='|' read -r name old_version new_version github <<< "${line}"
+            module="github.com/${github}"
+            if grep -q "^[[:space:]]*${module} " go.mod; then
+              echo "Updating go.mod: ${module} ${old_version} → ${new_version}"
+              go get "${module}@${new_version}"
+              UPDATED=true
+            fi
+          fi
+        done < bump-output.txt
+        if [[ "${UPDATED}" == "true" ]]; then
+          go mod tidy
+          go mod vendor
+        fi
     - name: generate commit message and PR body
       id: generate-message
       run: |


### PR DESCRIPTION
Parse bump-output.txt for updated components that are also direct Go dependencies (e.g. pipeline, triggers, pruner, pipelines-as-code, tekton-kueue) and run go get + go mod tidy + go mod vendor so go.mod stays in sync with components.yaml automatically.


Assisted-by: Claude Opus 4.6 (via Claude Code)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
