### PR TITLE
feat(pruner): add NetworkPolicy for controller and webhook

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -1969,9 +1969,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
-                  only components with NetworkPolicy reconciliation implemented. Other
-                  components (Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
+                  and TektonPruner, which are the components with NetworkPolicy reconciliation
+                  implemented. Other components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-
@@ -6031,6 +6031,24 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by TektonPruner.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -2163,9 +2163,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
-                  only components with NetworkPolicy reconciliation implemented. Other
-                  components (Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
+                  and TektonPruner, which are the components with NetworkPolicy reconciliation
+                  implemented. Other components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-
@@ -6010,6 +6010,24 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by TektonPruner.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -573,9 +573,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
-                  only components with NetworkPolicy reconciliation implemented. Other
-                  components (Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
+                  and TektonPruner, which are the components with NetworkPolicy reconciliation
+                  implemented. Other components (Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -242,6 +242,24 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by TektonPruner.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -8,8 +8,8 @@ weight: 15
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
 Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
-TektonTrigger, TektonChain, Pipelines-as-Code, and ManualApprovalGate are
-supported; other components will be added later.
+TektonTrigger, TektonChain, Pipelines-as-Code, ManualApprovalGate, and TektonPruner
+are supported; other components will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -33,8 +33,8 @@ spec:
 ```
 
 The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger`,
-`TektonPipeline`, and `TektonChain`. Users can also configure it directly on the
-individual component CRs.
+`TektonPipeline`, `TektonChain`, and `TektonPruner`. Users can also configure it
+directly on the individual component CRs.
 
 ## Default Policies
 
@@ -139,6 +139,18 @@ spec:
     disabled: false
 ```
 
+### TektonPruner
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `tekton-pruner-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: tekton-pruner` |
+| `pruner-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| `pruner-webhook` | ingress | TCP/8443 | Any (admission webhook) |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 ### Console Plugin (OpenShift only)
 
 The console plugin is a static file server (nginx) — all API calls run in the

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -135,9 +135,9 @@ type TektonConfigSpec struct {
 	// +optional
 	TargetNamespaceMetadata *NamespaceMetadata `json:"targetNamespaceMetadata,omitempty"`
 	// NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-	// This field is propagated to TektonTrigger, TektonChain and TektonPipeline, which are the
-	// only components with NetworkPolicy reconciliation implemented. Other
-	// components (Results, Dashboard) do not yet act on this field.
+	// This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
+	// and TektonPruner, which are the components with NetworkPolicy reconciliation
+	// implemented. Other components (Results, Dashboard) do not yet act on this field.
 	// +optional
 	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -75,6 +75,10 @@ type TektonPrunerSpec struct {
 	// Config holds the configuration for resources created by TektonPruner
 	// +optional
 	Config Config `json:"config,omitempty"`
+	// NetworkPolicy configures NetworkPolicy creation for the controller
+	// and webhook workloads deployed by TektonPruner.
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 // TektonPrunerStatus defines the observed state of TektonPruner

--- a/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_validation.go
@@ -44,6 +44,8 @@ func (tp *TektonPruner) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// Validate pruner configuration using direct struct validation
 	errs = errs.Also(tp.Spec.Pruner.validate("spec.pruner"))
 
+	errs = errs.Also(tp.Spec.NetworkPolicy.validate("spec.networkPolicy"))
+
 	return errs
 }
 

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -2367,6 +2367,7 @@ func (in *TektonPrunerSpec) DeepCopyInto(out *TektonPrunerSpec) {
 	out.CommonSpec = in.CommonSpec
 	in.Pruner.DeepCopyInto(&out.Pruner)
 	in.Config.DeepCopyInto(&out.Config)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektonpruner/controller.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/controller.go
@@ -21,6 +21,7 @@ import (
 
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -62,6 +63,12 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 		metrics, _ := NewRecorder()
+
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		c := &Reconciler{
 			operatorClientSet:  operatorclient.Get(ctx),
 			kubeClientSet:      kubeclient.Get(ctx),
@@ -71,6 +78,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			manifest:           manifest,
 			prunerVersion:      prunerVer,
 			operatorVersion:    operatorVer,
+			platformParams:     params,
 		}
 		impl := tektonPrunerreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektonpruner/finalize.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/finalize.go
@@ -45,6 +45,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 		return err
 	}
 
+	if err := r.installerSetClient.CleanupCustomSet(ctx, "pruner-network-policies"); err != nil {
+		logger.Error("failed to cleanup pruner network policies installerset: ", err)
+		return err
+	}
+
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}

--- a/pkg/reconciler/kubernetes/tektonpruner/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/networkpolicies.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonpruner
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func prunerDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(9090)
+	webhookPort := intstr.FromInt32(8443)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pruner-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-pruner-controller"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pruner-webhook"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/component": "webhook",
+						"app.kubernetes.io/part-of":   "tekton-pruner",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.WebhookIngressRule("", webhookPort),
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func defaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy("tekton-pruner-default-deny", metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/part-of": "tekton-pruner"},
+	})
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, tp *v1alpha1.TektonPruner) error {
+	if tp.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, "pruner-network-policies")
+	}
+	defaults := append(
+		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
+		prunerDefaultPolicies(r.platformParams)...,
+	)
+	manifest, err := networkpolicy.Generate(
+		tp.Spec.NetworkPolicy,
+		tp.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, tp, "pruner-network-policies", &manifest, passthroughTransform, nil)
+}
+
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/kubernetes/tektonpruner/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/reconcile.go
@@ -26,6 +26,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektonprunerreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonpruner"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -50,6 +51,8 @@ type Reconciler struct {
 	// version of pruner which we are installing
 	prunerVersion   string
 	operatorVersion string
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -111,6 +114,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tp *v1alpha1.TektonPrune
 	//  Create/Update Required TektonInstallerSets
 	if err := r.ensureInstallerSets(ctx, tp); err != nil {
 		return err
+	}
+
+	if err := r.reconcileNetworkPolicies(ctx, tp); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		tp.Status.MarkInstallerSetNotReady(msg)
+		return nil
 	}
 
 	if err := r.extension.PostReconcile(ctx, tp); err != nil {

--- a/pkg/reconciler/shared/tektonconfig/pruner/pruner.go
+++ b/pkg/reconciler/shared/tektonconfig/pruner/pruner.go
@@ -77,8 +77,9 @@ func GetTektonPrunerCR(config *v1alpha1.TektonConfig, operatorVersion string) *v
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Config: config.Spec.Config,
-			Pruner: config.Spec.TektonPruner,
+			Config:        config.Spec.Config,
+			Pruner:        config.Spec.TektonPruner,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 }
@@ -113,6 +114,11 @@ func UpdatePruner(ctx context.Context, old *v1alpha1.TektonPruner, new *v1alpha1
 
 	if !reflect.DeepEqual(old.Spec.Config, new.Spec.Config) {
 		old.Spec.Config = new.Spec.Config
+		updated = true
+	}
+
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
 		updated = true
 	}
 

--- a/test/e2e/common/08_tektonpruner_networkpolicy_test.go
+++ b/test/e2e/common/08_tektonpruner_networkpolicy_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const prunerNPTestNamespace = "pruner-np-e2e"
+
+// TestTektonPrunerNetworkPolicy verifies NetworkPolicies are created by default
+// for the controller and webhook workloads TektonPruner deploys, that the pruner
+// webhook keeps working under those policies (ConfigMap validation via the
+// pruner's own ValidatingWebhookConfiguration on port 8443 succeeds), and that
+// toggling spec.networkPolicy.disabled correctly adds and removes the policies.
+func TestTektonPrunerNetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownTektonPruner(clients, crNames.TektonPruner) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, prunerNPTestNamespace) })
+	defer utils.TearDownNamespace(clients, prunerNPTestNamespace)
+	defer utils.TearDownTektonPruner(clients, crNames.TektonPruner)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+	resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPrunerExists(clients.TektonPruner(), crNames); err != nil {
+		t.Fatalf("TektonPruner %q failed to create: %v", crNames.TektonPruner, err)
+	}
+	resources.AssertTektonPrunerCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"tekton-pruner-default-deny",
+		"pruner-controller",
+		"pruner-webhook",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	// The pruner's ValidatingWebhookConfiguration (failurePolicy: Fail) intercepts
+	// ConfigMap mutations with labels app.kubernetes.io/part-of=tekton-pruner and
+	// pruner.tekton.dev/config-type=namespace. Creating such a ConfigMap exercises the
+	// pruner webhook on port 8443 — if the NetworkPolicy blocked ingress on that port,
+	// the API server would reject the request because failurePolicy is Fail.
+	t.Run("pruner-webhook-functional-with-networkpolicies", func(t *testing.T) {
+		if err := resources.CreateNamespace(clients.KubeClient, prunerNPTestNamespace); err != nil {
+			t.Fatalf("failed to create test namespace %q: %v", prunerNPTestNamespace, err)
+		}
+
+		// Valid ConfigMap — accepted by the pruner webhook (proves webhook reachable on 8443)
+		validCM := prunerNamespaceConfigMap(prunerNPTestNamespace, "ttlSecondsAfterFinished: 600")
+		_, err := clients.KubeClient.CoreV1().ConfigMaps(prunerNPTestNamespace).Create(
+			context.TODO(), validCM, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("pruner webhook rejected valid ConfigMap in namespace %q: %v (NetworkPolicy may be blocking port 8443)",
+				prunerNPTestNamespace, err)
+		}
+
+		// Invalid ConfigMap — rejected by the pruner webhook (proves active validation, not passthrough)
+		invalidCM := prunerNamespaceConfigMap(prunerNPTestNamespace, "ttlSecondsAfterFinished: -999")
+		invalidCM.Name = "tekton-pruner-namespace-spec-invalid"
+		_, err = clients.KubeClient.CoreV1().ConfigMaps(prunerNPTestNamespace).Create(
+			context.TODO(), invalidCM, metav1.CreateOptions{})
+		if err == nil {
+			t.Fatal("pruner webhook accepted invalid ConfigMap (negative TTL) — webhook may not be validating")
+		}
+		if !errors.IsForbidden(err) && !errors.IsInvalid(err) {
+			if !strings.Contains(err.Error(), "denied the request") {
+				t.Fatalf("unexpected error creating invalid ConfigMap: %v (expected webhook rejection)", err)
+			}
+		}
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		tp, err := clients.TektonPruner().Get(context.TODO(), crNames.TektonPruner, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonPruner %q: %v", crNames.TektonPruner, err)
+		}
+		tp.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.TektonPruner().Update(context.TODO(), tp, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on TektonPruner %q: %v", crNames.TektonPruner, err)
+		}
+		resources.AssertTektonPrunerCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		tp, err := clients.TektonPruner().Get(context.TODO(), crNames.TektonPruner, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonPruner %q: %v", crNames.TektonPruner, err)
+		}
+		tp.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.TektonPruner().Update(context.TODO(), tp, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on TektonPruner %q: %v", crNames.TektonPruner, err)
+		}
+		resources.AssertTektonPrunerCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}
+
+// prunerNamespaceConfigMap creates a ConfigMap with the labels that trigger the
+// pruner's ValidatingWebhookConfiguration (namespace-level webhook).
+func prunerNamespaceConfigMap(namespace, configData string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tekton-pruner-namespace-spec",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":     "tekton-pruner",
+				"pruner.tekton.dev/config-type": "namespace",
+			},
+		},
+		Data: map[string]string{
+			"ns-config": configData,
+		},
+	}
+}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
  - Adds `spec.networkPolicy` to `TektonPruner`
  - Reconciles three default NetworkPolicies: a scoped default-deny for all pruner (`app.kubernetes.io/part-of: tekton-pruner`), a controller allow policy (Prometheus metrics ingress on TCP/9090, unrestricted egress), and a webhook allow policy (admission callbacks on TCP/8443, Prometheus metrics on TCP/9090, unrestricted egress)
  - Propagates `spec.networkPolicy` from `TektonConfig` → `TektonPruner`, so `disabled: true` on TektonConfig removes polcies
  - Cleans up the `pruner-network-policies` CustomSet on TektonPruner CR deletion

  Egress is unrestricted because the pruner controller needs API server access to list, watch, and delete PipelineRun/TaskRun resources across namespaces, and NetworkPolicy cannot select endpoints on the host network.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
TektonPruner gains a `spec.networkPolicy` field so its controller and webhook default-deny and allow policies can be reconciled, overridden, or disabled per component. The field is propagated from TektonConfig.
```

/kind feature