### PR TITLE
[release-v0.79.x] chore(operatorhub): remove tech-preview label from Results

### DIFF
--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -401,7 +401,7 @@ spec:
     - Pipelines as Code: v0.42.3
     - Tekton Chains: v0.26.6
     - Tekton Hub (tech-preview): v1.23.12
-    - Tekton Results (tech-preview): v0.18.0
+    - Tekton Results: v0.18.0
     - Manual Approval Gate (tech-preview): v0.8.0
     - Tekton Pruner: v0.3.5
     - Tekton Scheduler (tech-preview): v0.3.1

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
@@ -400,7 +400,7 @@ spec:
     - Pipelines as Code: {{ with index .Versions "pipelines-as-code"}}{{ .Version }}{{end}}
     - Tekton Chains: {{ with index .Versions "chains"}}{{ .Version }}{{end}}
     - Tekton Hub (tech-preview): {{ with index .Versions "hub"}}{{ .Version }}{{end}}
-    - Tekton Results (tech-preview): {{ with index .Versions "results"}}{{ .Version }}{{end}}
+    - Tekton Results: {{ with index .Versions "results"}}{{ .Version }}{{end}}
     - Manual Approval Gate (tech-preview): {{ with index .Versions "manual-approval-gate"}}{{ .Version }}{{end}}
     - Tekton Pruner: {{ with index .Versions "pruner"}}{{ .Version }}{{end}}
     - Tekton Scheduler (tech-preview): {{ with index .Versions "scheduler"}}{{ .Version }}{{end}}


### PR DESCRIPTION
Tekton Results has graduated from tech-preview, update the ClusterServiceVersion template to reflect GA status.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
