### PR TITLE
feat(manualapprovalgate): add NetworkPolicy support

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -54,6 +54,24 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by ManualApprovalGate.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -54,6 +54,24 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by ManualApprovalGate.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
@@ -50,6 +50,24 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller
+                  and webhook workloads deployed by ManualApprovalGate.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -8,8 +8,8 @@ weight: 15
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
 Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
-TektonTrigger, TektonChain, and Pipelines-as-Code are supported; other components
-will be added later.
+TektonTrigger, TektonChain, Pipelines-as-Code, and ManualApprovalGate are
+supported; other components will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -112,6 +112,32 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
 | | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+### ManualApprovalGate
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `mag-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: openshift-pipelines-manual-approval-gates` |
+| `mag-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| `mag-webhook` | ingress | TCP/8443 | Any (admission webhook) |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+The `networkPolicy` field is available directly on the `ManualApprovalGate` CR
+(MAG is a standalone CR, not managed through `TektonConfig`):
+
+```yaml
+apiVersion: operator.tekton.dev/v1alpha1
+kind: ManualApprovalGate
+metadata:
+  name: manual-approval-gate
+spec:
+  networkPolicy:
+    disabled: false
+```
 
 ### Console Plugin (OpenShift only)
 

--- a/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
+++ b/pkg/apis/operator/v1alpha1/manualapprovalgate_types.go
@@ -48,6 +48,10 @@ type ManualApprovalGate struct {
 type ManualApprovalGateSpec struct {
 	CommonSpec     `json:",inline"`
 	ManualApproval `json:",inline"`
+	// NetworkPolicy configures NetworkPolicy creation for the controller
+	// and webhook workloads deployed by ManualApprovalGate.
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 type ManualApproval struct {

--- a/pkg/apis/operator/v1alpha1/manualapprovalgate_validation.go
+++ b/pkg/apis/operator/v1alpha1/manualapprovalgate_validation.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+func (mag *ManualApprovalGate) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
+	if mag.GetName() != ManualApprovalGates {
+		errMsg := fmt.Sprintf("metadata.name, Only one instance of ManualApprovalGate is allowed by name, %s", ManualApprovalGates)
+		errs = errs.Also(apis.ErrInvalidValue(mag.GetName(), errMsg))
+	}
+
+	errs = errs.Also(mag.Spec.CommonSpec.validate("spec"))
+	errs = errs.Also(mag.Spec.NetworkPolicy.validate("spec.networkPolicy"))
+
+	return errs
+}

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -461,6 +461,7 @@ func (in *ManualApprovalGateSpec) DeepCopyInto(out *ManualApprovalGateSpec) {
 	*out = *in
 	out.CommonSpec = in.CommonSpec
 	in.ManualApproval.DeepCopyInto(&out.ManualApproval)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/kubernetes/manualapprovalgate/controller.go
+++ b/pkg/reconciler/kubernetes/manualapprovalgate/controller.go
@@ -26,6 +26,7 @@ import (
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	manualapprovalgatereconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/manualapprovalgate"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -64,6 +65,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		c := &Reconciler{
 			operatorClientSet:         operatorclient.Get(ctx),
 			kubeClientSet:             kubeclient.Get(ctx),
@@ -73,6 +79,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:          tektonPipelineinformer.Get(ctx),
 			operatorVersion:           operatorVer,
 			manualApprovalGateVersion: ver,
+			platformParams:            params,
 		}
 		impl := manualapprovalgatereconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/manualapprovalgate/finalize.go
+++ b/pkg/reconciler/kubernetes/manualapprovalgate/finalize.go
@@ -45,6 +45,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Manual
 		return err
 	}
 
+	if err := r.installerSetClient.CleanupCustomSet(ctx, "mag-network-policies"); err != nil {
+		logger.Error("failed to cleanup mag network policies installerset: ", err)
+		return err
+	}
+
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}

--- a/pkg/reconciler/kubernetes/manualapprovalgate/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/manualapprovalgate/networkpolicies.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manualapprovalgate
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func magDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(9090)
+	webhookPort := intstr.FromInt32(8443)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mag-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-taskgroup-controller"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mag-webhook"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "manual-approval-gate-webhook"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.WebhookIngressRule("", webhookPort),
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func defaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy(
+		"mag-default-deny",
+		metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/part-of": "openshift-pipelines-manual-approval-gates",
+			},
+		},
+	)
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, mag *v1alpha1.ManualApprovalGate) error {
+	if mag.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, "mag-network-policies")
+	}
+	defaults := append(
+		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
+		magDefaultPolicies(r.platformParams)...,
+	)
+	manifest, err := networkpolicy.Generate(
+		mag.Spec.NetworkPolicy,
+		mag.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, mag, "mag-network-policies", &manifest, passthroughTransform, nil)
+}
+
+// passthroughTransform is a no-op FilterAndTransform used for pre-built manifests
+// where namespace injection is already handled by Generate.
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/kubernetes/manualapprovalgate/reconcile.go
+++ b/pkg/reconciler/kubernetes/manualapprovalgate/reconcile.go
@@ -26,6 +26,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	manualapprovalgatereconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/manualapprovalgate"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
@@ -51,6 +52,8 @@ type Reconciler struct {
 	// pipelineInformer provides access to a shared informer and lister for
 	// TektonPipelines
 	pipelineInformer pipelineinformer.TektonPipelineInformer
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -135,6 +138,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, mag *v1alpha1.ManualAppr
 		return nil
 	}
 	logger.Info("Main manifest applied successfully")
+
+	if err := r.reconcileNetworkPolicies(ctx, mag); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		mag.Status.MarkInstallerSetNotReady(msg)
+		return nil
+	}
 
 	logger.Debug("Executing post-reconciliation")
 	if err := r.extension.PostReconcile(ctx, mag); err != nil {

--- a/test/e2e/common/06_manualapprovalgate_networkpolicy_test.go
+++ b/test/e2e/common/06_manualapprovalgate_networkpolicy_test.go
@@ -1,0 +1,227 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// TestManualApprovalGateNetworkPolicy verifies NetworkPolicies are created by
+// default when ManualApprovalGate is installed, and that toggling
+// spec.networkPolicy.disabled correctly adds and removes the policies.
+func TestManualApprovalGateNetworkPolicy(t *testing.T) {
+	crNames := utils.ResourceNames{
+		TektonConfig:       "config",
+		TektonPipeline:     "pipeline",
+		ManualApprovalGate: "manual-approval-gate",
+		TargetNamespace:    "tekton-pipelines",
+	}
+
+	if os.Getenv("TARGET") == "openshift" {
+		crNames.TargetNamespace = "openshift-pipelines"
+	}
+	platform := os.Getenv("PLATFORM")
+	if platform == "linux/ppc64le" || platform == "linux/s390x" {
+		t.Skipf("ManualApprovalGate is not available for %q", platform)
+	}
+
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownManualApprovalGate(clients, crNames.ManualApprovalGate) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+	defer utils.TearDownManualApprovalGate(clients, crNames.ManualApprovalGate)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+	resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+
+	if _, err := resources.EnsureManualApprovalGateExists(clients.ManualApprovalGate(), crNames); err != nil {
+		t.Fatalf("ManualApprovalGate %q failed to create: %v", crNames.ManualApprovalGate, err)
+	}
+	resources.AssertManualApprovalGateCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"mag-default-deny",
+		"mag-controller",
+		"mag-webhook",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	// A PipelineRun referencing the ApprovalTask custom task
+	// (https://github.com/openshift-pipelines/manual-approval-gate) exercises the
+	// full MAG request path under the default policies: the Tekton Pipeline
+	// controller creates a CustomRun, MAG's own controller reconciles it and
+	// creates the backing ApprovalTask object via the API server (mag-controller
+	// egress), and that CREATE is admitted by MAG's ValidatingWebhookConfiguration
+	// — proving the API server can reach the mag-webhook pod on port 8443 under
+	// the mag-webhook policy's ingress rule. If either path were blocked, the
+	// ApprovalTask would never reach a status.state.
+	t.Run("mag-functional-with-networkpolicies", func(t *testing.T) {
+		prName := createApprovalTaskPipelineRun(t, crNames.TargetNamespace)
+		defer func() {
+			_ = exec.Command("kubectl", "delete", "pipelinerun", prName, "-n", crNames.TargetNamespace, "--ignore-not-found").Run()
+		}()
+
+		state := waitForApprovalTaskState(t, crNames.TargetNamespace, prName)
+		if state == "" {
+			t.Fatalf("ApprovalTask for PipelineRun %q reported an empty status.state", prName)
+		}
+		t.Logf("ApprovalTask for PipelineRun %q reached status.state %q under NetworkPolicy", prName, state)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		mag, err := clients.ManualApprovalGate().Get(context.TODO(), crNames.ManualApprovalGate, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get ManualApprovalGate: %v", err)
+		}
+		mag.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.ManualApprovalGate().Update(context.TODO(), mag, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on ManualApprovalGate: %v", err)
+		}
+		resources.AssertManualApprovalGateCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		mag, err := clients.ManualApprovalGate().Get(context.TODO(), crNames.ManualApprovalGate, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get ManualApprovalGate: %v", err)
+		}
+		mag.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.ManualApprovalGate().Update(context.TODO(), mag, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on ManualApprovalGate: %v", err)
+		}
+		resources.AssertManualApprovalGateCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}
+
+// approvalTaskPipelineRunYAML is a minimal PipelineRun with a single task
+// referencing the ApprovalTask custom task. The ApprovalTask CRD and its
+// controller/webhook belong to a separate module (openshift-pipelines/
+// manual-approval-gate) that this repo does not vendor a typed client for, so
+// it is created and polled via kubectl, matching the pattern used by the
+// TektonTrigger NetworkPolicy e2e test.
+const approvalTaskPipelineRunYAML = `
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: np-e2e-approval-
+  namespace: %s
+spec:
+  pipelineSpec:
+    tasks:
+      - name: wait-for-approval
+        taskRef:
+          apiVersion: openshift-pipelines.org/v1alpha1
+          kind: ApprovalTask
+        params:
+          - name: approvers
+            value:
+              - np-e2e-approver
+          - name: numberOfApprovalsRequired
+            value: "1"
+          - name: description
+            value: "NetworkPolicy e2e functional probe"
+`
+
+// createApprovalTaskPipelineRun creates the PipelineRun above and returns its
+// generated name.
+func createApprovalTaskPipelineRun(t *testing.T, namespace string) string {
+	t.Helper()
+
+	var stdout, stderr strings.Builder
+	cmd := exec.Command("kubectl", "create", "-f", "-", "-o", "jsonpath={.metadata.name}")
+	cmd.Stdin = strings.NewReader(fmt.Sprintf(approvalTaskPipelineRunYAML, namespace))
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to create ApprovalTask PipelineRun: %v\nstderr: %s", err, stderr.String())
+	}
+	name := strings.TrimSpace(stdout.String())
+	if name == "" {
+		t.Fatalf("kubectl did not return a PipelineRun name, stderr: %s", stderr.String())
+	}
+	return name
+}
+
+// waitForApprovalTaskState polls until MAG's controller has created the
+// ApprovalTask object backing pipelineRunName's CustomRun and that object
+// reports a non-empty status.state, then returns that state. It fails the
+// test if either the CustomRun or the ApprovalTask never materializes, which
+// would indicate the controller or webhook path was blocked.
+func waitForApprovalTaskState(t *testing.T, namespace, pipelineRunName string) string {
+	t.Helper()
+
+	var customRunName string
+	if err := wait.PollUntilContextTimeout(context.TODO(), utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		out, err := exec.CommandContext(ctx, "kubectl", "get", "customruns.tekton.dev",
+			"-n", namespace,
+			"-l", "tekton.dev/pipelineRun="+pipelineRunName,
+			"-o", "jsonpath={.items[0].metadata.name}",
+		).Output()
+		if err != nil {
+			return false, nil
+		}
+		customRunName = strings.TrimSpace(string(out))
+		return customRunName != "", nil
+	}); err != nil {
+		t.Fatalf("no CustomRun created for PipelineRun %q: %v", pipelineRunName, err)
+	}
+
+	var state string
+	if err := wait.PollUntilContextTimeout(context.TODO(), utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		out, err := exec.CommandContext(ctx, "kubectl", "get", "approvaltasks.openshift-pipelines.org",
+			customRunName, "-n", namespace, "-o", "jsonpath={.status.state}",
+		).Output()
+		if err != nil {
+			// Not created yet — the controller's create request may still be
+			// in flight through the admission webhook.
+			return false, nil
+		}
+		state = strings.TrimSpace(string(out))
+		return state != "", nil
+	}); err != nil {
+		t.Fatalf("ApprovalTask %q for PipelineRun %q never reached a status.state "+
+			"(controller or mag-webhook may be unreachable under NetworkPolicy): %v",
+			customRunName, pipelineRunName, err)
+	}
+	return state
+}


### PR DESCRIPTION


# Changes

Add default-deny, controller, and webhook NetworkPolicies for the ManualApprovalGate component, following the same pattern used by TektonTrigger and TektonPipeline. Policies are reconciled via a CustomSet and respect the spec.networkPolicy toggle for disabling and custom overrides. Includes validation, cleanup on CR deletion, e2e test, CRD schema updates, and documentation.


Assisted-by: Claude Opus 4.6 (via Cursor)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
ManualApprovalGate now creates default NetworkPolicies that restrict ingress/egress for its controller and webhook pods. These are enabled by default. To opt out, set `spec.networkPolicy.disabled: true` on the ManualApprovalGate CR.
```
