### PR TITLE
build(release-pipeline): bump plumbing pin for release title fix

### DIFF
--- a/.tekton/release-patch.yaml
+++ b/.tekton/release-patch.yaml
@@ -75,6 +75,13 @@ spec:
       value: ""
     - name: releaseName
       value: ""
+    # Publish patch releases directly instead of leaving an unpublished
+    # draft behind: draft GitHub releases don't push a real git tag, so
+    # leaving this at the pipeline's "true" default would silently skip
+    # the tag push that triggers helm-release.yaml (and any other
+    # tag-triggered workflows).
+    - name: draft
+      value: "false"
   timeouts:
     pipeline: 3h0m0s
   workspaces:

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -56,6 +56,13 @@ spec:
   - name: components
     description: Components file to use
     default: components.yaml
+  - name: draft
+    description: |
+      Whether to create the GitHub release as a draft for manual review
+      (the default, preserving existing behavior). Set to "false" to
+      publish the release directly instead, e.g. for routine patch
+      releases that don't need manual curation.
+    default: "true"
   workspaces:
   - name: workarea
     description: The workspace where the repo will be cloned.
@@ -612,6 +619,8 @@ spec:
       value: $(tasks.prepare-draft-release.results.previous-tag)
     - name: rekor-uuid
       value: $(tasks.wait-for-chains.results.rekor-uuid)
+    - name: draft
+      value: $(params.draft)
     - name: source-subpath
       value: git
     - name: release-subpath

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -596,7 +596,7 @@ spec:
       - name: url
         value: https://github.com/tektoncd/plumbing
       - name: revision
-        value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+        value: bc8a1039c385499f8b286b27d8b873308ca4f67c
       - name: pathInRepo
         value: tekton/resources/release/base/github_release_oci.yaml
     params:


### PR DESCRIPTION
# Changes

Bump the pinned `tektoncd/plumbing` git revision used by the
`create-draft-release` task in `tekton/operator-release-pipeline.yaml`
from `7abffd2` to `bc8a103` (latest `main`).

This picks up the fix from tektoncd/plumbing#3519, which:
- Sets `--title` explicitly on `gh release create` so releases get a
  clean title (e.g. `Tekton Operator release v0.79.2`) instead of
  sitting untitled.
- Drops the redundant, duplicated quoted release name from the H1 of
  the generated release body (previously produced titles like
  `Tekton Operator release v0.79.2 "Release v0.79.2"` once copied by
  hand).
- Stops marking draft releases as `--prerelease` (draft and
  prerelease are conflicting states; the flag only applies once a
  release is published).

The commits between the fix and latest `main` are unrelated dependabot
CI/dependency bumps.

Without this bump, the weekly `release-patch` workflow (and manual
releases via the same pipeline) would keep producing draft releases
with the old duplicated/untitled behavior.

This is a pin-only bump; the referenced task's new `draft` param
defaults to `"true"`, preserving current behavior, so no other
pipeline changes are required.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
