### PR TITLE
feat(tektonresult): add NetworkPolicy support for Results

### DIFF
--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -531,8 +531,6 @@ spec:
                           type: string
                       type: object
                     type: array
-                required:
-                - options
                 type: object
               multiclusterProxyAAE:
                 description: MulticlusterProxyAAE holds the customizable options for

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -531,6 +531,8 @@ spec:
                           type: string
                       type: object
                     type: array
+                required:
+                - options
                 type: object
               multiclusterProxyAAE:
                 description: MulticlusterProxyAAE holds the customizable options for
@@ -574,8 +576,8 @@ spec:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
                   This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-                  and TektonPruner, which are the components with NetworkPolicy reconciliation
-                  implemented. Other components (Results, Dashboard) do not yet act on this field.
+                  TektonPruner, and TektonResult, which implement NetworkPolicy reconciliation.
+                  Other components (Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
@@ -174,6 +174,23 @@ spec:
                 type: string
               loki_stack_namespace:
                 type: string
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonResult
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: Options holds additions fields and these fields will
                   be updated on the manifests

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -188,7 +188,7 @@ NetworkPolicy is enabled.
 **Recommended:** add a dedicated temporary NetworkPolicy that allows a dedicated
 admin label. Do **not** reuse `app: tekton-results-api` on a debug pod — that label
 is also used by the Results API Service selector and can route API traffic to the
-wrong pod.
+wrong pod. A dedicated label (below) avoids that.
 
 Apply directly:
 

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -8,8 +8,8 @@ weight: 15
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
 Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
-TektonTrigger, TektonChain, Pipelines-as-Code, ManualApprovalGate, and TektonPruner
-are supported; other components will be added later.
+TektonTrigger, TektonChain, Pipelines-as-Code, ManualApprovalGate, TektonPruner,
+and TektonResult are supported; other components will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -33,8 +33,11 @@ spec:
 ```
 
 The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger`,
-`TektonPipeline`, `TektonChain`, and `TektonPruner`. Users can also configure it
-directly on the individual component CRs.
+`TektonPipeline`, `TektonChain`, `TektonPruner`, and `TektonResult`. When those
+component CRs are managed by `TektonConfig` (the usual install path),
+**TektonConfig is the source of truth**: edits to `spec.networkPolicy` on the
+component CRs alone are overwritten on the next Config reconcile. Configure
+NetworkPolicy via `TektonConfig.spec.networkPolicy`.
 
 ## Default Policies
 
@@ -151,6 +154,95 @@ spec:
 | | ingress | TCP/9090 | Prometheus namespace |
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
 | | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+### TektonResult
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `results-default-deny` | deny all | — | Pods with `app.kubernetes.io/name` in Results API, watcher, retention-policy-agent, postgres |
+| `results-api` | ingress | TCP/8080 | All namespaces (Console Plugin, CLI, routes, watcher, internal clients) |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | TCP/`db_port` (default 5432) | Any destination (in-cluster or external DB; port from Results Spec) |
+| | egress | all | API server (auth token review / impersonation) |
+| `results-watcher` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints; also covers Results API) |
+| `results-retention-policy-agent` | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | TCP/`db_port` (default 5432) | Any destination (in-cluster or external DB) |
+| `results-postgres` | ingress | TCP/`db_port` | Results API and retention-policy-agent pods only |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+
+API and retention DB egress is **port-only** (no pod/CIDR peer). NetworkPolicy cannot
+match on hostname or JDBC URL, so restricting `To` to in-cluster postgres pods would
+break external databases. Configure `db_host` / `db_port` as usual; when `db_port`
+changes in the Results Spec, the operator regenerates these policies on reconcile.
+No custom NetworkPolicy is required for an external database.
+
+#### Administrative / debug access to in-cluster Postgres
+
+`results-postgres` ingress allows only Results API and retention-policy-agent pods.
+One-off workloads (DB migrations, `psql` debug pods) are otherwise dropped once
+NetworkPolicy is enabled.
+
+**Recommended:** add a dedicated temporary NetworkPolicy that allows a dedicated
+admin label. Do **not** reuse `app: tekton-results-api` on a debug pod — that label
+is also used by the Results API Service selector and can route API traffic to the
+wrong pod.
+
+Apply directly:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: results-postgres-admin
+  namespace: tekton-pipelines   # or openshift-pipelines
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-postgres
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: tekton-results-db-admin
+      ports:
+        - protocol: TCP
+          port: 5432   # match Spec db_port when customized
+```
+
+Or the same rule via `spec.networkPolicy.policies` (use a new name so you do not
+replace a managed default):
+
+```yaml
+spec:
+  networkPolicy:
+    policies:
+      results-postgres-admin:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: tekton-results-postgres
+        policyTypes: [Ingress]
+        ingress:
+          - from:
+              - podSelector:
+                  matchLabels:
+                    app: tekton-results-db-admin
+            ports:
+              - protocol: TCP
+                port: 5432
+```
+
+Label the migration/`psql` pod with `app: tekton-results-db-admin`, then remove the
+policy (or the `policies` entry) when finished.
+
+**Emergency only:** temporarily set `spec.networkPolicy.disabled: true` (on
+`TektonConfig` when Config manages Results), run the admin work, then set
+`disabled: false` again. Prefer the dedicated admin NetworkPolicy above so other
+workloads stay locked down.
+
 ### Console Plugin (OpenShift only)
 
 The console plugin is a static file server (nginx) — all API calls run in the

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -136,8 +136,8 @@ type TektonConfigSpec struct {
 	TargetNamespaceMetadata *NamespaceMetadata `json:"targetNamespaceMetadata,omitempty"`
 	// NetworkPolicy configures NetworkPolicy resources for the operand namespace.
 	// This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-	// and TektonPruner, which are the components with NetworkPolicy reconciliation
-	// implemented. Other components (Results, Dashboard) do not yet act on this field.
+	// TektonPruner, and TektonResult, which implement NetworkPolicy reconciliation.
+	// Other components (Dashboard) do not yet act on this field.
 	// +optional
 	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_types.go
@@ -62,6 +62,9 @@ type TektonResultSpec struct {
 	// Config holds the configuration for resources created by TektonResult
 	// +optional
 	Config Config `json:"config,omitempty"`
+	// NetworkPolicy configures NetworkPolicy creation for TektonResult workloads.
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 type LokiStackProperties struct {

--- a/pkg/apis/operator/v1alpha1/tektonresult_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_validation.go
@@ -60,5 +60,7 @@ func (trs *TektonResultSpec) validate(path string) (errs *apis.FieldError) {
 	// validate watcher properties
 	errs = errs.Also(trs.Watcher.Validate(fmt.Sprintf("%s.watcher", path)))
 
+	errs = errs.Also(trs.NetworkPolicy.validate(fmt.Sprintf("%s.networkPolicy", path)))
+
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -2465,6 +2465,7 @@ func (in *TektonResultSpec) DeepCopyInto(out *TektonResultSpec) {
 	out.CommonSpec = in.CommonSpec
 	in.Result.DeepCopyInto(&out.Result)
 	in.Config.DeepCopyInto(&out.Config)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektonresult/controller.go
+++ b/pkg/reconciler/kubernetes/tektonresult/controller.go
@@ -28,6 +28,7 @@ import (
 	tektonResultInformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonresult"
 	tektonResultReconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonresult"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
@@ -68,6 +69,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		c := &Reconciler{
 			installerSetClient: client.NewInstallerSetClient(tisClient, operatorVer, resultsVer, v1alpha1.KindTektonResult, metrics),
 			kubeClientSet:      kubeclient.Get(ctx),
@@ -77,6 +83,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:   tektonPipelineInformer.Get(ctx),
 			operatorVersion:    operatorVer,
 			resultsVersion:     resultsVer,
+			platformParams:     params,
 		}
 		impl := tektonResultReconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonresult
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func resultsDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	apiPort := intstr.FromInt32(8080)
+	metricsPort := intstr.FromInt32(9090)
+	postgresPort := intstr.FromInt32(5432)
+	tcp := corev1.ProtocolTCP
+
+	postgresPeer := networkingv1.NetworkPolicyPeer{
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "tekton-results-postgres",
+			},
+		},
+	}
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "results-api"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-results-api"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						// Console Plugin, CLI, watcher, and other internal clients
+						// live in many namespaces — allow from all namespaces.
+						From: []networkingv1.NetworkPolicyPeer{
+							{NamespaceSelector: &metav1.LabelSelector{}},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &apiPort},
+						},
+					},
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &postgresPort},
+						},
+						To: []networkingv1.NetworkPolicyPeer{postgresPeer},
+					},
+					// Auth token review / impersonation talks to the API server.
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "results-watcher"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-results-watcher"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				// Allow-all egress: NetworkPolicy cannot target the API server on
+				// the host network; address/port are not fixed (SRVKP-12055).
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "results-retention-policy-agent"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "tekton-results-retention-policy-agent"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &postgresPort},
+						},
+						To: []networkingv1.NetworkPolicyPeer{postgresPeer},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "results-postgres"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/name": "tekton-results-postgres",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "tekton-results-api"},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "tekton-results-retention-policy-agent"},
+								},
+							},
+						},
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &postgresPort},
+						},
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+				},
+			},
+		},
+	}
+}
+
+// defaultDenyPolicy scopes deny-all to Results pods only.
+// Do not reuse "tekton-default-deny" — Triggers already owns that name.
+// Pod templates use app.kubernetes.io/name (not part-of) on the pod itself.
+func defaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy(
+		"results-default-deny",
+		metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "app.kubernetes.io/name",
+					Operator: metav1.LabelSelectorOpIn,
+					Values: []string{
+						"tekton-results-api",
+						"tekton-results-watcher",
+						"tekton-results-retention-policy-agent",
+						"tekton-results-postgres",
+					},
+				},
+			},
+		},
+	)
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, tr *v1alpha1.TektonResult) error {
+	if tr.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, "results-network-policies")
+	}
+	defaults := append(
+		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
+		resultsDefaultPolicies(r.platformParams)...,
+	)
+	manifest, err := networkpolicy.Generate(
+		tr.Spec.NetworkPolicy,
+		tr.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, tr, "results-network-policies", &manifest, passthroughTransform, nil)
+}
+
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
@@ -18,7 +18,6 @@ package tektonresult
 
 import (
 	"context"
-	"math"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -160,9 +159,11 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 	}
 }
 
-// portOrDefault returns *p as int32 when set and positive, otherwise def.
+// portOrDefault returns *p as int32 when set to a valid TCP/UDP port (1–65535),
+// otherwise def. Values outside that range (e.g. 99999) would produce NetworkPolicy
+// objects Kubernetes rejects.
 func portOrDefault(p *int64, def int32) int32 {
-	if p != nil && *p > 0 && *p <= math.MaxInt32 {
+	if p != nil && *p >= 1 && *p <= 65535 {
 		return int32(*p)
 	}
 	return def

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
@@ -18,6 +18,7 @@ package tektonresult
 
 import (
 	"context"
+	"math"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -29,10 +30,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func resultsDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
-	apiPort := intstr.FromInt32(8080)
-	metricsPort := intstr.FromInt32(9090)
-	postgresPort := intstr.FromInt32(5432)
+const (
+	defaultAPIPort        int32 = 8080
+	defaultPrometheusPort int32 = 9090
+	defaultDBPort         int32 = 5432
+)
+
+func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.ResultsAPIProperties) []networkingv1.NetworkPolicy {
+	apiPort := intstr.FromInt32(portOrDefault(props.ServerPort, defaultAPIPort))
+	metricsPort := intstr.FromInt32(portOrDefault(props.PrometheusPort, defaultPrometheusPort))
+	postgresPort := intstr.FromInt32(portOrDefault(props.DBPort, defaultDBPort))
 	tcp := corev1.ProtocolTCP
 
 	postgresPeer := networkingv1.NetworkPolicyPeer{
@@ -93,9 +100,10 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					networkpolicy.PrometheusIngressRule(params, metricsPort),
 				},
-				// Allow-all egress: NetworkPolicy cannot target the API server on
-				// the host network; address/port are not fixed (SRVKP-12055).
+				// Keep an explicit DNS egress rule in addition to allow-all so DNS
+				// keeps working if the API-server egress rule is later tightened.
 				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
 					networkpolicy.APIServerEgressRule(),
 				},
 			},
@@ -160,6 +168,14 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.
 	}
 }
 
+// portOrDefault returns *p as int32 when set and positive, otherwise def.
+func portOrDefault(p *int64, def int32) int32 {
+	if p != nil && *p > 0 && *p <= math.MaxInt32 {
+		return int32(*p)
+	}
+	return def
+}
+
 // defaultDenyPolicy scopes deny-all to Results pods only.
 // Do not reuse "tekton-default-deny" — Triggers already owns that name.
 // Pod templates use app.kubernetes.io/name (not part-of) on the pod itself.
@@ -189,7 +205,7 @@ func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, tr *v1alpha1.
 	}
 	defaults := append(
 		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
-		resultsDefaultPolicies(r.platformParams)...,
+		resultsDefaultPolicies(r.platformParams, tr.Spec.ResultsAPIProperties)...,
 	)
 	manifest, err := networkpolicy.Generate(
 		tr.Spec.NetworkPolicy,

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
@@ -42,11 +42,13 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 	postgresPort := intstr.FromInt32(portOrDefault(props.DBPort, defaultDBPort))
 	tcp := corev1.ProtocolTCP
 
-	postgresPeer := networkingv1.NetworkPolicyPeer{
-		PodSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app.kubernetes.io/name": "tekton-results-postgres",
-			},
+	// DB egress is port-only (no pod/CIDR peer). NetworkPolicy cannot match on
+	// hostname/URL, so restricting To in-cluster postgres would break external DB
+	// deployments. Any destination on db_port is allowed; for in-cluster postgres,
+	// results-postgres ingress still limits who may connect.
+	dbEgress := networkingv1.NetworkPolicyEgressRule{
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &postgresPort},
 		},
 	}
 
@@ -63,7 +65,7 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 				},
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					{
-						// Console Plugin, CLI, watcher, and other internal clients
+						// Console Plugin, CLI, routes, watcher, and other clients
 						// live in many namespaces — allow from all namespaces.
 						From: []networkingv1.NetworkPolicyPeer{
 							{NamespaceSelector: &metav1.LabelSelector{}},
@@ -76,12 +78,7 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					{
-						Ports: []networkingv1.NetworkPolicyPort{
-							{Protocol: &tcp, Port: &postgresPort},
-						},
-						To: []networkingv1.NetworkPolicyPeer{postgresPeer},
-					},
+					dbEgress,
 					// Auth token review / impersonation talks to the API server.
 					networkpolicy.APIServerEgressRule(),
 				},
@@ -120,12 +117,7 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
-					{
-						Ports: []networkingv1.NetworkPolicyPort{
-							{Protocol: &tcp, Port: &postgresPort},
-						},
-						To: []networkingv1.NetworkPolicyPeer{postgresPeer},
-					},
+					dbEgress,
 				},
 			},
 		},

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonresult
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestResultsDefaultPolicies(t *testing.T) {
+	policies := resultsDefaultPolicies(networkpolicy.OpenShiftPlatformDefaults())
+	wantNames := []string{
+		"results-api",
+		"results-watcher",
+		"results-retention-policy-agent",
+		"results-postgres",
+	}
+	if len(policies) != len(wantNames) {
+		t.Fatalf("expected %d policies, got %d", len(wantNames), len(policies))
+	}
+	for i, name := range wantNames {
+		if policies[i].Name != name {
+			t.Errorf("policy[%d]: expected %q, got %q", i, name, policies[i].Name)
+		}
+	}
+
+	watcher := policies[1]
+	if got := len(watcher.Spec.Egress); got != 1 {
+		t.Fatalf("results-watcher: expected 1 egress rule (allow-all), got %d", got)
+	}
+	if len(watcher.Spec.Egress[0].Ports) != 0 || len(watcher.Spec.Egress[0].To) != 0 {
+		t.Errorf("results-watcher: expected empty allow-all egress rule, got %#v", watcher.Spec.Egress[0])
+	}
+}
+
+func TestGenerateResultsNetworkPolicies(t *testing.T) {
+	defaults := append(
+		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
+		resultsDefaultPolicies(networkpolicy.KubernetesPlatformDefaults())...,
+	)
+	m, err := networkpolicy.Generate(v1alpha1.NetworkPolicyConfig{}, "tekton-pipelines", defaults)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got := len(m.Resources()); got != 5 {
+		t.Errorf("expected 5 resources (deny + 4 defaults), got %d", got)
+	}
+
+	disabled, err := networkpolicy.Generate(
+		v1alpha1.NetworkPolicyConfig{Disabled: true},
+		"tekton-pipelines",
+		defaults,
+	)
+	if err != nil {
+		t.Fatalf("Generate disabled: %v", err)
+	}
+	if got := len(disabled.Resources()); got != 0 {
+		t.Errorf("expected empty manifest when disabled, got %d", got)
+	}
+}

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/ptr"
@@ -54,12 +55,12 @@ func TestResultsDefaultPolicies(t *testing.T) {
 	if got := len(watcher.Spec.Egress); got != 2 {
 		t.Fatalf("results-watcher: expected 2 egress rules (DNS + allow-all), got %d", got)
 	}
-	assertEgressHasDNS(t, "results-watcher", watcher.Spec.Egress)
+	assertEgressHasDNS(t, "results-watcher", watcher.Spec.Egress, 5353)
 	assertEgressHasAllowAll(t, "results-watcher", watcher.Spec.Egress)
 	assertIngressHasPort(t, "results-watcher", watcher.Spec.Ingress, 9090)
 
 	retention := byName["results-retention-policy-agent"]
-	assertEgressHasDNS(t, "results-retention-policy-agent", retention.Spec.Egress)
+	assertEgressHasDNS(t, "results-retention-policy-agent", retention.Spec.Egress, 5353)
 	assertEgressHasDBPort(t, "results-retention-policy-agent", retention.Spec.Egress, 5432)
 
 	postgres := byName["results-postgres"]
@@ -94,6 +95,15 @@ func TestPortOrDefault(t *testing.T) {
 	}
 	if got := portOrDefault(ptr.Int64(9090), 8080); got != 9090 {
 		t.Errorf("set: got %d", got)
+	}
+	if got := portOrDefault(ptr.Int64(0), 8080); got != 8080 {
+		t.Errorf("zero: got %d, want default", got)
+	}
+	if got := portOrDefault(ptr.Int64(99999), 5432); got != 5432 {
+		t.Errorf("above max port: got %d, want default", got)
+	}
+	if got := portOrDefault(ptr.Int64(65535), 5432); got != 65535 {
+		t.Errorf("max valid port: got %d", got)
 	}
 }
 
@@ -161,14 +171,30 @@ func assertEgressHasDBPort(t *testing.T, policy string, rules []networkingv1.Net
 	t.Errorf("%s: expected port-only egress TCP/%d (no To peer)", policy, port)
 }
 
-func assertEgressHasDNS(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule) {
+func assertEgressHasDNS(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule, dnsPort int32) {
 	t.Helper()
+	want := intstr.FromInt32(dnsPort)
 	for _, rule := range rules {
-		if len(rule.Ports) > 0 && len(rule.To) > 0 {
+		if len(rule.To) == 0 {
+			continue
+		}
+		hasUDP, hasTCP := false, false
+		for _, p := range rule.Ports {
+			if p.Port == nil || *p.Port != want || p.Protocol == nil {
+				continue
+			}
+			switch *p.Protocol {
+			case corev1.ProtocolUDP:
+				hasUDP = true
+			case corev1.ProtocolTCP:
+				hasTCP = true
+			}
+		}
+		if hasUDP && hasTCP {
 			return
 		}
 	}
-	t.Errorf("%s: expected DNS egress rule", policy)
+	t.Errorf("%s: expected DNS egress rule with UDP+TCP/%d", policy, dnsPort)
 }
 
 func assertEgressHasAllowAll(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule) {

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
@@ -48,7 +48,7 @@ func TestResultsDefaultPolicies(t *testing.T) {
 	api := byName["results-api"]
 	assertIngressHasPort(t, "results-api", api.Spec.Ingress, 8080)
 	assertIngressHasPort(t, "results-api", api.Spec.Ingress, 9090)
-	assertEgressHasPortToPostgres(t, "results-api", api.Spec.Egress, 5432)
+	assertEgressHasDBPort(t, "results-api", api.Spec.Egress, 5432)
 
 	watcher := byName["results-watcher"]
 	if got := len(watcher.Spec.Egress); got != 2 {
@@ -60,7 +60,7 @@ func TestResultsDefaultPolicies(t *testing.T) {
 
 	retention := byName["results-retention-policy-agent"]
 	assertEgressHasDNS(t, "results-retention-policy-agent", retention.Spec.Egress)
-	assertEgressHasPortToPostgres(t, "results-retention-policy-agent", retention.Spec.Egress, 5432)
+	assertEgressHasDBPort(t, "results-retention-policy-agent", retention.Spec.Egress, 5432)
 
 	postgres := byName["results-postgres"]
 	assertIngressHasPort(t, "results-postgres", postgres.Spec.Ingress, 5432)
@@ -82,9 +82,9 @@ func TestResultsDefaultPoliciesUsesSpecPorts(t *testing.T) {
 
 	assertIngressHasPort(t, "results-api", byName["results-api"].Spec.Ingress, 18080)
 	assertIngressHasPort(t, "results-api", byName["results-api"].Spec.Ingress, 19090)
-	assertEgressHasPortToPostgres(t, "results-api", byName["results-api"].Spec.Egress, 15432)
+	assertEgressHasDBPort(t, "results-api", byName["results-api"].Spec.Egress, 15432)
 	assertIngressHasPort(t, "results-watcher", byName["results-watcher"].Spec.Ingress, 19090)
-	assertEgressHasPortToPostgres(t, "results-retention-policy-agent", byName["results-retention-policy-agent"].Spec.Egress, 15432)
+	assertEgressHasDBPort(t, "results-retention-policy-agent", byName["results-retention-policy-agent"].Spec.Egress, 15432)
 	assertIngressHasPort(t, "results-postgres", byName["results-postgres"].Spec.Ingress, 15432)
 }
 
@@ -143,27 +143,22 @@ func assertIngressHasPort(t *testing.T, policy string, rules []networkingv1.Netw
 	t.Errorf("%s: expected ingress port %d", policy, port)
 }
 
-func assertEgressHasPortToPostgres(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule, port int32) {
+// assertEgressHasDBPort checks for a port-only DB egress rule (no To peer), so
+// in-cluster and external databases both work without a custom NetworkPolicy.
+func assertEgressHasDBPort(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule, port int32) {
 	t.Helper()
 	want := intstr.FromInt32(port)
 	for _, rule := range rules {
-		hasPort := false
-		for _, p := range rule.Ports {
-			if p.Port != nil && *p.Port == want {
-				hasPort = true
-				break
-			}
-		}
-		if !hasPort {
+		if len(rule.To) != 0 {
 			continue
 		}
-		for _, peer := range rule.To {
-			if peer.PodSelector != nil && peer.PodSelector.MatchLabels["app.kubernetes.io/name"] == "tekton-results-postgres" {
+		for _, p := range rule.Ports {
+			if p.Port != nil && *p.Port == want {
 				return
 			}
 		}
 	}
-	t.Errorf("%s: expected egress TCP/%d to tekton-results-postgres", policy, port)
+	t.Errorf("%s: expected port-only egress TCP/%d (no To peer)", policy, port)
 }
 
 func assertEgressHasDNS(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule) {

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/ptr"
 )
 
 func TestResultsDefaultPolicies(t *testing.T) {
-	policies := resultsDefaultPolicies(networkpolicy.OpenShiftPlatformDefaults())
+	policies := resultsDefaultPolicies(networkpolicy.OpenShiftPlatformDefaults(), v1alpha1.ResultsAPIProperties{})
 	wantNames := []string{
 		"results-api",
 		"results-watcher",
@@ -35,25 +37,77 @@ func TestResultsDefaultPolicies(t *testing.T) {
 	if len(policies) != len(wantNames) {
 		t.Fatalf("expected %d policies, got %d", len(wantNames), len(policies))
 	}
+	byName := map[string]networkingv1.NetworkPolicy{}
 	for i, name := range wantNames {
 		if policies[i].Name != name {
 			t.Errorf("policy[%d]: expected %q, got %q", i, name, policies[i].Name)
 		}
+		byName[policies[i].Name] = policies[i]
 	}
 
-	watcher := policies[1]
-	if got := len(watcher.Spec.Egress); got != 1 {
-		t.Fatalf("results-watcher: expected 1 egress rule (allow-all), got %d", got)
+	api := byName["results-api"]
+	assertIngressHasPort(t, "results-api", api.Spec.Ingress, 8080)
+	assertIngressHasPort(t, "results-api", api.Spec.Ingress, 9090)
+	assertEgressHasPortToPostgres(t, "results-api", api.Spec.Egress, 5432)
+
+	watcher := byName["results-watcher"]
+	if got := len(watcher.Spec.Egress); got != 2 {
+		t.Fatalf("results-watcher: expected 2 egress rules (DNS + allow-all), got %d", got)
 	}
-	if len(watcher.Spec.Egress[0].Ports) != 0 || len(watcher.Spec.Egress[0].To) != 0 {
-		t.Errorf("results-watcher: expected empty allow-all egress rule, got %#v", watcher.Spec.Egress[0])
+	assertEgressHasDNS(t, "results-watcher", watcher.Spec.Egress)
+	assertEgressHasAllowAll(t, "results-watcher", watcher.Spec.Egress)
+	assertIngressHasPort(t, "results-watcher", watcher.Spec.Ingress, 9090)
+
+	retention := byName["results-retention-policy-agent"]
+	assertEgressHasDNS(t, "results-retention-policy-agent", retention.Spec.Egress)
+	assertEgressHasPortToPostgres(t, "results-retention-policy-agent", retention.Spec.Egress, 5432)
+
+	postgres := byName["results-postgres"]
+	assertIngressHasPort(t, "results-postgres", postgres.Spec.Ingress, 5432)
+	assertIngressFromApp(t, "results-postgres", postgres.Spec.Ingress, "tekton-results-api")
+	assertIngressFromApp(t, "results-postgres", postgres.Spec.Ingress, "tekton-results-retention-policy-agent")
+}
+
+func TestResultsDefaultPoliciesUsesSpecPorts(t *testing.T) {
+	props := v1alpha1.ResultsAPIProperties{
+		ServerPort:     ptr.Int64(18080),
+		PrometheusPort: ptr.Int64(19090),
+		DBPort:         ptr.Int64(15432),
+	}
+	policies := resultsDefaultPolicies(networkpolicy.KubernetesPlatformDefaults(), props)
+	byName := map[string]networkingv1.NetworkPolicy{}
+	for _, p := range policies {
+		byName[p.Name] = p
+	}
+
+	assertIngressHasPort(t, "results-api", byName["results-api"].Spec.Ingress, 18080)
+	assertIngressHasPort(t, "results-api", byName["results-api"].Spec.Ingress, 19090)
+	assertEgressHasPortToPostgres(t, "results-api", byName["results-api"].Spec.Egress, 15432)
+	assertIngressHasPort(t, "results-watcher", byName["results-watcher"].Spec.Ingress, 19090)
+	assertEgressHasPortToPostgres(t, "results-retention-policy-agent", byName["results-retention-policy-agent"].Spec.Egress, 15432)
+	assertIngressHasPort(t, "results-postgres", byName["results-postgres"].Spec.Ingress, 15432)
+}
+
+func TestPortOrDefault(t *testing.T) {
+	if got := portOrDefault(nil, 8080); got != 8080 {
+		t.Errorf("nil: got %d", got)
+	}
+	if got := portOrDefault(ptr.Int64(9090), 8080); got != 9090 {
+		t.Errorf("set: got %d", got)
+	}
+}
+
+func TestResultsDefaultDenyPolicy(t *testing.T) {
+	deny := defaultDenyPolicy()
+	if deny.Name != "results-default-deny" {
+		t.Fatalf("expected name results-default-deny, got %q", deny.Name)
 	}
 }
 
 func TestGenerateResultsNetworkPolicies(t *testing.T) {
 	defaults := append(
 		[]networkingv1.NetworkPolicy{defaultDenyPolicy()},
-		resultsDefaultPolicies(networkpolicy.KubernetesPlatformDefaults())...,
+		resultsDefaultPolicies(networkpolicy.KubernetesPlatformDefaults(), v1alpha1.ResultsAPIProperties{})...,
 	)
 	m, err := networkpolicy.Generate(v1alpha1.NetworkPolicyConfig{}, "tekton-pipelines", defaults)
 	if err != nil {
@@ -74,4 +128,72 @@ func TestGenerateResultsNetworkPolicies(t *testing.T) {
 	if got := len(disabled.Resources()); got != 0 {
 		t.Errorf("expected empty manifest when disabled, got %d", got)
 	}
+}
+
+func assertIngressHasPort(t *testing.T, policy string, rules []networkingv1.NetworkPolicyIngressRule, port int32) {
+	t.Helper()
+	want := intstr.FromInt32(port)
+	for _, rule := range rules {
+		for _, p := range rule.Ports {
+			if p.Port != nil && *p.Port == want {
+				return
+			}
+		}
+	}
+	t.Errorf("%s: expected ingress port %d", policy, port)
+}
+
+func assertEgressHasPortToPostgres(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule, port int32) {
+	t.Helper()
+	want := intstr.FromInt32(port)
+	for _, rule := range rules {
+		hasPort := false
+		for _, p := range rule.Ports {
+			if p.Port != nil && *p.Port == want {
+				hasPort = true
+				break
+			}
+		}
+		if !hasPort {
+			continue
+		}
+		for _, peer := range rule.To {
+			if peer.PodSelector != nil && peer.PodSelector.MatchLabels["app.kubernetes.io/name"] == "tekton-results-postgres" {
+				return
+			}
+		}
+	}
+	t.Errorf("%s: expected egress TCP/%d to tekton-results-postgres", policy, port)
+}
+
+func assertEgressHasDNS(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule) {
+	t.Helper()
+	for _, rule := range rules {
+		if len(rule.Ports) > 0 && len(rule.To) > 0 {
+			return
+		}
+	}
+	t.Errorf("%s: expected DNS egress rule", policy)
+}
+
+func assertEgressHasAllowAll(t *testing.T, policy string, rules []networkingv1.NetworkPolicyEgressRule) {
+	t.Helper()
+	for _, rule := range rules {
+		if len(rule.Ports) == 0 && len(rule.To) == 0 {
+			return
+		}
+	}
+	t.Errorf("%s: expected allow-all egress rule", policy)
+}
+
+func assertIngressFromApp(t *testing.T, policy string, rules []networkingv1.NetworkPolicyIngressRule, app string) {
+	t.Helper()
+	for _, rule := range rules {
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil && peer.PodSelector.MatchLabels["app"] == app {
+				return
+			}
+		}
+	}
+	t.Errorf("%s: expected ingress From app=%s", policy, app)
 }

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -41,6 +41,7 @@ import (
 	pipelineInformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	tektonresultconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonresult"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/hash"
 	corev1 "k8s.io/api/core/v1"
@@ -80,6 +81,8 @@ type Reconciler struct {
 
 	operatorVersion string
 	resultsVersion  string
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -110,6 +113,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 			LabelSelector: labelSelector,
 		}); err != nil {
 		logger.Error("Failed to delete installer set created by TektonResult", err)
+		return err
+	}
+
+	if err := r.installerSetClient.CleanupCustomSet(ctx, "results-network-policies"); err != nil {
+		logger.Error("failed to cleanup results network policies installerset: ", err)
 		return err
 	}
 
@@ -407,6 +415,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 	// MarkInstallerSetReady
 	tr.Status.MarkInstallerSetReady()
 	logger.Infow("Installer set is ready", "name", installedTIS.Name)
+
+	if err := r.reconcileNetworkPolicies(ctx, tr); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		tr.Status.MarkInstallerSetNotReady(msg)
+		return nil
+	}
 
 	if err := r.extension.PostReconcile(ctx, tr); err != nil {
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {

--- a/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
+++ b/pkg/reconciler/kubernetes/tektonresult/tektonresult.go
@@ -417,9 +417,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *v1alpha1.TektonResul
 	logger.Infow("Installer set is ready", "name", installedTIS.Name)
 
 	if err := r.reconcileNetworkPolicies(ctx, tr); err != nil {
-		if err == v1alpha1.REQUEUE_EVENT_AFTER {
-			return err
-		}
 		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
 		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
 		tr.Status.MarkInstallerSetNotReady(msg)

--- a/pkg/reconciler/kubernetes/tektonresult/transform.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform.go
@@ -390,12 +390,18 @@ func updateApiEnv(s v1alpha1.TektonResultSpec) mf.Transformer {
 			}
 
 			replaceEnv(existingContainerEnv, prop)
-			for k, v := range prop {
-				newEnv := corev1.EnvVar{
+			// Sort keys so env order is stable across transforms. Unordered map
+			// iteration would change Deployment Spec hashes and roll pods.
+			keys := make([]string, 0, len(prop))
+			for k := range prop {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				existingContainerEnv = append(existingContainerEnv, corev1.EnvVar{
 					Name:  k,
-					Value: v,
-				}
-				existingContainerEnv = append(existingContainerEnv, newEnv)
+					Value: prop[k],
+				})
 			}
 			dep.Spec.Template.Spec.Containers[containerIndex].Env = existingContainerEnv
 			break

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -293,6 +293,56 @@ func TestUpdateAPIEnv(t *testing.T) {
 	assert.Equal(t, true, containerFound, "container not found")
 }
 
+func TestUpdateApiEnvDeterministicOrder(t *testing.T) {
+	testData := path.Join("testdata", "api-deployment.yaml")
+	boolVal := true
+	intVal := int64(12345)
+	spec := v1alpha1.TektonResultSpec{
+		Result: v1alpha1.Result{
+			ResultsAPIProperties: v1alpha1.ResultsAPIProperties{
+				DBHost:                "localhost",
+				DBName:                "test",
+				ServerPort:            &intVal,
+				DBEnableAutoMigration: &boolVal,
+				AuthDisable:           &boolVal,
+				LogLevel:              "warn",
+				LogsAPI:               &boolVal,
+				LogsPath:              "/logs/test",
+				LogsType:              "S3",
+				LogsBufferSize:        &intVal,
+			},
+		},
+	}
+
+	envNames := func() []string {
+		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+		assert.NilError(t, err)
+		manifest, err = manifest.Transform(updateApiEnv(spec))
+		assert.NilError(t, err)
+		deployment := &appsv1.Deployment{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, deployment)
+		assert.NilError(t, err)
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name != apiContainerName {
+				continue
+			}
+			names := make([]string, 0, len(container.Env))
+			for _, env := range container.Env {
+				names = append(names, env.Name)
+			}
+			return names
+		}
+		t.Fatal("api container not found")
+		return nil
+	}
+
+	first := envNames()
+	for i := 0; i < 10; i++ {
+		got := envNames()
+		assert.DeepEqual(t, first, got)
+	}
+}
+
 func TestUpdateEnvWithDBSecretName(t *testing.T) {
 	testData := path.Join("testdata", "api-deployment.yaml")
 	manifest, err := mf.ManifestFrom(mf.Recursive(testData))

--- a/pkg/reconciler/shared/tektonconfig/result/result.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result.go
@@ -150,6 +150,11 @@ func UpdateResult(ctx context.Context, old *v1alpha1.TektonResult, new *v1alpha1
 		updated = true
 	}
 
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
+		updated = true
+	}
+
 	if old.ObjectMeta.OwnerReferences == nil {
 		old.ObjectMeta.OwnerReferences = new.ObjectMeta.OwnerReferences
 		updated = true
@@ -207,8 +212,9 @@ func GetTektonResultCR(config *v1alpha1.TektonConfig, operatorVersion string) *v
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Result: result,
-			Config: config.Spec.Config,
+			Result:        result,
+			Config:        config.Spec.Config,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,7 +45,7 @@ failed=0
 tektonconfig_ready_wait
 
 header "Running Go e2e tests"
-go_test_e2e -timeout=40m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
+go_test_e2e -timeout=55m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
 go_test_e2e -timeout=20m ./test/e2e/${TARGET} ${KUBECONFIG_PARAM} || failed=1
 
 (( failed )) && fail_test

--- a/test/e2e/common/03_tektonresult_networkpolicy_test.go
+++ b/test/e2e/common/03_tektonresult_networkpolicy_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/tektoncd/operator/test/resources"
 	"github.com/tektoncd/operator/test/utils"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // TestTektonResultNetworkPolicy verifies NetworkPolicies are created by default
@@ -42,8 +44,8 @@ func TestTektonResultNetworkPolicy(t *testing.T) {
 
 	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
 	utils.CleanupOnInterrupt(func() { utils.TearDownResult(clients, crNames.TektonResult) })
-	defer utils.TearDownResult(clients, crNames.TektonResult)
 	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+	defer utils.TearDownResult(clients, crNames.TektonResult)
 
 	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
 
@@ -81,6 +83,7 @@ func TestTektonResultNetworkPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create TaskRun: %v", err)
 		}
+		defer deleteResultNPProbeTaskRun(t, clients, crNames.TargetNamespace, createdTaskRun.Name)
 
 		if err := resources.WaitForTaskRunHappy(
 			clients.TektonClient,
@@ -128,6 +131,27 @@ func TestTektonResultNetworkPolicy(t *testing.T) {
 		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
 		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
 	})
+}
+
+// deleteResultNPProbeTaskRun deletes the probe TaskRun and waits until it is
+// fully gone. Must run while TektonResult is still installed so the Results
+// watcher can clear results.tekton.dev/taskrun.
+func deleteResultNPProbeTaskRun(t *testing.T, clients *utils.Clients, namespace, name string) {
+	t.Helper()
+	ctx := context.Background()
+	err := clients.TektonClient.TaskRuns(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrs.IsNotFound(err) {
+		t.Fatalf("failed to delete probe TaskRun %q: %v", name, err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		_, getErr := clients.TektonClient.TaskRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrs.IsNotFound(getErr) {
+			return true, nil
+		}
+		return false, getErr
+	}); err != nil {
+		t.Fatalf("probe TaskRun %q was not fully deleted (Results finalizer may be stuck): %v", name, err)
+	}
 }
 
 // createResultNPProbeTaskRun creates a minimal TaskRun that completes quickly.

--- a/test/e2e/common/03_tektonresult_networkpolicy_test.go
+++ b/test/e2e/common/03_tektonresult_networkpolicy_test.go
@@ -1,0 +1,155 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestTektonResultNetworkPolicy verifies NetworkPolicies are created by default
+// for Results workloads, that Results stays Ready under those policies (API can
+// reach Postgres; watcher can reach the API server), and that toggling
+// spec.networkPolicy.disabled correctly adds and removes the policies.
+func TestTektonResultNetworkPolicy(t *testing.T) {
+
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownResult(clients, crNames.TektonResult) })
+	defer utils.TearDownResult(clients, crNames.TektonResult)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+	resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+
+	// Operator creates default TLS + Postgres secrets when missing.
+	if _, err := resources.EnsureTektonResultExists(clients.TektonResult(), crNames); err != nil {
+		t.Fatalf("TektonResult %q failed to create: %v", crNames.TektonResult, err)
+	}
+	resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"results-default-deny",
+		"results-api",
+		"results-watcher",
+		"results-retention-policy-agent",
+		"results-postgres",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	// Ready status already proves API↔DB and watcher↔API-server under NP.
+	// A successful TaskRun additionally exercises watcher API-server egress
+	t.Run("results-functional-with-networkpolicies", func(t *testing.T) {
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+
+		taskRun := createResultNPProbeTaskRun(crNames.TargetNamespace)
+		createdTaskRun, err := clients.TektonClient.TaskRuns(crNames.TargetNamespace).Create(
+			context.TODO(), taskRun, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create TaskRun: %v", err)
+		}
+
+		if err := resources.WaitForTaskRunHappy(
+			clients.TektonClient,
+			crNames.TargetNamespace,
+			createdTaskRun.Name,
+			func(tr *pipelinev1.TaskRun) (bool, error) {
+				if tr.IsDone() {
+					if tr.IsSuccessful() {
+						return true, nil
+					}
+					return false, fmt.Errorf("TaskRun failed")
+				}
+				return false, nil
+			},
+		); err != nil {
+			t.Fatalf("TaskRun did not complete successfully under NetworkPolicy: %v", err)
+		}
+
+		// Results must still be Ready after the TaskRun (watcher/API/DB path).
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		tr, err := clients.TektonResult().Get(context.TODO(), crNames.TektonResult, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonResult: %v", err)
+		}
+		tr.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.TektonResult().Update(context.TODO(), tr, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on TektonResult: %v", err)
+		}
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		tr, err := clients.TektonResult().Get(context.TODO(), crNames.TektonResult, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonResult: %v", err)
+		}
+		tr.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.TektonResult().Update(context.TODO(), tr, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on TektonResult: %v", err)
+		}
+		resources.AssertTektonResultCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}
+
+// createResultNPProbeTaskRun creates a minimal TaskRun that completes quickly.
+// Completion exercises the Results watcher watch of the API server under NP.
+func createResultNPProbeTaskRun(namespace string) *pipelinev1.TaskRun {
+	return &pipelinev1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "result-np-probe-taskrun-",
+			Namespace:    namespace,
+		},
+		Spec: pipelinev1.TaskRunSpec{
+			ServiceAccountName: "default",
+			TaskSpec: &pipelinev1.TaskSpec{
+				Steps: []pipelinev1.Step{
+					{
+						Name:    "echo",
+						Image:   "busybox:stable",
+						Command: []string{"echo"},
+						Args:    []string{"results NetworkPolicy probe"},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Reconcile default NetworkPolicies for Results API, watcher, retention-policy-agent, and postgres via InstallerSet, propagated from TektonConfig.spec.networkPolicy (SRVKP-12055).

# Changes

Adds NetworkPolicy support for Tekton Results, following the existing Pipeline/Triggers pattern.
- Add `spec.networkPolicy` on `TektonResult` (CRD + validation) and propagate `TektonConfig.spec.networkPolicy` → `TektonResult`
- Reconcile default policies via Custom InstallerSet `results-network-policies`:
  - `results-default-deny`
  - `results-api` (ingress 8080 / Prometheus 9090; egress DNS, Postgres 5432, API server)
  - `results-watcher` (Prometheus ingress; allow-all egress for API server)
  - `results-retention-policy-agent` (egress DNS + Postgres; no ingress)
  - `results-postgres` (ingress 5432 from API + retention; egress DNS)
- Disable via `TektonConfig.spec.networkPolicy.disabled: true` removes the managed policies
- Document Results policies in `docs/NetworkPolicy.md`


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add NetworkPolicy support for Tekton Results. Default policies for Results API, watcher, retention-policy-agent, and postgres are reconciled from TektonConfig.spec.networkPolicy (enabled by default; set disabled: true to remove them).
```
