### PR TITLE
fix(tektonchain): sync leader-election configmap

### DIFF
--- a/pkg/reconciler/common/testdata/test-chain-leader-election-configmap.yaml
+++ b/pkg/reconciler/common/testdata/test-chain-leader-election-configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-chains-controller
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-chains
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-chains
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-chains
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tekton-chains
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/part-of: tekton-chains
+    spec:
+      serviceAccountName: tekton-chains-controller
+      containers:
+      - name: tekton-chains-controller
+        image: gcr.io/tekton-releases/github.com/tektoncd/chains/cmd/controller:latest
+        args:
+        - -disable-ha=true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-chains-config-leader-election
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+data:
+  buckets: "1"

--- a/pkg/reconciler/kubernetes/tektonchain/transform.go
+++ b/pkg/reconciler/kubernetes/tektonchain/transform.go
@@ -48,6 +48,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.AddConfigMapValues(ChainsConfig, chainCR.Spec.Chain.ChainProperties),
 			common.AddDeploymentRestrictedPSA(),
 			AddControllerEnv(chainCR.Spec.Chain.ControllerEnvs),
+			common.AddConfigMapValues(leaderElectionChainConfig, chainCR.Spec.Chain.Performance.PerformanceLeaderElectionConfig),
 			common.UpdatePerformanceFlagsInDeploymentAndLeaderConfigMap(&chainCR.Spec.Performance, leaderElectionChainConfig, chainControllerDeployment, chainControllerContainer),
 		}
 		if chainCR.Spec.GenerateSigningSecret {

--- a/pkg/reconciler/kubernetes/tektonchain/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonchain/transform_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/ptr"
@@ -116,5 +117,64 @@ func TestUpdateStatefulSetOrdinalsForChains(t *testing.T) {
 			t.Error("Expected Deployment to be removed from manifest")
 			break
 		}
+	}
+}
+
+func TestUpdateLeaderElectionConfigMapForChains(t *testing.T) {
+	desiredBuckets := uint(5)
+	cr := &v1alpha1.TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chains",
+			Namespace: "tekton-pipelines",
+		},
+		Spec: v1alpha1.TektonChainSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: "tekton-chains",
+			},
+			Chain: v1alpha1.Chain{
+				ChainProperties: v1alpha1.ChainProperties{
+					Performance: v1alpha1.PerformanceProperties{
+						PerformanceLeaderElectionConfig: v1alpha1.PerformanceLeaderElectionConfig{
+							Buckets: &desiredBuckets,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	manifest, err := common.Fetch("../../common/testdata/test-chain-leader-election-configmap.yaml")
+	if err != nil {
+		t.Fatalf("Failed to fetch test data: %v", err)
+	}
+
+	extension := common.NoExtension(ctx)
+	transformers := filterAndTransform(extension)
+	result, err := transformers(ctx, &manifest, cr)
+	if err != nil {
+		t.Fatalf("Error applying transformers: %v", err)
+	}
+
+	foundConfigMap := false
+	for _, resource := range result.Resources() {
+		if resource.GetKind() == "ConfigMap" && resource.GetName() == leaderElectionChainConfig {
+			foundConfigMap = true
+
+			cm := &corev1.ConfigMap{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, cm); err != nil {
+				t.Fatalf("Failed to convert resource to ConfigMap: %v", err)
+			}
+
+			expectedBuckets := "5"
+			if cm.Data["buckets"] != expectedBuckets {
+				t.Errorf("Expected ConfigMap %s data[buckets] to be %q, got %q", leaderElectionChainConfig, expectedBuckets, cm.Data["buckets"])
+			}
+			break
+		}
+	}
+
+	if !foundConfigMap {
+		t.Errorf("Expected to find ConfigMap %s in the transformed manifest, but none was found", leaderElectionChainConfig)
 	}
 }


### PR DESCRIPTION
Motivation:
TektonConfig.spec.chain.performance values (e.g. buckets) were
correctly propagated to the tekton-chains-controller Deployment's
pod labels and container args, but the ConfigMap
tekton-chains-config-leader-election was never updated to match,
so it kept stale/default data instead of reflecting the current
TektonConfig. This is a data-consistency bug in that ConfigMap,
not a functional HA failure: the controller itself already
receives the tuned values via the Deployment's args and pod
labels, which are unaffected by this fix.

Approach:
tektonpipeline and tektonresult already call
common.AddConfigMapValues(<leaderElectionConfigMapName>, ...
Performance.PerformanceLeaderElectionConfig) alongside
common.UpdatePerformanceFlagsInDeploymentAndLeaderConfigMap to
keep their leader-election ConfigMaps in sync. The tektonchain
transformer chain was missing that call. Add it, mirroring the
existing pipeline/result behavior.

Validation:
Added TestUpdateLeaderElectionConfigMapForChains to
pkg/reconciler/kubernetes/tektonchain/transform_test.go, with a
new minimal fixture testdata/test-chain-leader-election-configmap.yaml.
Confirmed (by temporarily reverting transform.go) that this test
fails without the fix and passes with it.

  go build ./...
  go test ./pkg/reconciler/kubernetes/tektonchain/... ./pkg/reconciler/common/...

Both commands pass. golangci-lint could not be downloaded in this
sandbox (checksum mismatch fetching the pinned release binary,
unrelated to this change); go vet and go build are clean.

Fixes #2884

```release-note
Fix `tekton-chains-config-leader-election` ConfigMap not being
updated with `TektonConfig.spec.chain.performance` values.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.