### PR TITLE
RFE-9431: expose full openAPIV3Schema for pruner, scheduler, and networkpolicy configs

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -298,11 +298,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1474,11 +1944,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               params:
@@ -2093,6 +3033,19 @@ spec:
                     description: |-
                       This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                       match the key here
+                    properties:
+                      cel:
+                        properties:
+                          expressions:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      multiKueueOverride:
+                        type: boolean
+                      queueName:
+                        type: string
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   disabled:
                     description: enable or disable TektonScheduler Component
@@ -2165,6 +3118,127 @@ spec:
                     description: enable or disable TektonPruner Component
                     type: boolean
                   global-config:
+                    description: |-
+                      GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                      Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                      NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                    properties:
+                      enforcedConfigLevel:
+                        description: 'EnforcedConfigLevel allowed values: global,
+                          namespace (default: namespace)'
+                        type: string
+                      failedHistoryLimit:
+                        type: integer
+                      historyLimit:
+                        type: integer
+                      namespaces:
+                        additionalProperties:
+                          description: |-
+                            NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                            Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                            Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                          properties:
+                            enforcedConfigLevel:
+                              description: 'EnforcedConfigLevel allowed values: global,
+                                namespace (default: namespace)'
+                              type: string
+                            failedHistoryLimit:
+                              type: integer
+                            historyLimit:
+                              type: integer
+                            pipelineRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    type: integer
+                                  historyLimit:
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    type: integer
+                                type: object
+                              type: array
+                            successfulHistoryLimit:
+                              type: integer
+                            taskRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    type: integer
+                                  historyLimit:
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    type: integer
+                                type: object
+                              type: array
+                            ttlSecondsAfterFinished:
+                              type: integer
+                          type: object
+                        type: object
+                      successfulHistoryLimit:
+                        type: integer
+                      ttlSecondsAfterFinished:
+                        type: integer
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   options:
                     description: options holds additions fields and these fields will
@@ -2858,11 +3932,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -3507,11 +5051,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -3726,6 +5740,127 @@ spec:
                 description: enable or disable TektonPruner Component
                 type: boolean
               global-config:
+                description: |-
+                  GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                  Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                  NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                properties:
+                  enforcedConfigLevel:
+                    description: 'EnforcedConfigLevel allowed values: global, namespace
+                      (default: namespace)'
+                    type: string
+                  failedHistoryLimit:
+                    type: integer
+                  historyLimit:
+                    type: integer
+                  namespaces:
+                    additionalProperties:
+                      description: |-
+                        NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                        Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                        Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                      properties:
+                        enforcedConfigLevel:
+                          description: 'EnforcedConfigLevel allowed values: global,
+                            namespace (default: namespace)'
+                          type: string
+                        failedHistoryLimit:
+                          type: integer
+                        historyLimit:
+                          type: integer
+                        pipelineRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                type: integer
+                              historyLimit:
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                type: integer
+                            type: object
+                          type: array
+                        successfulHistoryLimit:
+                          type: integer
+                        taskRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                type: integer
+                              historyLimit:
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                type: integer
+                            type: object
+                          type: array
+                        ttlSecondsAfterFinished:
+                          type: integer
+                      type: object
+                    type: object
+                  successfulHistoryLimit:
+                    type: integer
+                  ttlSecondsAfterFinished:
+                    type: integer
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               options:
                 description: options holds additions fields and these fields will
@@ -3889,6 +6024,19 @@ spec:
                 description: |-
                   This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                   match the key here
+                properties:
+                  cel:
+                    properties:
+                      expressions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  multiKueueOverride:
+                    type: boolean
+                  queueName:
+                    type: string
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               disabled:
                 description: enable or disable TektonScheduler Component

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -298,11 +298,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1668,11 +2138,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               params:
@@ -2287,6 +3227,19 @@ spec:
                     description: |-
                       This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                       match the key here
+                    properties:
+                      cel:
+                        properties:
+                          expressions:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      multiKueueOverride:
+                        type: boolean
+                      queueName:
+                        type: string
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   disabled:
                     description: enable or disable TektonScheduler Component
@@ -2359,6 +3312,127 @@ spec:
                     description: enable or disable TektonPruner Component
                     type: boolean
                   global-config:
+                    description: |-
+                      GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                      Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                      NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                    properties:
+                      enforcedConfigLevel:
+                        description: 'EnforcedConfigLevel allowed values: global,
+                          namespace (default: namespace)'
+                        type: string
+                      failedHistoryLimit:
+                        type: integer
+                      historyLimit:
+                        type: integer
+                      namespaces:
+                        additionalProperties:
+                          description: |-
+                            NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                            Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                            Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                          properties:
+                            enforcedConfigLevel:
+                              description: 'EnforcedConfigLevel allowed values: global,
+                                namespace (default: namespace)'
+                              type: string
+                            failedHistoryLimit:
+                              type: integer
+                            historyLimit:
+                              type: integer
+                            pipelineRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    type: integer
+                                  historyLimit:
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    type: integer
+                                type: object
+                              type: array
+                            successfulHistoryLimit:
+                              type: integer
+                            taskRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    type: integer
+                                  historyLimit:
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    type: integer
+                                type: object
+                              type: array
+                            ttlSecondsAfterFinished:
+                              type: integer
+                          type: object
+                        type: object
+                      successfulHistoryLimit:
+                        type: integer
+                      ttlSecondsAfterFinished:
+                        type: integer
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   options:
                     description: options holds additions fields and these fields will
@@ -2837,11 +3911,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -3486,11 +5030,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -3705,6 +5719,127 @@ spec:
                 description: enable or disable TektonPruner Component
                 type: boolean
               global-config:
+                description: |-
+                  GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                  Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                  NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                properties:
+                  enforcedConfigLevel:
+                    description: 'EnforcedConfigLevel allowed values: global, namespace
+                      (default: namespace)'
+                    type: string
+                  failedHistoryLimit:
+                    type: integer
+                  historyLimit:
+                    type: integer
+                  namespaces:
+                    additionalProperties:
+                      description: |-
+                        NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                        Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                        Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                      properties:
+                        enforcedConfigLevel:
+                          description: 'EnforcedConfigLevel allowed values: global,
+                            namespace (default: namespace)'
+                          type: string
+                        failedHistoryLimit:
+                          type: integer
+                        historyLimit:
+                          type: integer
+                        pipelineRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                type: integer
+                              historyLimit:
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                type: integer
+                            type: object
+                          type: array
+                        successfulHistoryLimit:
+                          type: integer
+                        taskRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                type: integer
+                              historyLimit:
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                type: integer
+                            type: object
+                          type: array
+                        ttlSecondsAfterFinished:
+                          type: integer
+                      type: object
+                    type: object
+                  successfulHistoryLimit:
+                    type: integer
+                  ttlSecondsAfterFinished:
+                    type: integer
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               options:
                 description: options holds additions fields and these fields will
@@ -3868,6 +6003,19 @@ spec:
                 description: |-
                   This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                   match the key here
+                properties:
+                  cel:
+                    properties:
+                      expressions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  multiKueueOverride:
+                    type: boolean
+                  queueName:
+                    type: string
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               disabled:
                 description: enable or disable TektonScheduler Component

--- a/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -138,11 +138,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -583,11 +583,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               params:
@@ -1214,6 +1686,19 @@ spec:
                     description: |-
                       This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                       match the key here
+                    properties:
+                      cel:
+                        properties:
+                          expressions:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      multiKueueOverride:
+                        type: boolean
+                      queueName:
+                        type: string
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   disabled:
                     description: enable or disable TektonScheduler Component
@@ -1287,6 +1772,143 @@ spec:
                     description: enable or disable TektonPruner Component
                     type: boolean
                   global-config:
+                    description: |-
+                      GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                      Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                      NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                    properties:
+                      enforcedConfigLevel:
+                        description: 'EnforcedConfigLevel allowed values: global,
+                          namespace (default: namespace)'
+                        type: string
+                      failedHistoryLimit:
+                        format: int32
+                        type: integer
+                      historyLimit:
+                        format: int32
+                        type: integer
+                      namespaces:
+                        additionalProperties:
+                          description: |-
+                            NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                            Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                            Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                          properties:
+                            enforcedConfigLevel:
+                              description: 'EnforcedConfigLevel allowed values: global,
+                                namespace (default: namespace)'
+                              type: string
+                            failedHistoryLimit:
+                              format: int32
+                              type: integer
+                            historyLimit:
+                              format: int32
+                              type: integer
+                            pipelineRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    format: int32
+                                    type: integer
+                                  historyLimit:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    format: int32
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              type: array
+                            successfulHistoryLimit:
+                              format: int32
+                              type: integer
+                            taskRuns:
+                              items:
+                                description: |-
+                                  ResourceSpec is used to hold the config of a specific resource
+                                  Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                                properties:
+                                  enforcedConfigLevel:
+                                    description: 'EnforcedConfigLevel allowed values:
+                                      global, namespace (default: namespace)'
+                                    type: string
+                                  failedHistoryLimit:
+                                    format: int32
+                                    type: integer
+                                  historyLimit:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  selector:
+                                    items:
+                                      description: |-
+                                        SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                        Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                      properties:
+                                        matchAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Match by labels AND annotations.
+                                            If both are specified, BOTH must match
+                                            (AND logic)
+                                          type: object
+                                      type: object
+                                    type: array
+                                  successfulHistoryLimit:
+                                    format: int32
+                                    type: integer
+                                  ttlSecondsAfterFinished:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              type: array
+                            ttlSecondsAfterFinished:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: object
+                      successfulHistoryLimit:
+                        format: int32
+                        type: integer
+                      ttlSecondsAfterFinished:
+                        format: int32
+                        type: integer
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   options:
                     description: options holds additions fields and these fields will

--- a/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpipelines.yaml
@@ -207,11 +207,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -104,6 +104,143 @@ spec:
                 description: enable or disable TektonPruner Component
                 type: boolean
               global-config:
+                description: |-
+                  GlobalConfig represents the global ConfigMap (tekton-pruner-default-spec)
+                  Root-level fields are defaults; Namespaces map is for per-namespace defaults
+                  NOTE: Selector support (PipelineRuns/TaskRuns arrays) is IGNORED in global ConfigMap
+                properties:
+                  enforcedConfigLevel:
+                    description: 'EnforcedConfigLevel allowed values: global, namespace
+                      (default: namespace)'
+                    type: string
+                  failedHistoryLimit:
+                    format: int32
+                    type: integer
+                  historyLimit:
+                    format: int32
+                    type: integer
+                  namespaces:
+                    additionalProperties:
+                      description: |-
+                        NamespaceSpec is used to hold the pruning config of a specific namespace and its resources
+                        Used in both global ConfigMap (tekton-pruner-default-spec) and namespace ConfigMap (tekton-pruner-namespace-spec)
+                        Selector support (PipelineRuns/TaskRuns arrays) ONLY works in namespace ConfigMaps
+                      properties:
+                        enforcedConfigLevel:
+                          description: 'EnforcedConfigLevel allowed values: global,
+                            namespace (default: namespace)'
+                          type: string
+                        failedHistoryLimit:
+                          format: int32
+                          type: integer
+                        historyLimit:
+                          format: int32
+                          type: integer
+                        pipelineRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                format: int32
+                                type: integer
+                              historyLimit:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                format: int32
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        successfulHistoryLimit:
+                          format: int32
+                          type: integer
+                        taskRuns:
+                          items:
+                            description: |-
+                              ResourceSpec is used to hold the config of a specific resource
+                              Only used in namespace-level ConfigMaps (tekton-pruner-namespace-spec), NOT in global ConfigMaps
+                            properties:
+                              enforcedConfigLevel:
+                                description: 'EnforcedConfigLevel allowed values:
+                                  global, namespace (default: namespace)'
+                                type: string
+                              failedHistoryLimit:
+                                format: int32
+                                type: integer
+                              historyLimit:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              selector:
+                                items:
+                                  description: |-
+                                    SelectorSpec allows specifying selectors for matching resources like PipelineRun or TaskRun
+                                    Only applicable in namespace-level ConfigMaps, NOT in global ConfigMaps
+                                  properties:
+                                    matchAnnotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Match by labels AND annotations.
+                                        If both are specified, BOTH must match (AND
+                                        logic)
+                                      type: object
+                                  type: object
+                                type: array
+                              successfulHistoryLimit:
+                                format: int32
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        ttlSecondsAfterFinished:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: object
+                  successfulHistoryLimit:
+                    format: int32
+                    type: integer
+                  ttlSecondsAfterFinished:
+                    format: int32
+                    type: integer
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               options:
                 description: options holds additions fields and these fields will

--- a/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
@@ -52,6 +52,19 @@ spec:
                 description: |-
                   This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
                   match the key here
+                properties:
+                  cel:
+                    properties:
+                      expressions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  multiKueueOverride:
+                    type: boolean
+                  queueName:
+                    type: string
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               disabled:
                 description: enable or disable TektonScheduler Component

--- a/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektontriggers.yaml
@@ -118,11 +118,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/pkg/apis/operator/v1alpha1/networkpolicy_config.go
+++ b/pkg/apis/operator/v1alpha1/networkpolicy_config.go
@@ -36,7 +36,6 @@ type NetworkPolicyConfig struct {
 	// If nil or empty, all operator defaults are applied unchanged.
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:Schemaless
 	Policies map[string]networkingv1.NetworkPolicySpec `json:"policies,omitempty"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonpruner_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonpruner_types.go
@@ -47,7 +47,6 @@ type TektonPruner struct {
 
 type TektonPrunerConfig struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:Schemaless
 	GlobalConfig *config.GlobalConfig `json:"global-config"`
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
@@ -60,7 +60,6 @@ type SchedulerConfig struct {
 	// This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
 	// match the key here
 	// +kubebuilder:pruning:PreserveUnknownFields
-	// +kubebuilder:validation:Schemaless
 	config.Config `json:"config.yaml"`
 }
 


### PR DESCRIPTION
## Changes

Removes `+kubebuilder:validation:Schemaless` from three configuration types so that `oc explain` shows the full schema for configurable fields in the TektonConfig CRD.

**Before:** `oc explain tektonconfig.spec.tektonpruner.global-config` shows just `<Object>` with no fields.

**After:** Shows all configurable fields (enforcedConfigLevel, ttlSecondsAfterFinished, historyLimit, namespaces, etc.)

Ref: https://redhat.atlassian.net/browse/RFE-9431

### What was changed:

- Removed `// +kubebuilder:validation:Schemaless` from:
  - `SchedulerConfig.Config` in `tektonscheduler_types.go` (exposes: queueName, multiKueueOverride, cel)
  - `TektonPrunerConfig.GlobalConfig` in `tektonpruner_types.go` (exposes: ttlSecondsAfterFinished, historyLimit, namespaces, etc.)
  - `NetworkPolicyConfig.Policies` in `networkpolicy_config.go` (exposes: podSelector, ingress, egress)
- Kept `+kubebuilder:pruning:PreserveUnknownFields` on all three fields for backward compatibility
- Regenerated all affected CRDs via controller-gen v0.18.0

### Size Impact

| CRD | Before | After | Limit |
|-----|--------|-------|-------|
| TektonConfig | 71 KB | 111 KB | 256 KB |

All CRDs remain well under the 256 KB size constraint enforced by `hack/sync-helm-crds.sh`.

### Why not expand AdditionalOptions?

The `AdditionalOptions` fields (Deployments, StatefulSets, ConfigMaps, HPAs) embed full Kubernetes types that would each add ~100 KB per instance across 11 components, pushing the CRD far over the 256 KB limit. These remain schemaless by necessity.

### Testing

- Applied the regenerated CRD to an OCP 4.21.18 cluster with OpenShift Pipelines 1.23.0
- Verified `oc explain` now shows full field schemas for all three types
- Verified TektonConfig resource remains Ready=True with all conditions healthy
- No disruption to running Tekton components (18 pods in openshift-pipelines namespace)

## Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

## Release Notes

```release-note
Exposed full openAPIV3Schema for TektonConfig CRD fields: tektonpruner global-config, scheduler config.yaml, and networkPolicy policies. Users can now run `oc explain tektonconfig.spec.tektonpruner.global-config` to see all configurable fields instead of just `<Object>`.
```