### PR TITLE
feat(common): support rollout strategy in options

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -769,6 +769,12 @@ There is a field called `options` available in all the components.<br>
 > **NOTE:** There is a possibility to have two different values for a field.<br>
 > An example: with a pre-defined field you can set value and the same field may be defined under `options` as well. In that case value from `options` will be final.
 
+> **NOTE:** The embedded objects are not merged as a whole. The operator copies a
+> known set of fields onto the manifest, and the per-kind lists below are
+> exhaustive - a field outside them is ignored silently, with no error or warning.
+> If a field you set under `options` has no effect, it is most likely not
+> supported yet - please open an issue.
+
 A sample `options` field,
 
 ```yaml
@@ -822,6 +828,11 @@ options:
           custom-annotation: "foo"
       spec:
         replicas: 2
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 0
+            maxUnavailable: 1
         template:
           spec:
             containers:
@@ -838,6 +849,10 @@ options:
           custom-annotation: foo
       spec:
         replicas: 3
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            partition: 1
         template:
           spec:
             containers:
@@ -895,6 +910,7 @@ The following fields are supported in `deployment`
   - `annotations` - supports add and update
 - `spec`
   - `replicas` - updates deployment replicas count
+  - `strategy` - replaces the existing deployment strategy with this, if `type` is not empty
   - `template`
     - `metadata`
       - `labels` - supports add and update
@@ -929,6 +945,7 @@ The following fields are supported in `StatefulSet`
   - `annotations` - supports add and update
 - `spec`
   - `replicas` - updates statefulSets replicas count
+  - `updateStrategy` - replaces the existing statefulSet update strategy with this, if `type` is not empty
   - `serviceName` - updates service name
   - `podManagementPolicy` - updates pod management policy
   - `volumeClaimTemplates` - updates volume claim templates

--- a/pkg/reconciler/common/testdata/test-additional-options-base-strategy-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-base-strategy-deployment.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1

--- a/pkg/reconciler/common/testdata/test-additional-options-base-strategy-recreate-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-base-strategy-recreate-deployment.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1

--- a/pkg/reconciler/common/testdata/test-additional-options-base-updatestrategy-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-base-updatestrategy-statefulset.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: nginx
+  replicas: 2
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: registry.k8s.io/nginx-slim:0.8

--- a/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+status: {}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1
+          resources: {}

--- a/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-to-rollingupdate-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-to-rollingupdate-deployment.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+status: {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1
+          resources: {}

--- a/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-with-rollingupdate-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-strategy-recreate-with-rollingupdate-deployment.yaml
@@ -1,0 +1,29 @@
+---
+# The options asked for Recreate while also supplying a rollingUpdate block.
+# The transformer passes both through untouched rather than silently dropping
+# one of them; the API server is the component that rejects the combination.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+status: {}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1
+          resources: {}

--- a/pkg/reconciler/common/testdata/test-additional-options-test-strategy-rollingupdate-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-strategy-rollingupdate-deployment.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+status: {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1
+          resources: {}

--- a/pkg/reconciler/common/testdata/test-additional-options-test-strategy-unset-deployment.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-strategy-unset-deployment.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+status: {}
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: controller
+    spec:
+      containers:
+        - name: tekton-pipelines-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.50.1
+          resources: {}

--- a/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-ondelete-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-ondelete-statefulset.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: nginx
+  replicas: 2
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: registry.k8s.io/nginx-slim:0.8
+          resources: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-partition-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-partition-statefulset.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: nginx
+  replicas: 2
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: registry.k8s.io/nginx-slim:0.8
+          resources: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-unset-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-additional-options-test-updatestrategy-unset-statefulset.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: nginx
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: registry.k8s.io/nginx-slim:0.8
+          resources: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/pkg/reconciler/common/transformer_additional_options.go
+++ b/pkg/reconciler/common/transformer_additional_options.go
@@ -287,6 +287,15 @@ func (ot *OptionsTransformer) updateDeployments(u *unstructured.Unstructured) er
 		targetDeployment.Spec.Replicas = ptr.Int32(*deploymentOptions.Spec.Replicas)
 	}
 
+	// update deployment strategy
+	// The whole struct is replaced instead of merged field by field: "rollingUpdate"
+	// may not be set when the type is "Recreate", so merging would leave the
+	// rollingUpdate block from the base manifest behind and the API server would
+	// reject the resulting deployment.
+	if deploymentOptions.Spec.Strategy.Type != "" {
+		targetDeployment.Spec.Strategy = deploymentOptions.Spec.Strategy
+	}
+
 	// update affinity
 	if deploymentOptions.Spec.Template.Spec.Affinity != nil {
 		targetDeployment.Spec.Template.Spec.Affinity = deploymentOptions.Spec.Template.Spec.Affinity
@@ -587,6 +596,15 @@ func (ot *OptionsTransformer) updateStatefulSets(u *unstructured.Unstructured) e
 	// update replicas
 	if statefulSetOptions.Spec.Replicas != nil {
 		targetStatefulSet.Spec.Replicas = ptr.Int32(*statefulSetOptions.Spec.Replicas)
+	}
+
+	// update statefulSet update strategy
+	// The whole struct is replaced instead of merged field by field: "rollingUpdate"
+	// may not be set when the type is "OnDelete", so merging would leave the
+	// rollingUpdate block from the base manifest behind and the API server would
+	// reject the resulting statefulSet.
+	if statefulSetOptions.Spec.UpdateStrategy.Type != "" {
+		targetStatefulSet.Spec.UpdateStrategy = statefulSetOptions.Spec.UpdateStrategy
 	}
 
 	// update affinity

--- a/pkg/reconciler/common/transformer_additional_options_test.go
+++ b/pkg/reconciler/common/transformer_additional_options_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/ptr"
 )
 
@@ -41,6 +42,8 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 	ignorePolicy := admissionregistrationv1.Ignore
 	failPolicy := admissionregistrationv1.Fail
 	sideEffectUnknown := admissionregistrationv1.SideEffectClassUnknown
+	maxSurgeZero := intstr.FromInt32(0)
+	maxUnavailableOne := intstr.FromInt32(1)
 
 	// verify the changes applied on the manifest
 
@@ -576,6 +579,188 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 			expectedResultFilename: "./testdata/test-additional-options-test-webhook.yaml",
 		},
 		{
+			// switching to Recreate must drop the rollingUpdate block coming from
+			// the base manifest, otherwise the API server rejects the deployment
+			name: "test-strategy-recreate-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RecreateDeploymentStrategyType,
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-recreate-deployment.yaml",
+		},
+		{
+			name: "test-strategy-rollingupdate-tuning-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RollingUpdateDeploymentStrategyType,
+								RollingUpdate: &appsv1.RollingUpdateDeployment{
+									MaxSurge:       &maxSurgeZero,
+									MaxUnavailable: &maxUnavailableOne,
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-rollingupdate-deployment.yaml",
+		},
+		{
+			// a deployment present in options but without a strategy must keep
+			// the strategy defined in the base manifest untouched
+			name: "test-strategy-not-set-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Replicas: ptr.Int32(2),
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-unset-deployment.yaml",
+		},
+		{
+			// switching back from Recreate must bring the rollingUpdate block in,
+			// proving the replacement works in both directions
+			name: "test-strategy-recreate-to-rollingupdate-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RollingUpdateDeploymentStrategyType,
+								RollingUpdate: &appsv1.RollingUpdateDeployment{
+									MaxSurge:       &maxSurgeZero,
+									MaxUnavailable: &maxUnavailableOne,
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-recreate-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-recreate-to-rollingupdate-deployment.yaml",
+		},
+		{
+			// a rollingUpdate without a strategy type is deliberately ignored:
+			// the type drives the decision and an empty type means "keep the base"
+			name: "test-strategy-rollingupdate-without-type-is-ignored-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Replicas: ptr.Int32(2),
+							Strategy: appsv1.DeploymentStrategy{
+								RollingUpdate: &appsv1.RollingUpdateDeployment{
+									MaxSurge:       &maxSurgeZero,
+									MaxUnavailable: &maxUnavailableOne,
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-unset-deployment.yaml",
+		},
+		{
+			// a self-contradictory strategy from options is passed through as given
+			// rather than partially dropped; rejecting it is the API server's job
+			name: "test-strategy-recreate-with-rollingupdate-is-passed-through-for-deployments",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				Deployments: map[string]appsv1.Deployment{
+					"tekton-pipelines-controller": {
+						Spec: appsv1.DeploymentSpec{
+							Strategy: appsv1.DeploymentStrategy{
+								Type: appsv1.RecreateDeploymentStrategyType,
+								RollingUpdate: &appsv1.RollingUpdateDeployment{
+									MaxSurge:       &maxSurgeZero,
+									MaxUnavailable: &maxUnavailableOne,
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-strategy-deployment.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-strategy-recreate-with-rollingupdate-deployment.yaml",
+		},
+		{
+			name: "test-updatestrategy-partition-tuning-for-statefulsets",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				StatefulSets: map[string]appsv1.StatefulSet{
+					"web": {
+						Spec: appsv1.StatefulSetSpec{
+							UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+								Type: appsv1.RollingUpdateStatefulSetStrategyType,
+								RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+									Partition: ptr.Int32(2),
+								},
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-updatestrategy-statefulset.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-updatestrategy-partition-statefulset.yaml",
+		},
+		{
+			// a statefulSet present in options but without an update strategy must
+			// keep the strategy defined in the base manifest untouched
+			name: "test-updatestrategy-not-set-for-statefulsets",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				StatefulSets: map[string]appsv1.StatefulSet{
+					"web": {
+						Spec: appsv1.StatefulSetSpec{
+							Replicas: ptr.Int32(3),
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-updatestrategy-statefulset.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-updatestrategy-unset-statefulset.yaml",
+		},
+		{
+			// switching to OnDelete must drop the rollingUpdate block coming from
+			// the base manifest, otherwise the API server rejects the statefulSet
+			name: "test-updatestrategy-ondelete-for-statefulsets",
+			additionalOptions: v1alpha1.AdditionalOptions{
+				Disabled: ptr.Bool(false),
+				StatefulSets: map[string]appsv1.StatefulSet{
+					"web": {
+						Spec: appsv1.StatefulSetSpec{
+							UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+								Type: appsv1.OnDeleteStatefulSetStrategyType,
+							},
+						},
+					},
+				},
+			},
+			inputFilename:          "./testdata/test-additional-options-base-updatestrategy-statefulset.yaml",
+			expectedResultFilename: "./testdata/test-additional-options-test-updatestrategy-ondelete-statefulset.yaml",
+		},
+		{
 			name: "test-runtimeclassname-for-deployments",
 			additionalOptions: v1alpha1.AdditionalOptions{
 				Disabled: ptr.Bool(false),
@@ -860,4 +1045,66 @@ func TestExecuteAdditionalOptionsTransformer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The pod-template hash label drives pod recreation: it is recomputed from the
+// deployment spec, but updateDeploymentHashValue() deliberately zeroes the
+// strategy before hashing. Changing only the strategy must therefore leave the
+// hash untouched, so switching the rollout strategy does not restart the pods.
+// The table test above strips this label before comparing, so it is asserted here.
+func TestDeploymentStrategyDoesNotAffectSpecHash(t *testing.T) {
+	ctx := context.TODO()
+	targetNamespace := "tekton-pipelines"
+	inputFile := "./testdata/test-additional-options-base-strategy-deployment.yaml"
+
+	hashOf := func(t *testing.T, options v1alpha1.AdditionalOptions) string {
+		t.Helper()
+		manifest, err := Fetch(inputFile)
+		require.NoError(t, err)
+		require.NoError(t, ExecuteAdditionalOptionsTransformer(ctx, &manifest, targetNamespace, options))
+
+		for _, resource := range manifest.Resources() {
+			if resource.GetKind() != "Deployment" {
+				continue
+			}
+			labels, found, err := unstructured.NestedStringMap(resource.Object, "spec", "template", "metadata", "labels")
+			require.NoError(t, err)
+			require.True(t, found, "pod template labels not found")
+			hash, found := labels[v1alpha1.DeploymentSpecHashValueLabelKey]
+			require.True(t, found, "spec hash label not found")
+			return hash
+		}
+		t.Fatal("no deployment found in manifest")
+		return ""
+	}
+
+	baseline := hashOf(t, v1alpha1.AdditionalOptions{Disabled: ptr.Bool(false)})
+
+	strategyOnly := hashOf(t, v1alpha1.AdditionalOptions{
+		Disabled: ptr.Bool(false),
+		Deployments: map[string]appsv1.Deployment{
+			"tekton-pipelines-controller": {
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+				},
+			},
+		},
+	})
+	require.Equal(t, baseline, strategyOnly, "changing the strategy must not change the spec hash")
+
+	// a change outside the strategy must still be reflected in the hash,
+	// otherwise the assertion above would hold vacuously
+	replicasChanged := hashOf(t, v1alpha1.AdditionalOptions{
+		Disabled: ptr.Bool(false),
+		Deployments: map[string]appsv1.Deployment{
+			"tekton-pipelines-controller": {
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.Int32(5),
+				},
+			},
+		},
+	})
+	require.NotEqual(t, baseline, replicasChanged, "changing the replicas must change the spec hash")
 }


### PR DESCRIPTION
# Changes

Fixes #3812

Adds `spec.strategy` (Deployment) and `spec.updateStrategy` (StatefulSet) to the
set of fields that `options` copies onto the generated manifests.

## Why

`options` does not merge the embedded object — the transformer copies an
explicit list of fields, documented under
[Deployments](https://github.com/tektoncd/operator/blob/main/docs/TektonConfig.md#deployments).
`replicas`, `affinity` and `topologySpreadConstraints` are on that list; the
rollout strategy is not, so a `strategy` block under `options` is stored by the
API server (the field is `x-kubernetes-preserve-unknown-fields`, so it is not
validated) and then dropped by the reconciler without any error, warning or
condition.

That combination has a concrete failure mode, because the fields already
supported are exactly the ones needed to construct it:

```yaml
options:
  deployments:
    tekton-pipelines-controller:
      spec:
        replicas: 3
        template:
          spec:
            affinity:
              podAntiAffinity:
                requiredDuringSchedulingIgnoredDuringExecution:
                  - topologyKey: kubernetes.io/hostname
                    labelSelector:
                      matchLabels:
                        app.kubernetes.io/name: controller
```

Three HA replicas, hard anti-affinity so no two share a node. None of the
shipped Deployments declare `spec.strategy`, so Kubernetes applies the default
`RollingUpdate` with `maxSurge: 25%` / `maxUnavailable: 25%`, computed by
rounding the surge **up** and the unavailable count **down**. At `replicas: 3`
that is `maxSurge: 1`, `maxUnavailable: 0`.

On a cluster with exactly three eligible nodes, all three already hold a
replica. The surge pod has no node satisfying the anti-affinity rule and stays
`Pending`, and `maxUnavailable: 0` forbids terminating any old pod to make room.
The rollout cannot complete — not as a scheduling race, but arithmetically, and
`maxUnavailable` rounds to 0 for any `replicas` ≤ 3, which is the common
on-premises cluster size. `topologySpreadConstraints` with
`whenUnsatisfiable: DoNotSchedule` deadlocks identically.

The remedy is `maxSurge: 0` with `maxUnavailable: 1` — replace the replicas one
at a time, never needing a spare node — or `type: Recreate`. That is exactly the
field `options` will not carry over, and there is no way to set it from outside
`options` either: `resourceReconcileFields()` returns `spec` for Deployment and
StatefulSet and `copyResourceFields()` applies
`unstructured.SetNestedField(dst.Object, fieldValue, "spec")`, so the whole
`spec` is overwritten from the expected manifest and a hand-edited strategy is
reverted on the next reconcile.

I do not think the operator should infer this. Whether a spare eligible node
exists is not knowable from the Deployment alone, clusters with headroom
genuinely want the surge behaviour, and inference would not cover the adjacent
cases (a full namespace `ResourceQuota` leaving no room for the surge pod —
which the operator already detects via `ReplicaSetReplicaFailure` /
`FailedCreate` — or single-node clusters). It is an environment-specific
decision, the same reasoning behind `priorityClassName`, `runtimeClassName` and
`topologySpreadConstraints` being added to `options`.

## Implementation

Two symmetric additions, in `updateDeployments()` and `updateStatefulSets()`,
guarded on a non-empty strategy type to match the existing
`PriorityClassName != ""` style in the same functions:

```go
if deploymentOptions.Spec.Strategy.Type != "" {
    targetDeployment.Spec.Strategy = deploymentOptions.Spec.Strategy
}
```

Three semantics worth calling out, each covered by a test:

- **The whole struct is replaced, not merged field by field.** `rollingUpdate`
  may not be set when the type is `Recreate` (`OnDelete` for StatefulSets); a
  field-wise merge would leave the base manifest's `rollingUpdate` block behind
  and produce an object the API server rejects. That is the failure mode the
  `Recreate` test case exists to catch.
- **An empty type is a no-op**, keeping the base manifest's strategy. This
  matches the "non-empty wins" semantics of every other field in the
  transformer.
- **A self-contradictory strategy is passed through as given** rather than
  partially dropped, so the user gets a real API server error instead of a
  silent half-application.

`updateDeploymentHashValue()` already zeroes `Spec.Strategy` before computing
the pod-template hash, so changing only the strategy leaves
`operator.tekton.dev/deployment-spec-applied-hash` unchanged and does not
trigger a rollout through that mechanism — which is the behaviour you want, and
is now asserted by a test.

> **Open to feedback:** requiring `type` means the common case above has to
> spell out `type: RollingUpdate` alongside `rollingUpdate`, even though it is
> not changing the type. I chose that over honouring a bare `rollingUpdate:`
> block because the latter has to decide whether an unset type inherits the base
> strategy's type or falls back to the Kubernetes default, and either answer is
> surprising in some case. Happy to change it if reviewers prefer the looser
> form.

## Tests

Added to the existing table-driven golden-file test in
`transformer_additional_options_test.go`:

| Case | Covers |
|---|---|
| `test-strategy-recreate-for-deployments` | base has `RollingUpdate` + a `rollingUpdate` block, options set `Recreate` → result is `Recreate` with **no** `rollingUpdate` key |
| `test-strategy-rollingupdate-tuning-for-deployments` | `maxSurge` / `maxUnavailable` tuning is applied (the case from the description) |
| `test-strategy-recreate-to-rollingupdate-for-deployments` | the reverse direction, base `Recreate` → options `RollingUpdate` |
| `test-strategy-not-set-for-deployments` | options present without a strategy → base strategy preserved (regression guard) |
| `test-strategy-rollingupdate-without-type-is-ignored-for-deployments` | `rollingUpdate` without `type` is a no-op |
| `test-strategy-recreate-with-rollingupdate-is-passed-through-for-deployments` | contradictory options are passed through, not partially dropped |
| `test-updatestrategy-ondelete-for-statefulsets` | StatefulSet `OnDelete` drops the base `rollingUpdate` block |
| `test-updatestrategy-partition-tuning-for-statefulsets` | `partition` is applied |
| `test-updatestrategy-not-set-for-statefulsets` | regression guard |

Plus `TestDeploymentStrategyDoesNotAffectSpecHash`, which the golden-file cases
cannot cover because the shared test helper strips the hash label before
comparing. It pairs the assertion with a `replicas` change as a vacuity guard,
so it cannot pass by hashing nothing.

Falsified against the source change: with
`pkg/reconciler/common/transformer_additional_options.go` reverted, the four
feature cases fail and the three regression guards still pass.

## Docs

`docs/TektonConfig.md`:

- `strategy` and `updateStrategy` added to the supported-field lists under
  `#### Deployments` and `#### StatefulSets`.
- Both `options` examples extended with the `maxSurge: 0` / `maxUnavailable: 1`
  form, since that is the shape people will actually need.
- A note in the `Additional fields as options` section stating that the embedded
  objects are not merged as a whole and that the per-kind lists are exhaustive —
  fields outside them are ignored silently. The lists were already there and
  correct, but nothing said they were the complete story, and the silent drop is
  easy to mistake for a bug in your own YAML.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

This change was AI-assisted (Claude Opus 5 via Claude Code) and is disclosed
with an `Assisted-by:` trailer on the commit, per the
[AI contribution policy](https://github.com/tektoncd/community/blob/main/ai-contribution-policy.md).
I have reviewed and tested it, I understand it, and I take responsibility for
it.

# Release Notes

```release-note
`options` now applies `deployments[].spec.strategy` and
`statefulSets[].spec.updateStrategy` to the generated workloads instead of
ignoring them. This makes it possible to set, for example,
`rollingUpdate.maxSurge: 0` on a component whose replicas are pinned
one-per-node by anti-affinity, where the default surge-based rollout cannot
schedule the extra pod.
```
