### PR TITLE
feat(openshiftpipelinesascode): add NetworkPolicy support

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -287,6 +287,24 @@ spec:
                       type: object
                     type: array
                 type: object
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller,
+                  watcher and webhook workloads deployed by OpenShiftPipelinesAsCode.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -287,6 +287,24 @@ spec:
                       type: object
                     type: array
                 type: object
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller,
+                  watcher and webhook workloads deployed by OpenShiftPipelinesAsCode.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -576,6 +594,3753 @@ spec:
                   ObservedGeneration is the 'Generation' of the Service that
                   was last processed by the controller.
                 type: integer
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonchains.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonChain
+    listKind: TektonChainList
+    plural: tektonchains
+    singular: tektonchain
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonChain is the Schema for the tektonchain API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonChainSpec defines the desired state of TektonChain
+            properties:
+              artifacts.oci.format:
+                description: oci artifacts config
+                type: string
+              artifacts.oci.signer:
+                type: string
+              artifacts.oci.storage:
+                type: string
+              artifacts.pipelinerun.enable-deep-inspection:
+                type: string
+              artifacts.pipelinerun.format:
+                description: pipelinerun artifacts config
+                type: string
+              artifacts.pipelinerun.signer:
+                type: string
+              artifacts.pipelinerun.storage:
+                type: string
+              artifacts.taskrun.format:
+                description: taskrun artifacts config
+                type: string
+              artifacts.taskrun.signer:
+                type: string
+              artifacts.taskrun.storage:
+                type: string
+              builddefinition.buildtype:
+                type: string
+              builder.id:
+                description: builder config
+                type: string
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonChain
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              controllerEnvs:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              disabled:
+                description: enable or disable chains feature
+                type: boolean
+              generateSigningSecret:
+                description: generate signing key
+                type: boolean
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              signers.kms.auth.address:
+                type: string
+              signers.kms.auth.oidc.path:
+                type: string
+              signers.kms.auth.oidc.role:
+                type: string
+              signers.kms.auth.spire.audience:
+                type: string
+              signers.kms.auth.spire.sock:
+                type: string
+              signers.kms.auth.token:
+                type: string
+              signers.kms.auth.token-path:
+                type: string
+              signers.kms.kmsref:
+                description: kms signer config
+                type: string
+              signers.x509.fulcio.address:
+                type: string
+              signers.x509.fulcio.enabled:
+                description: x509 signer config
+                type: boolean
+              signers.x509.fulcio.issuer:
+                type: string
+              signers.x509.fulcio.provider:
+                type: string
+              signers.x509.identity.token.file:
+                type: string
+              signers.x509.tuf.mirror.url:
+                type: string
+              storage.docdb.mongo-server-url:
+                type: string
+              storage.docdb.mongo-server-url-dir:
+                type: string
+              storage.docdb.url:
+                type: string
+              storage.gcs.bucket:
+                description: storage configs
+                type: string
+              storage.grafeas.notehint:
+                type: string
+              storage.grafeas.noteid:
+                type: string
+              storage.grafeas.projectid:
+                type: string
+              storage.oci.repository:
+                type: string
+              storage.oci.repository.insecure:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              transparency.enabled:
+                type: string
+              transparency.url:
+                type: string
+            required:
+            - disabled
+            type: object
+          status:
+            description: TektonChainStatus defines the observed state of TektonChain
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonChain
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonconfigs.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonConfig
+    listKind: TektonConfigList
+    plural: tektonconfigs
+    singular: tektonconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonConfig is the Schema for the TektonConfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonConfigSpec defines the desired state of TektonConfig
+            properties:
+              addon:
+                description: Addon holds the addons config
+                properties:
+                  enablePipelinesAsCode:
+                    description: |-
+                      Deprecated, will be removed in further release
+                      EnablePAC field defines whether to install PAC
+                    type: boolean
+                  params:
+                    description: Params is the list of params passed for Addon customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              chain:
+                description: Chain holds the customizable option for chains component
+                properties:
+                  artifacts.oci.format:
+                    description: oci artifacts config
+                    type: string
+                  artifacts.oci.signer:
+                    type: string
+                  artifacts.oci.storage:
+                    type: string
+                  artifacts.pipelinerun.enable-deep-inspection:
+                    type: string
+                  artifacts.pipelinerun.format:
+                    description: pipelinerun artifacts config
+                    type: string
+                  artifacts.pipelinerun.signer:
+                    type: string
+                  artifacts.pipelinerun.storage:
+                    type: string
+                  artifacts.taskrun.format:
+                    description: taskrun artifacts config
+                    type: string
+                  artifacts.taskrun.signer:
+                    type: string
+                  artifacts.taskrun.storage:
+                    type: string
+                  builddefinition.buildtype:
+                    type: string
+                  builder.id:
+                    description: builder config
+                    type: string
+                  controllerEnvs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  disabled:
+                    description: enable or disable chains feature
+                    type: boolean
+                  generateSigningSecret:
+                    description: generate signing key
+                    type: boolean
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  signers.kms.auth.address:
+                    type: string
+                  signers.kms.auth.oidc.path:
+                    type: string
+                  signers.kms.auth.oidc.role:
+                    type: string
+                  signers.kms.auth.spire.audience:
+                    type: string
+                  signers.kms.auth.spire.sock:
+                    type: string
+                  signers.kms.auth.token:
+                    type: string
+                  signers.kms.auth.token-path:
+                    type: string
+                  signers.kms.kmsref:
+                    description: kms signer config
+                    type: string
+                  signers.x509.fulcio.address:
+                    type: string
+                  signers.x509.fulcio.enabled:
+                    description: x509 signer config
+                    type: boolean
+                  signers.x509.fulcio.issuer:
+                    type: string
+                  signers.x509.fulcio.provider:
+                    type: string
+                  signers.x509.identity.token.file:
+                    type: string
+                  signers.x509.tuf.mirror.url:
+                    type: string
+                  storage.docdb.mongo-server-url:
+                    type: string
+                  storage.docdb.mongo-server-url-dir:
+                    type: string
+                  storage.docdb.url:
+                    type: string
+                  storage.gcs.bucket:
+                    description: storage configs
+                    type: string
+                  storage.grafeas.notehint:
+                    type: string
+                  storage.grafeas.noteid:
+                    type: string
+                  storage.grafeas.projectid:
+                    type: string
+                  storage.oci.repository:
+                    type: string
+                  storage.oci.repository.insecure:
+                    type: boolean
+                  transparency.enabled:
+                    type: string
+                  transparency.url:
+                    type: string
+                required:
+                - disabled
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonConfig
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              dashboard:
+                description: Dashboard holds the customizable options for dashboards
+                  component
+                properties:
+                  external-logs:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  readonly:
+                    description: Readonly when set to true configures the Tekton dashboard
+                      in read-only mode
+                    type: boolean
+                required:
+                - readonly
+                type: object
+              hub:
+                description: Hub holds the hub config
+                properties:
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: Params is the list of params passed for Hub customization
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              multiclusterProxyAAE:
+                description: MulticlusterProxyAAE holds the customizable options for
+                  the multicluster-proxy-aae component
+                properties:
+                  options:
+                    description: options holds additional fields and these fields
+                      will be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                type: object
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy resources for the operand namespace.
+                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  only components with NetworkPolicy reconciliation implemented. Other
+                  components (Chains, Results, Dashboard) do not yet act on this field.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              params:
+                description: Params is the list of params passed for all platforms
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              pipeline:
+                description: Pipeline holds the customizable option for pipeline component
+                properties:
+                  await-sidecar-readiness:
+                    type: boolean
+                  bundles-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  cluster-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  coschedule:
+                    type: string
+                  default-affinity-assistant-pod-template:
+                    type: string
+                  default-cloud-events-sink:
+                    type: string
+                  default-forbidden-env:
+                    type: string
+                  default-managed-by-label-value:
+                    type: string
+                  default-max-matrix-combinations-count:
+                    type: string
+                  default-pod-template:
+                    type: string
+                  default-resolver-type:
+                    type: string
+                  default-service-account:
+                    type: string
+                  default-task-run-workspace-binding:
+                    type: string
+                  default-timeout-minutes:
+                    type: integer
+                  disable-affinity-assistant:
+                    description: |-
+                      Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                      This field is removed from pipeline component.
+                      Keeping here to maintain API compatibility during upgrades.
+                    type: boolean
+                  disable-creds-init:
+                    type: boolean
+                  disable-inline-spec:
+                    type: string
+                  embedded-status:
+                    type: string
+                  enable-api-fields:
+                    type: string
+                  enable-bundles-resolver:
+                    type: boolean
+                  enable-cel-in-whenexpression:
+                    type: boolean
+                  enable-cluster-resolver:
+                    type: boolean
+                  enable-custom-tasks:
+                    type: boolean
+                  enable-git-resolver:
+                    type: boolean
+                  enable-hub-resolver:
+                    type: boolean
+                  enable-param-enum:
+                    type: boolean
+                  enable-provenance-in-status:
+                    type: boolean
+                  enable-step-actions:
+                    type: boolean
+                  enable-tekton-oci-bundles:
+                    description: |-
+                      not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                      this field is removed from pipeline component
+                      keeping here to maintain the API compatibility
+                    type: boolean
+                  enforce-nonfalsifiability:
+                    type: string
+                  git-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  hub-resolver-config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  keep-pod-on-cancel:
+                    type: boolean
+                  max-result-size:
+                    type: integer
+                  metrics.count.enable-reason:
+                    type: boolean
+                  metrics.pipelinerun.duration-type:
+                    type: string
+                  metrics.pipelinerun.level:
+                    type: string
+                  metrics.taskrun.duration-type:
+                    type: string
+                  metrics.taskrun.level:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  params:
+                    description: The params to customize different components of Pipelines
+                    items:
+                      description: Param declares an string value to use for the parameter
+                        called name.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  require-git-ssh-secret-known-hosts:
+                    type: boolean
+                  results-from:
+                    type: string
+                  running-in-environment-with-injected-sidecars:
+                    type: boolean
+                  scope-when-expressions-to-task:
+                    description: ScopeWhenExpressionsToTask is deprecated and never
+                      used.
+                    type: boolean
+                  send-cloudevents-for-runs:
+                    description: |-
+                      Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                      (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                      CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                      the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                      effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                      when a custom task controller already sends its own CloudEvents.
+                    type: boolean
+                  set-security-context:
+                    type: boolean
+                  traces.credentialsSecret:
+                    description: CredentialsSecret is the name of the secret containing
+                      credentials for the tracing endpoint
+                    type: string
+                  traces.enabled:
+                    description: Enabled controls whether tracing is enabled or not
+                    type: boolean
+                  traces.endpoint:
+                    description: Endpoint is the URL for the OpenTelemetry trace collector
+                    type: string
+                  trusted-resources-verification-no-match-policy:
+                    type: string
+                  verification-mode:
+                    type: string
+                type: object
+              platforms:
+                description: Platforms allows configuring platform specific configurations
+                properties:
+                  kubernetes:
+                    description: Kubernetes allows configuring kubernetes specific
+                      components and configurations
+                    properties:
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  openshift:
+                    description: OpenShift allows configuring openshift specific components
+                      and configurations
+                    properties:
+                      enableCentralTLSConfig:
+                        description: |-
+                          EnableCentralTLSConfig controls TLS configuration inheritance from the
+                          cluster's APIServer TLS security profile. When enabled (the default),
+                          TLS settings (minimum version, cipher suites, curve preferences) are
+                          automatically derived from the cluster-wide security policy and injected
+                          into Tekton component containers that support TLS configuration.
+                          Set to false to opt out and manage TLS settings manually.
+                          Default: true (opt-out)
+                        type: boolean
+                      pipelinesAsCode:
+                        description: PipelinesAsCode allows configuring PipelinesAsCode
+                          configurations
+                        properties:
+                          additionalPACControllers:
+                            additionalProperties:
+                              description: AdditionalPACControllerConfig contains
+                                config for additionalPACControllers
+                              properties:
+                                configMapName:
+                                  description: Name of the additional controller configMap
+                                  type: string
+                                enable:
+                                  description: Enable or disable this additional pipelines
+                                    as code instance by changing this bool
+                                  type: boolean
+                                secretName:
+                                  description: Name of the additional controller Secret
+                                  type: string
+                                settings:
+                                  additionalProperties:
+                                    type: string
+                                  description: Setting will contains the configMap
+                                    data
+                                  type: object
+                              type: object
+                            description: AdditionalPACControllers allows to deploy
+                              additional PAC controller
+                            type: object
+                          enable:
+                            description: Enable or disable pipelines as code by changing
+                              this bool
+                            type: boolean
+                          options:
+                            description: options holds additions fields and these
+                              fields will be updated on the manifests
+                            properties:
+                              configMaps:
+                                x-kubernetes-preserve-unknown-fields: true
+                              deployments:
+                                x-kubernetes-preserve-unknown-fields: true
+                              disabled:
+                                type: boolean
+                              horizontalPodAutoscalers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              statefulSets:
+                                x-kubernetes-preserve-unknown-fields: true
+                              webhookConfigurationOptions:
+                                additionalProperties:
+                                  description: WebhookOptions defines options for
+                                    webhooks
+                                  properties:
+                                    failurePolicy:
+                                      description: FailurePolicyType specifies a failure
+                                        policy that defines how unrecognized errors
+                                        from the admission endpoint are handled.
+                                      type: string
+                                    sideEffects:
+                                      description: SideEffectClass specifies the types
+                                        of side effects a webhook may have.
+                                      type: string
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                type: object
+                            type: object
+                          settings:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      scc:
+                        description: SCC allows configuring security context constraints
+                          used by workloads
+                        properties:
+                          default:
+                            description: |-
+                              Default contains the default SCC that will be attached to the service
+                              account used for workloads (`pipeline` SA by default) and defined in
+                              PipelineProperties.OptionalPipelineProperties.DefaultServiceAccount
+                            type: string
+                          maxAllowed:
+                            description: |-
+                              MaxAllowed specifies the highest SCC that can be requested for in a
+                              namespace or in the Default field.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              profile:
+                type: string
+              pruner:
+                description: Pruner holds the prune config
+                properties:
+                  disabled:
+                    description: enable or disable pruner feature
+                    type: boolean
+                  keep:
+                    description: |-
+                      The number of resource to keep
+                      You dont want to delete all the pipelinerun/taskrun's by a cron
+                    type: integer
+                  keep-since:
+                    description: |-
+                      KeepSince keeps the resources younger than the specified value
+                      Its value is taken in minutes
+                    type: integer
+                  prune-per-resource:
+                    description: apply the prune job to the individual resources
+                    type: boolean
+                  resources:
+                    description: The resources which need to be pruned
+                    items:
+                      type: string
+                    type: array
+                  schedule:
+                    description: How frequent pruning should happen
+                    type: string
+                  startingDeadlineSeconds:
+                    description: |-
+                      Optional deadline in seconds for starting the job if it misses scheduled time for any reason.
+                      Missed jobs executions will be counted as failed ones.
+                    type: integer
+                required:
+                - disabled
+                type: object
+              result:
+                description: Result holds the customize option for results component
+                properties:
+                  auth_disable:
+                    type: boolean
+                  auth_impersonate:
+                    type: boolean
+                  db_enable_auto_migration:
+                    type: boolean
+                  db_host:
+                    type: string
+                  db_name:
+                    type: string
+                  db_port:
+                    type: integer
+                  db_secret_name:
+                    type: string
+                  db_secret_password_key:
+                    type: string
+                  db_secret_user_key:
+                    type: string
+                  db_sslmode:
+                    type: string
+                  db_sslrootcert:
+                    type: string
+                  disabled:
+                    description: enable or disable Result Component
+                    type: boolean
+                  gcs_bucket_name:
+                    type: string
+                  gcs_creds_secret_key:
+                    type: string
+                  gcs_creds_secret_name:
+                    type: string
+                  is_external_db:
+                    type: boolean
+                  log_level:
+                    type: string
+                  logging_plugin_api_url:
+                    type: string
+                  logging_plugin_ca_cert:
+                    type: string
+                  logging_plugin_forwarder_delay_duration:
+                    type: integer
+                  logging_plugin_multipart_regex:
+                    type: string
+                  logging_plugin_namespace_key:
+                    type: string
+                  logging_plugin_proxy_path:
+                    type: string
+                  logging_plugin_query_limit:
+                    type: integer
+                  logging_plugin_query_params:
+                    type: string
+                  logging_plugin_static_labels:
+                    type: string
+                  logging_plugin_tls_verification_disable:
+                    type: boolean
+                  logging_plugin_token_path:
+                    type: string
+                  logging_pvc_name:
+                    type: string
+                  logs_api:
+                    type: boolean
+                  logs_buffer_size:
+                    type: integer
+                  logs_path:
+                    type: string
+                  logs_type:
+                    type: string
+                  loki_stack_name:
+                    type: string
+                  loki_stack_namespace:
+                    type: string
+                  options:
+                    description: Options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                  performance:
+                    description: |-
+                      PerformanceProperties defines the fields which are configurable
+                      to tune the performance of component controller
+                    properties:
+                      buckets:
+                        type: integer
+                      disable-ha:
+                        description: if it is true, disables the HA feature
+                        type: boolean
+                      kube-api-burst:
+                        type: integer
+                      kube-api-qps:
+                        description: |-
+                          queries per second (QPS) and burst to the master from rest API client
+                          actually the number multiplied by 2
+                          https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                          defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                        type: number
+                      replicas:
+                        type: integer
+                      statefulset-ordinals:
+                        description: if is true, enable StatefulsetOrdinals mode
+                        type: boolean
+                      threads-per-controller:
+                        description: The number of workers to use when processing
+                          the component controller's work queue
+                        type: integer
+                    required:
+                    - disable-ha
+                    type: object
+                  prometheus_histogram:
+                    type: boolean
+                  prometheus_port:
+                    type: integer
+                  route_enabled:
+                    description: Route configuration for Results API service exposure
+                    type: boolean
+                  route_host:
+                    type: string
+                  route_path:
+                    type: string
+                  route_tls_termination:
+                    type: string
+                  secret_name:
+                    description: |-
+                      name of the secret used to get S3 credentials and
+                      pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                    type: string
+                  server_port:
+                    type: integer
+                  storage_emulator_host:
+                    type: string
+                  tls_hostname_override:
+                    type: string
+                required:
+                - disabled
+                - is_external_db
+                type: object
+              scheduler:
+                description: To enable Pipeline Scheduling on Single Cluster or Multiple
+                  Clusters
+                properties:
+                  config.yaml:
+                    description: |-
+                      This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                      match the key here
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    description: enable or disable TektonScheduler Component
+                    type: boolean
+                  multi-cluster-disabled:
+                    type: boolean
+                  multi-cluster-role:
+                    description: |-
+                      MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                      can be one of Hub or Spoke
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - config.yaml
+                - disabled
+                - multi-cluster-disabled
+                - multi-cluster-role
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              targetNamespaceMetadata:
+                description: holds target namespace metadata
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              tektonpruner:
+                description: New EventBasedPruner which provides more granular control
+                  over TaskRun and PipelineRuns
+                properties:
+                  disabled:
+                    description: enable or disable TektonPruner Component
+                    type: boolean
+                  global-config:
+                    x-kubernetes-preserve-unknown-fields: true
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                - global-config
+                type: object
+              trigger:
+                description: Trigger holds the customizable option for triggers component
+                properties:
+                  default-service-account:
+                    type: string
+                  disabled:
+                    description: enable or disable Trigger Component
+                    type: boolean
+                  enable-api-fields:
+                    type: string
+                  options:
+                    description: options holds additions fields and these fields will
+                      be updated on the manifests
+                    properties:
+                      configMaps:
+                        x-kubernetes-preserve-unknown-fields: true
+                      deployments:
+                        x-kubernetes-preserve-unknown-fields: true
+                      disabled:
+                        type: boolean
+                      horizontalPodAutoscalers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      statefulSets:
+                        x-kubernetes-preserve-unknown-fields: true
+                      webhookConfigurationOptions:
+                        additionalProperties:
+                          description: WebhookOptions defines options for webhooks
+                          properties:
+                            failurePolicy:
+                              description: FailurePolicyType specifies a failure policy
+                                that defines how unrecognized errors from the admission
+                                endpoint are handled.
+                              type: string
+                            sideEffects:
+                              description: SideEffectClass specifies the types of
+                                side effects a webhook may have.
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                          type: object
+                        type: object
+                    type: object
+                required:
+                - disabled
+                type: object
+            type: object
+          status:
+            description: TektonConfigStatus defines the observed state of TektonConfig
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              profile:
+                description: The profile installed
+                type: string
+              tektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The current installer set name
+                type: object
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektoninstallersets.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonInstallerSet
+    listKind: TektonInstallerSetList
+    plural: tektoninstallersets
+    singular: tektoninstallerset
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonInstallerSet is the Schema for the TektonInstallerSet API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonInstallerSetSpec defines the desired state of TektonInstallerSet
+            properties:
+              manifests:
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: TektonInstallerSetStatus defines the observed state of TektonInstallerSet
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonpipelines.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonPipeline
+    listKind: TektonPipelineList
+    plural: tektonpipelines
+    singular: tektonpipeline
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPipeline is the Schema for the tektonpipelines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonPipelineSpec defines the desired state of TektonPipeline
+            properties:
+              await-sidecar-readiness:
+                type: boolean
+              bundles-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              cluster-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPipeline
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              coschedule:
+                type: string
+              default-affinity-assistant-pod-template:
+                type: string
+              default-cloud-events-sink:
+                type: string
+              default-forbidden-env:
+                type: string
+              default-managed-by-label-value:
+                type: string
+              default-max-matrix-combinations-count:
+                type: string
+              default-pod-template:
+                type: string
+              default-resolver-type:
+                type: string
+              default-service-account:
+                type: string
+              default-task-run-workspace-binding:
+                type: string
+              default-timeout-minutes:
+                type: integer
+              disable-affinity-assistant:
+                description: |-
+                  Deprecated: DisableAffinityAssistant is deprecated and no longer used.
+                  This field is removed from pipeline component.
+                  Keeping here to maintain API compatibility during upgrades.
+                type: boolean
+              disable-creds-init:
+                type: boolean
+              disable-inline-spec:
+                type: string
+              embedded-status:
+                type: string
+              enable-api-fields:
+                type: string
+              enable-bundles-resolver:
+                type: boolean
+              enable-cel-in-whenexpression:
+                type: boolean
+              enable-cluster-resolver:
+                type: boolean
+              enable-custom-tasks:
+                type: boolean
+              enable-git-resolver:
+                type: boolean
+              enable-hub-resolver:
+                type: boolean
+              enable-param-enum:
+                type: boolean
+              enable-provenance-in-status:
+                type: boolean
+              enable-step-actions:
+                type: boolean
+              enable-tekton-oci-bundles:
+                description: |-
+                  not in use, see: https://github.com/tektoncd/pipeline/pull/7789
+                  this field is removed from pipeline component
+                  keeping here to maintain the API compatibility
+                type: boolean
+              enforce-nonfalsifiability:
+                type: string
+              git-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              hub-resolver-config:
+                additionalProperties:
+                  type: string
+                type: object
+              keep-pod-on-cancel:
+                type: boolean
+              max-result-size:
+                type: integer
+              metrics.count.enable-reason:
+                type: boolean
+              metrics.pipelinerun.duration-type:
+                type: string
+              metrics.pipelinerun.level:
+                type: string
+              metrics.taskrun.duration-type:
+                type: string
+              metrics.taskrun.level:
+                type: string
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the proxy-webhook
+                  workload deployed by TektonPipeline.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              params:
+                description: The params to customize different components of Pipelines
+                items:
+                  description: Param declares an string value to use for the parameter
+                    called name.
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              require-git-ssh-secret-known-hosts:
+                type: boolean
+              results-from:
+                type: string
+              running-in-environment-with-injected-sidecars:
+                type: boolean
+              scope-when-expressions-to-task:
+                description: ScopeWhenExpressionsToTask is deprecated and never used.
+                type: boolean
+              send-cloudevents-for-runs:
+                description: |-
+                  Deprecated: send-cloudevents-for-runs is deprecated in tektoncd/pipeline v1.12.0
+                  (https://github.com/tektoncd/pipeline/pull/9774) and will be removed in a future release.
+                  CloudEvents for CustomRuns are now enabled by default when a sink is configured in
+                  the config-events ConfigMap. This field only affects CustomRun objects; it has no
+                  effect on TaskRuns or PipelineRuns. Set to false only to suppress duplicate events
+                  when a custom task controller already sends its own CloudEvents.
+                type: boolean
+              set-security-context:
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              traces.credentialsSecret:
+                description: CredentialsSecret is the name of the secret containing
+                  credentials for the tracing endpoint
+                type: string
+              traces.enabled:
+                description: Enabled controls whether tracing is enabled or not
+                type: boolean
+              traces.endpoint:
+                description: Endpoint is the URL for the OpenTelemetry trace collector
+                type: string
+              trusted-resources-verification-no-match-policy:
+                type: string
+              verification-mode:
+                type: string
+            type: object
+          status:
+            description: TektonPipelineStatus defines the observed state of TektonPipeline
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              extTektonInstallerSets:
+                additionalProperties:
+                  type: string
+                description: The installer sets created for extension components
+                type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPipeline
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonresults.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonResult
+    listKind: TektonResultList
+    plural: tektonresults
+    singular: tektonresult
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonResult is the Schema for the tektonresults API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonResultSpec defines the desired state of TektonResult
+            properties:
+              auth_disable:
+                type: boolean
+              auth_impersonate:
+                type: boolean
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonResult
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              db_enable_auto_migration:
+                type: boolean
+              db_host:
+                type: string
+              db_name:
+                type: string
+              db_port:
+                type: integer
+              db_secret_name:
+                type: string
+              db_secret_password_key:
+                type: string
+              db_secret_user_key:
+                type: string
+              db_sslmode:
+                type: string
+              db_sslrootcert:
+                type: string
+              disabled:
+                description: enable or disable Result Component
+                type: boolean
+              gcs_bucket_name:
+                type: string
+              gcs_creds_secret_key:
+                type: string
+              gcs_creds_secret_name:
+                type: string
+              is_external_db:
+                type: boolean
+              log_level:
+                type: string
+              logging_plugin_api_url:
+                type: string
+              logging_plugin_ca_cert:
+                type: string
+              logging_plugin_forwarder_delay_duration:
+                type: integer
+              logging_plugin_multipart_regex:
+                type: string
+              logging_plugin_namespace_key:
+                type: string
+              logging_plugin_proxy_path:
+                type: string
+              logging_plugin_query_limit:
+                type: integer
+              logging_plugin_query_params:
+                type: string
+              logging_plugin_static_labels:
+                type: string
+              logging_plugin_tls_verification_disable:
+                type: boolean
+              logging_plugin_token_path:
+                type: string
+              logging_pvc_name:
+                type: string
+              logs_api:
+                type: boolean
+              logs_buffer_size:
+                type: integer
+              logs_path:
+                type: string
+              logs_type:
+                type: string
+              loki_stack_name:
+                type: string
+              loki_stack_namespace:
+                type: string
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              performance:
+                description: |-
+                  PerformanceProperties defines the fields which are configurable
+                  to tune the performance of component controller
+                properties:
+                  buckets:
+                    type: integer
+                  disable-ha:
+                    description: if it is true, disables the HA feature
+                    type: boolean
+                  kube-api-burst:
+                    type: integer
+                  kube-api-qps:
+                    description: |-
+                      queries per second (QPS) and burst to the master from rest API client
+                      actually the number multiplied by 2
+                      https://github.com/pierretasci/pipeline/blob/05d67e427c722a2a57e58328d7097e21429b7524/cmd/controller/main.go#L85-L87
+                      defaults: https://github.com/tektoncd/pipeline/blob/34618964300620dca44d10a595e4af84e9903a55/vendor/k8s.io/client-go/rest/config.go#L45-L46
+                    type: number
+                  replicas:
+                    type: integer
+                  statefulset-ordinals:
+                    description: if is true, enable StatefulsetOrdinals mode
+                    type: boolean
+                  threads-per-controller:
+                    description: The number of workers to use when processing the
+                      component controller's work queue
+                    type: integer
+                required:
+                - disable-ha
+                type: object
+              prometheus_histogram:
+                type: boolean
+              prometheus_port:
+                type: integer
+              route_enabled:
+                description: Route configuration for Results API service exposure
+                type: boolean
+              route_host:
+                type: string
+              route_path:
+                type: string
+              route_tls_termination:
+                type: string
+              secret_name:
+                description: |-
+                  name of the secret used to get S3 credentials and
+                  pass it as environment variables to the "tekton-results-api" deployment under "api" container
+                type: string
+              server_port:
+                type: integer
+              storage_emulator_host:
+                type: string
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+              tls_hostname_override:
+                type: string
+            required:
+            - disabled
+            - is_external_db
+            type: object
+          status:
+            description: TektonResultStatus defines the observed state of TektonResult
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonResult
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektontriggers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonTrigger
+    listKind: TektonTriggerList
+    plural: tektontriggers
+    singular: tektontrigger
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonTrigger is the Schema for the tektontriggers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TektonTriggerSpec defines the desired state of TektonTrigger
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonTrigger
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              default-service-account:
+                type: string
+              disabled:
+                description: enable or disable Trigger Component
+                type: boolean
+              enable-api-fields:
+                type: string
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonTrigger
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            type: object
+          status:
+            description: TektonTriggerStatus defines the observed state of TektonTrigger
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonpruners.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonPruner
+    listKind: TektonPrunerList
+    plural: tektonpruners
+    singular: tektonpruner
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonPruner is the Schema for the TektonPruner API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by TektonPruner
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              disabled:
+                description: enable or disable TektonPruner Component
+                type: boolean
+              global-config:
+                x-kubernetes-preserve-unknown-fields: true
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - disabled
+            - global-config
+            type: object
+          status:
+            description: TektonPrunerStatus defines the observed state of TektonPruner
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonPruner
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonschedulers.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonScheduler
+    listKind: TektonSchedulerList
+    plural: tektonschedulers
+    singular: tektonscheduler
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonScheduler is the Schema for the TektonScheduler API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config.yaml:
+                description: |-
+                  This hold the config data from tekton-kueue. ConfigMap in tekton kueue is loaded as config.yaml so we need to
+                  match the key here
+                x-kubernetes-preserve-unknown-fields: true
+              disabled:
+                description: enable or disable TektonScheduler Component
+                type: boolean
+              multi-cluster-disabled:
+                type: boolean
+              multi-cluster-role:
+                description: |-
+                  MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
+                  can be one of Hub or Spoke
+                type: string
+              options:
+                description: options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            required:
+            - config.yaml
+            - disabled
+            - multi-cluster-disabled
+            - multi-cluster-role
+            type: object
+          status:
+            description: TektonSchedulerStatus defines the observed state of TektonScheduler
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tekton-scheduler:
+                description: The current installer set name for TektonScheduler
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tektonmulticlusterproxyaaes.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: TektonMulticlusterProxyAAE
+    listKind: TektonMulticlusterProxyAAEList
+    plural: tektonmulticlusterproxyaaes
+    singular: tektonmulticlusterproxyaae
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TektonMulticlusterProxyAAE is the Schema for the TektonMulticlusterProxyAAE
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              options:
+                description: options holds additional fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: TektonMulticlusterProxyAAEStatus defines the observed state
+              of TektonMulticlusterProxyAAE
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              tektonInstallerSet:
+                description: The current installer set name for TektonMulticlusterProxyAAE
+                type: string
+              version:
+                description: The version of the installed release
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: syncerservices.operator.tekton.dev
+  labels:
+    version: "devel"
+    operator.tekton.dev/release: "devel"
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: SyncerService
+    listKind: SyncerServiceList
+    plural: syncerservices
+    singular: syncerservice
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Reason
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SyncerService is the Schema for the syncerservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncerServiceSpec defines the desired state of SyncerService
+            properties:
+              config:
+                description: Config holds the configuration for resources created
+                  by SyncerService
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName holds the priority class to be
+                      set to pod template
+                    type: string
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              options:
+                description: Options holds additions fields and these fields will
+                  be updated on the manifests
+                properties:
+                  configMaps:
+                    x-kubernetes-preserve-unknown-fields: true
+                  deployments:
+                    x-kubernetes-preserve-unknown-fields: true
+                  disabled:
+                    type: boolean
+                  horizontalPodAutoscalers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSets:
+                    x-kubernetes-preserve-unknown-fields: true
+                  webhookConfigurationOptions:
+                    additionalProperties:
+                      description: WebhookOptions defines options for webhooks
+                      properties:
+                        failurePolicy:
+                          description: FailurePolicyType specifies a failure policy
+                            that defines how unrecognized errors from the admission
+                            endpoint are handled.
+                          type: string
+                        sideEffects:
+                          description: SideEffectClass specifies the types of side
+                            effects a webhook may have.
+                          type: string
+                        timeoutSeconds:
+                          type: integer
+                      type: object
+                    type: object
+                type: object
+              targetNamespace:
+                description: TargetNamespace is where resources will be installed
+                type: string
+            type: object
+          status:
+            description: SyncerServiceStatus defines the observed state of SyncerService
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Annotations is additional Status fields for the Resource to save some
+                  additional State as well as convey more information to the user. This is
+                  roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                  richer information outwards.
+                type: object
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                  current state.
+                items:
+                  description: |-
+                    Condition defines a readiness condition for a Knative resource.
+                    See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the condition transitioned from one status to another.
+                        We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the 'Generation' of the Service that
+                  was last processed by the controller.
+                type: integer
+              syncerServiceInstallerSet:
+                description: The current installer set name for SyncerService
+                type: string
               version:
                 description: The version of the installed release
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_openshiftpipelinesascodes.yaml
@@ -127,6 +127,24 @@ spec:
                       type: object
                     type: array
                 type: object
+              networkPolicy:
+                description: |-
+                  NetworkPolicy configures NetworkPolicy creation for the controller,
+                  watcher and webhook workloads deployed by OpenShiftPipelinesAsCode.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -7,8 +7,9 @@ weight: 15
 # NetworkPolicy
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
-Currently TektonPipeline (core controllers, resolvers, and proxy-webhook) and
-TektonTrigger are supported; other components will be added later.
+Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
+TektonTrigger, and Pipelines-as-Code are supported; other components
+will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -84,6 +85,25 @@ to the operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`):
 | | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
 | | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 | | egress | TCP/80, 443 | Any (external APIs e.g. GitHub) |
+
+### OpenShift Pipelines-as-Code
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `pac-default-deny` | deny all | — | All pods with `app.kubernetes.io/part-of: pipelines-as-code` |
+| `pac-controller` | ingress | TCP/9090 | Prometheus namespace |
+| | ingress | TCP/8082 | Any (Git provider webhooks via Route/Ingress) |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | TCP/80, 443 | Any (Git provider APIs: GitHub, GitLab, Bitbucket, Gitea) |
+| `pac-watcher` | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| | egress | TCP/80, 443 | Any (reporting status to Git providers) |
+| `pac-webhook` | ingress | TCP/8443 | Any (admission webhook) |
+| | ingress | TCP/9090 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
 
 ### Console Plugin (OpenShift only)
 

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_types.go
@@ -55,6 +55,10 @@ type OpenShiftPipelinesAsCodeSpec struct {
 	CommonSpec  `json:",inline"`
 	Config      Config `json:"config,omitempty"`
 	PACSettings `json:",inline"`
+	// NetworkPolicy configures NetworkPolicy creation for the controller,
+	// watcher and webhook workloads deployed by OpenShiftPipelinesAsCode.
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 // OpenShiftPipelinesAsCodeStatus defines the observed state of OpenShiftPipelinesAsCode

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
@@ -46,6 +46,7 @@ func (pac *OpenShiftPipelinesAsCode) Validate(ctx context.Context) *apis.FieldEr
 	errs = errs.Also(pac.Spec.CommonSpec.validate("spec"))
 
 	errs = errs.Also(pac.Spec.PACSettings.validate(logger, "spec"))
+	errs = errs.Also(pac.Spec.NetworkPolicy.validate("spec.networkPolicy"))
 
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,6 +133,37 @@ func TestValidateAddtionalPACControllerInvalidNameLength(t *testing.T) {
 	}
 	err := opacCR.Validate(context.TODO())
 	assert.Equal(t, fmt.Sprintf("invalid value: invalid resource name %q: length must be no more than 25 characters: name: spec.additionalPACControllers", "testlengthwhichexceedsthemaximumlength"), err.Error())
+}
+
+func TestValidateNetworkPolicyValidConfig(t *testing.T) {
+	cfg := NetworkPolicyConfig{
+		Policies: map[string]networkingv1.NetworkPolicySpec{
+			"pac-controller": {},
+			"custom-policy":  {},
+		},
+	}
+	if err := cfg.validate("spec.networkPolicy"); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidateNetworkPolicyInvalidPolicyName(t *testing.T) {
+	cfg := NetworkPolicyConfig{
+		Policies: map[string]networkingv1.NetworkPolicySpec{
+			"Invalid_Name": {},
+		},
+	}
+	err := cfg.validate("spec.networkPolicy")
+	assert.ErrorContains(t, err, "invalid key name \"Invalid_Name\"")
+}
+
+func TestValidateNetworkPolicyDisabled(t *testing.T) {
+	cfg := NetworkPolicyConfig{
+		Disabled: true,
+	}
+	if err := cfg.validate("spec.networkPolicy"); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
 }
 
 func TestValidateAddtionalPACControllerInvalidSetting(t *testing.T) {

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -675,6 +675,7 @@ func (in *OpenShiftPipelinesAsCodeSpec) DeepCopyInto(out *OpenShiftPipelinesAsCo
 	out.CommonSpec = in.CommonSpec
 	in.Config.DeepCopyInto(&out.Config)
 	in.PACSettings.DeepCopyInto(&out.PACSettings)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/controller.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/controller.go
@@ -26,6 +26,7 @@ import (
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	pacreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/openshiftpipelinesascode"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -65,6 +66,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Errorf("Failed to create trigger metrics recorder %v", err)
 		}
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		c := &Reconciler{
 			pipelineInformer:      tektonPipelineinformer.Get(ctx),
 			installerSetClient:    client.NewInstallerSetClient(tisClient, operatorVer, pacVersion, v1alpha1.KindOpenShiftPipelinesAsCode, metrics),
@@ -72,6 +78,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			manifest:              manifest,
 			additionalPACManifest: filterAdditionalControllerManifest(manifest),
 			pacVersion:            pacVersion,
+			platformParams:        params,
 		}
 		impl := pacreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/networkpolicies.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/networkpolicies.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openshiftpipelinesascode
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func pacDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(9090)
+	controllerAPIPort := intstr.FromInt32(8082)
+	webhookPort := intstr.FromInt32(8443)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pac-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "pipelines-as-code-controller"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+					// Git provider webhooks arrive via Route/Ingress — allow from any source.
+					networkpolicy.WebhookIngressRule("", controllerAPIPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+					networkpolicy.InternetEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pac-watcher"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "pipelines-as-code-watcher"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+					networkpolicy.InternetEgressRule(),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pac-webhook"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/component": "webhook",
+						"app.kubernetes.io/part-of":   "pipelines-as-code",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.WebhookIngressRule("", webhookPort),
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func pacDefaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy(
+		"pac-default-deny",
+		metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/part-of": "pipelines-as-code",
+			},
+		},
+	)
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, pac *v1alpha1.OpenShiftPipelinesAsCode) error {
+	if pac.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, "pac-network-policies")
+	}
+	defaults := append(
+		[]networkingv1.NetworkPolicy{pacDefaultDenyPolicy()},
+		pacDefaultPolicies(r.platformParams)...,
+	)
+	manifest, err := networkpolicy.Generate(
+		pac.Spec.NetworkPolicy,
+		pac.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, pac, "pac-network-policies", &manifest, passthroughTransform, nil)
+}
+
+// passthroughTransform is a no-op FilterAndTransform used for pre-built manifests
+// where namespace injection is already handled by Generate.
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/openshift/openshiftpipelinesascode/reconcile.go
+++ b/pkg/reconciler/openshift/openshiftpipelinesascode/reconcile.go
@@ -26,6 +26,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	pacreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/openshiftpipelinesascode"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -53,6 +54,8 @@ type Reconciler struct {
 	pacVersion string
 	// additionalPACManifest has the source manifest for the additional Openshift Pipelines As Code Controller
 	additionalPACManifest mf.Manifest
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -101,6 +104,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pac *v1alpha1.OpenShiftP
 		if err == v1alpha1.REQUEUE_EVENT_AFTER {
 			return err
 		}
+		pac.Status.MarkInstallerSetNotReady(msg)
+		return nil
+	}
+
+	if err := r.reconcileNetworkPolicies(ctx, pac); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
 		pac.Status.MarkInstallerSetNotReady(msg)
 		return nil
 	}

--- a/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode.go
+++ b/pkg/reconciler/shared/tektonconfig/pipelinesascode/pipelinesascode.go
@@ -91,8 +91,9 @@ func createOPAC(ctx context.Context, clients op.OpenShiftPipelinesAsCodeInterfac
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Config:      config.Spec.Config,
-			PACSettings: pacSettings,
+			Config:        config.Spec.Config,
+			PACSettings:   pacSettings,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 
@@ -140,6 +141,11 @@ func updateOPAC(ctx context.Context, opacCR *v1alpha1.OpenShiftPipelinesAsCode, 
 			opacCR.Spec.PACSettings.AdditionalPACControllers = p.PACSettings.AdditionalPACControllers
 			updated = true
 		}
+	}
+
+	if !reflect.DeepEqual(opacCR.Spec.NetworkPolicy, config.Spec.NetworkPolicy) {
+		opacCR.Spec.NetworkPolicy = config.Spec.NetworkPolicy
+		updated = true
 	}
 
 	if opacCR.ObjectMeta.OwnerReferences == nil {

--- a/test/e2e/common/11_openshiftpipelinesascode_networkpolicy_test.go
+++ b/test/e2e/common/11_openshiftpipelinesascode_networkpolicy_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestOpenShiftPipelinesAsCodeNetworkPolicy verifies NetworkPolicies are
+// created by default when OpenShiftPipelinesAsCode is installed, and that
+// toggling spec.networkPolicy.disabled correctly adds and removes the policies.
+func TestOpenShiftPipelinesAsCodeNetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownPipeline(clients, crNames.TektonPipeline) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownNamespace(clients, crNames.TargetNamespace) })
+	defer utils.TearDownNamespace(clients, crNames.TargetNamespace)
+	defer utils.TearDownPipeline(clients, crNames.TektonPipeline)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := resources.EnsureTektonPipelineExists(clients.TektonPipeline(), crNames); err != nil {
+		t.Fatalf("TektonPipeline %q failed to create: %v", crNames.TektonPipeline, err)
+	}
+	resources.AssertTektonPipelineCRReadyStatus(t, clients, crNames)
+
+	if _, err := resources.EnsureOpenShiftPipelinesAsCodeExists(clients.OpenShiftPipelinesAsCode(), crNames); err != nil {
+		t.Fatalf("OpenShiftPipelinesAsCode %q failed to create: %v", crNames.OpenShiftPipelinesAsCode, err)
+	}
+	resources.AssertOpenShiftPipelinesAsCodeCRReadyStatus(t, clients, crNames)
+	defer resources.OpenShiftPipelinesAsCodeCRDelete(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"pac-default-deny",
+		"pac-controller",
+		"pac-watcher",
+		"pac-webhook",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		pac, err := clients.OpenShiftPipelinesAsCode().Get(context.TODO(), crNames.OpenShiftPipelinesAsCode, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get OpenShiftPipelinesAsCode: %v", err)
+		}
+		pac.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.OpenShiftPipelinesAsCode().Update(context.TODO(), pac, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on OpenShiftPipelinesAsCode: %v", err)
+		}
+		resources.AssertOpenShiftPipelinesAsCodeCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		pac, err := clients.OpenShiftPipelinesAsCode().Get(context.TODO(), crNames.OpenShiftPipelinesAsCode, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get OpenShiftPipelinesAsCode: %v", err)
+		}
+		pac.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.OpenShiftPipelinesAsCode().Update(context.TODO(), pac, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on OpenShiftPipelinesAsCode: %v", err)
+		}
+		resources.AssertOpenShiftPipelinesAsCodeCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}


### PR DESCRIPTION
Add default-deny and per-pod NetworkPolicies for the three OpenShiftPipelinesAsCode workloads (controller, watcher, webhook), following the pattern established by TektonPipeline and TektonTrigger.

Default policies:
- pac-default-deny: deny all traffic to pods with app.kubernetes.io/part-of=pipelines-as-code
- pac-controller: allow Prometheus metrics ingress (TCP/9090), Git provider webhook ingress (TCP/8082), DNS egress, API server egress, and internet egress (TCP/80,443)
- pac-watcher: allow Prometheus metrics ingress (TCP/9090), DNS egress, API server egress, and internet egress (TCP/80,443)
- pac-webhook: allow admission webhook ingress (TCP/8443), Prometheus metrics ingress (TCP/9090), DNS egress, and API server egress

Policies are reconciled via InstallerSet.CustomSet and respect the spec.networkPolicy.disabled toggle. The NetworkPolicy field is propagated from TektonConfig to the OpenShiftPipelinesAsCode CR.

Includes unit tests for NetworkPolicyConfig validation, an E2E test for policy creation/disable/re-enable, and updated NetworkPolicy documentation.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
