### PR TITLE
add NetworkPolicy for MultiCluster Components

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -2913,9 +2913,10 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-                  and TektonPruner, which are the components with NetworkPolicy reconciliation
-                  implemented. Other components (Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonPipeline, TektonTrigger, TektonChain,
+                  TektonPruner, TektonResult, Pipelines-as-Code, and MultiCluster components
+                  (TektonScheduler, TektonMulticlusterProxyAAE, SyncerService).
+                  Other components (Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-
@@ -5816,6 +5817,493 @@ spec:
                 type: string
               loki_stack_namespace:
                 type: string
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonResult
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: Options holds additions fields and these fields will
                   be updated on the manifests
@@ -7649,6 +8137,493 @@ spec:
                   MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
                   can be one of Hub or Spoke
                 type: string
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -7810,6 +8785,493 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additional fields and these fields will
                   be updated on the manifests
@@ -8017,6 +9479,493 @@ spec:
                           type: string
                       type: object
                     type: array
+                type: object
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
                 description: Options holds additions fields and these fields will

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -3107,9 +3107,10 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-                  and TektonPruner, which are the components with NetworkPolicy reconciliation
-                  implemented. Other components (Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonPipeline, TektonTrigger, TektonChain,
+                  TektonPruner, TektonResult, Pipelines-as-Code, and MultiCluster components
+                  (TektonScheduler, TektonMulticlusterProxyAAE, SyncerService).
+                  Other components (Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-
@@ -5795,6 +5796,493 @@ spec:
                 type: string
               loki_stack_namespace:
                 type: string
+              networkPolicy:
+                description: NetworkPolicy configures NetworkPolicy creation for TektonResult
+                  workloads.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: Options holds additions fields and these fields will
                   be updated on the manifests
@@ -7628,6 +8116,493 @@ spec:
                   MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
                   can be one of Hub or Spoke
                 type: string
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests
@@ -7789,6 +8764,493 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additional fields and these fields will
                   be updated on the manifests
@@ -7996,6 +9458,493 @@ spec:
                           type: string
                       type: object
                     type: array
+                type: object
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
                 description: Options holds additions fields and these fields will

--- a/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_syncerservices.yaml
@@ -101,6 +101,495 @@ spec:
                       type: object
                     type: array
                 type: object
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: Options holds additions fields and these fields will
                   be updated on the manifests

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -575,8 +575,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-                  TektonPruner, and TektonResult, which implement NetworkPolicy reconciliation.
+                  This field is propagated to TektonPipeline, TektonTrigger, TektonChain,
+                  TektonPruner, TektonResult, Pipelines-as-Code, and MultiCluster components
+                  (TektonScheduler, TektonMulticlusterProxyAAE, SyncerService).
                   Other components (Dashboard) do not yet act on this field.
                 properties:
                   disabled:

--- a/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml
@@ -49,6 +49,495 @@ spec:
             type: object
           spec:
             properties:
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additional fields and these fields will
                   be updated on the manifests

--- a/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonresults.yaml
@@ -184,11 +184,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonschedulers.yaml
@@ -76,6 +76,495 @@ spec:
                   MultiClusterRole Define the role of current cluster in multi-cluster environment. The MultiClusterRole
                   can be one of Hub or Spoke
                 type: string
+              networkPolicy:
+                description: NetworkPolicyConfig configures NetworkPolicy creation
+                  for a Tekton component.
+                properties:
+                  disabled:
+                    description: |-
+                      Disabled disables all NetworkPolicy creation for this component.
+                      Existing policies are removed on the next reconcile.
+                    type: boolean
+                  policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    description: |-
+                      Policies merges with the operator's default NetworkPolicies by name.
+                      A key matching a default policy name replaces that default entirely.
+                      A key not matching any default is added alongside the defaults.
+                      If nil or empty, all operator defaults are applied unchanged.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               options:
                 description: options holds additions fields and these fields will
                   be updated on the manifests

--- a/docs/NetworkPolicy.md
+++ b/docs/NetworkPolicy.md
@@ -7,9 +7,10 @@ weight: 15
 # NetworkPolicy
 
 The operator can manage [NetworkPolicy][np] resources for Tekton component workloads.
-Currently TektonPipeline (core controllers, resolvers, and proxy-webhook),
-TektonTrigger, TektonChain, Pipelines-as-Code, ManualApprovalGate, TektonPruner,
-and TektonResult are supported; other components will be added later.
+TektonPipeline (core controllers, resolvers, and proxy-webhook), TektonTrigger,
+TektonChain, Pipelines-as-Code, ManualApprovalGate, TektonPruner, TektonResult,
+and MultiCluster components (TektonScheduler, TektonMulticlusterProxyAAE,
+SyncerService) are supported; other components will be added later.
 
 Configuration is available via `TektonConfig`:
 
@@ -32,12 +33,12 @@ spec:
               - port: 9000
 ```
 
-The `networkPolicy` field is propagated from `TektonConfig` to `TektonTrigger`,
-`TektonPipeline`, `TektonChain`, `TektonPruner`, and `TektonResult`. When those
-component CRs are managed by `TektonConfig` (the usual install path),
-**TektonConfig is the source of truth**: edits to `spec.networkPolicy` on the
-component CRs alone are overwritten on the next Config reconcile. Configure
-NetworkPolicy via `TektonConfig.spec.networkPolicy`.
+The `networkPolicy` field is propagated from `TektonConfig` to `TektonPipeline`,
+`TektonTrigger`, `TektonChain`, `TektonPruner`, `TektonResult`, Pipelines-as-Code,
+and MultiCluster components. When those component CRs are managed by `TektonConfig`
+(the usual install path), **TektonConfig is the source of truth**: edits to
+`spec.networkPolicy` on the component CRs alone are overwritten on the next Config
+reconcile. Configure NetworkPolicy via `TektonConfig.spec.networkPolicy`.
 
 ## Default Policies
 
@@ -256,8 +257,49 @@ user's browser via the OpenShift Console's proxy, not on this pod.
 These are static manifests shipped with the TektonConfig console plugin resources,
 not reconciled via `spec.networkPolicy`.
 
-All policies above are applied to the operand namespace (e.g. `tekton-pipelines`
-or `openshift-pipelines`). They do not cover the operator's own namespace
+### TektonScheduler
+
+Policies are applied to the operand namespace (`tekton-pipelines` or `openshift-pipelines`).
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `scheduler-controller-default-deny` | deny all | — | Scheduler controller pods |
+| `scheduler-webhook-default-deny` | deny all | — | Scheduler webhook pods |
+| `scheduler-controller` | ingress | TCP/8443 | Prometheus namespace |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+| `scheduler-webhook` | ingress | TCP/9443 | Any (admission webhook) |
+| | ingress | TCP/8443 | Prometheus namespace |
+| | egress | UDP+TCP/53 or 5353 | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+### TektonMulticlusterProxyAAE
+
+Policies are applied to the operand namespace (`tekton-pipelines` or `openshift-pipelines`).
+Deployed only when the scheduler is enabled with multi-cluster role = Hub.
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `proxy-aae-default-deny` | deny all | — | Proxy-AAE pods (`app: proxy-aae`) |
+| `proxy-aae` | ingress | TCP/8080 | Any (spoke clusters connect via service 443→8080) |
+| | egress | UDP+TCP/53 (K8s) or 5353 (OpenShift) | DNS resolver pods |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+### SyncerService (OpenShift only)
+
+Policies are applied to the operand namespace (`openshift-pipelines`).
+Deployed only when the scheduler is enabled with multi-cluster role = Hub.
+
+| Policy | Direction | Port | Source / Destination |
+|---|---|---|---|
+| `syncer-service-default-deny` | deny all | — | SyncerService pods (`app: workload-controller`) |
+| `syncer-service-controller` | egress | UDP+TCP/5353 | DNS resolver pods (OpenShift) |
+| | egress | all | API server (all egress allowed — NP cannot select host-network endpoints) |
+
+All component policies (TektonPipeline, TektonTrigger, TektonScheduler,
+TektonMulticlusterProxyAAE, SyncerService, and Console Plugin) are applied to the
+operand namespace (e.g. `tekton-pipelines` or `openshift-pipelines`).
+None of these cover the operator's own namespace
 (`tekton-operator` / `openshift-operators`), which ships fixed, non-configurable
 NetworkPolicies as part of the operator's own install manifests/bundle (see
 [Operator's own namespace](#operators-own-namespace) below).

--- a/pkg/apis/operator/v1alpha1/syncerservice_types.go
+++ b/pkg/apis/operator/v1alpha1/syncerservice_types.go
@@ -62,6 +62,8 @@ type SyncerServiceSpec struct {
 	// Config holds the configuration for resources created by SyncerService
 	// +optional
 	Config Config `json:"config,omitempty"`
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 // SyncerServiceOptions defines the fields to customize SyncerService component
@@ -89,7 +91,8 @@ func (sss *SyncerServiceStatus) MarkPreReconcilerFailed(msg string) {
 	syncerServiceCondSet.Manage(sss).MarkFalse(
 		PreReconciler,
 		"Error",
-		msg)
+		msg,
+	)
 }
 
 func (sss *SyncerServiceStatus) MarkPostReconcilerFailed(msg string) {
@@ -97,7 +100,8 @@ func (sss *SyncerServiceStatus) MarkPostReconcilerFailed(msg string) {
 	syncerServiceCondSet.Manage(sss).MarkFalse(
 		PostReconciler,
 		"Error",
-		msg)
+		msg,
+	)
 }
 
 // SyncerServiceList contains a list of SyncerService

--- a/pkg/apis/operator/v1alpha1/syncerservice_validation.go
+++ b/pkg/apis/operator/v1alpha1/syncerservice_validation.go
@@ -33,5 +33,6 @@ func (ss *SyncerService) Validate(ctx context.Context) (errs *apis.FieldError) {
 		return errs.Also(apis.ErrInvalidValue(ss.GetName(), errMsg))
 	}
 
+	errs = errs.Also(ss.Spec.NetworkPolicy.validate("spec.networkPolicy"))
 	return errs
 }

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -135,8 +135,9 @@ type TektonConfigSpec struct {
 	// +optional
 	TargetNamespaceMetadata *NamespaceMetadata `json:"targetNamespaceMetadata,omitempty"`
 	// NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-	// This field is propagated to TektonTrigger, TektonPipeline, TektonChain,
-	// TektonPruner, and TektonResult, which implement NetworkPolicy reconciliation.
+	// This field is propagated to TektonPipeline, TektonTrigger, TektonChain,
+	// TektonPruner, TektonResult, Pipelines-as-Code, and MultiCluster components
+	// (TektonScheduler, TektonMulticlusterProxyAAE, SyncerService).
 	// Other components (Dashboard) do not yet act on this field.
 	// +optional
 	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_types.go
@@ -48,6 +48,8 @@ type TektonMulticlusterProxyAAE struct {
 type TektonMulticlusterProxyAAESpec struct {
 	CommonSpec                  `json:",inline"`
 	MulticlusterProxyAAEOptions `json:",inline"`
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 type MulticlusterProxyAAEOptions struct {

--- a/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonmulticlusterproxyaae_validation.go
@@ -18,11 +18,22 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"knative.dev/pkg/apis"
 )
 
-// Validate implements the validation contract for the webhook. Reserved for future use.
+// Validate implements the validation contract for the webhook.
 func (t *TektonMulticlusterProxyAAE) Validate(ctx context.Context) (errs *apis.FieldError) {
-	return nil
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
+	if t.GetName() != MultiClusterProxyAAEResourceName {
+		errMsg := fmt.Sprintf("metadata.name, Only one instance of TektonMulticlusterProxyAAE is allowed by name, %s", MultiClusterProxyAAEResourceName)
+		errs = errs.Also(apis.ErrInvalidValue(t.GetName(), errMsg))
+	}
+
+	errs = errs.Also(t.Spec.NetworkPolicy.validate("spec.networkPolicy"))
+	return errs
 }

--- a/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_types.go
@@ -85,6 +85,8 @@ type TektonSchedulerList struct {
 type TektonSchedulerSpec struct {
 	CommonSpec `json:",inline"`
 	Scheduler  `json:",inline"`
+	// +optional
+	NetworkPolicy NetworkPolicyConfig `json:"networkPolicy,omitempty"`
 }
 
 // TektonSchedulerStatus defines the observed state of TektonScheduler

--- a/pkg/apis/operator/v1alpha1/tektonscheduler_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonscheduler_validation.go
@@ -25,7 +25,6 @@ import (
 )
 
 func (ts *TektonScheduler) Validate(ctx context.Context) (errs *apis.FieldError) {
-
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
@@ -37,6 +36,7 @@ func (ts *TektonScheduler) Validate(ctx context.Context) (errs *apis.FieldError)
 
 	// execute common spec validations
 	errs = errs.Also(ts.Spec.MultiClusterConfig.validate())
+	errs = errs.Also(ts.Spec.NetworkPolicy.validate("spec.networkPolicy"))
 	return errs
 }
 

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -1533,6 +1533,7 @@ func (in *SyncerServiceSpec) DeepCopyInto(out *SyncerServiceSpec) {
 	out.CommonSpec = in.CommonSpec
 	in.SyncerServiceOptions.DeepCopyInto(&out.SyncerServiceOptions)
 	in.Config.DeepCopyInto(&out.Config)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 
@@ -2155,6 +2156,7 @@ func (in *TektonMulticlusterProxyAAESpec) DeepCopyInto(out *TektonMulticlusterPr
 	*out = *in
 	out.CommonSpec = in.CommonSpec
 	in.MulticlusterProxyAAEOptions.DeepCopyInto(&out.MulticlusterProxyAAEOptions)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 
@@ -2562,6 +2564,7 @@ func (in *TektonSchedulerSpec) DeepCopyInto(out *TektonSchedulerSpec) {
 	*out = *in
 	out.CommonSpec = in.CommonSpec
 	in.Scheduler.DeepCopyInto(&out.Scheduler)
+	in.NetworkPolicy.DeepCopyInto(&out.NetworkPolicy)
 	return
 }
 

--- a/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/controller.go
+++ b/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/controller.go
@@ -21,6 +21,7 @@ import (
 
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -61,6 +62,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatal("Error while getting operator version", err)
 		}
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 		metrics, _ := NewRecorder()
 		c := &Reconciler{
@@ -70,6 +76,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			pipelineInformer:            tektonPipelineinformer.Get(ctx),
 			extension:                   generator(ctx),
 			manifest:                    manifest,
+			platformParams:              params,
 			multiclusterProxyAAEVersion: proxyAAEVer,
 			operatorVersion:             operatorVer,
 		}

--- a/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/finalize.go
+++ b/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/finalize.go
@@ -42,6 +42,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 		return err
 	}
 
+	if err := r.installerSetClient.CleanupCustomSet(ctx, proxyAAECustomSet); err != nil {
+		logger.Error("failed to cleanup network policy installerset", "error", err)
+		return err
+	}
+
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", "error", err)
 	}

--- a/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/networkpolicies.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonmulticlusterproxyaae
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const proxyAAECustomSet = "proxy-aae-network-policies"
+
+var proxyAAEPodSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{"app": "proxy-aae"},
+}
+
+func proxyAAEDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	proxyPort := intstr.FromInt32(8080)
+	tcp := corev1.ProtocolTCP
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "proxy-aae"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: proxyAAEPodSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &tcp, Port: &proxyPort},
+						},
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func proxyAAEDefaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy("proxy-aae-default-deny", proxyAAEPodSelector)
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, proxy *v1alpha1.TektonMulticlusterProxyAAE) error {
+	if proxy.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, proxyAAECustomSet)
+	}
+	defaults := []networkingv1.NetworkPolicy{
+		proxyAAEDefaultDenyPolicy(),
+	}
+	defaults = append(defaults, proxyAAEDefaultPolicies(r.platformParams)...)
+
+	manifest, err := networkpolicy.Generate(
+		proxy.Spec.NetworkPolicy,
+		proxy.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, proxy, proxyAAECustomSet, &manifest, passthroughTransform, nil)
+}
+
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/networkpolicies_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonmulticlusterproxyaae
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestConstants(t *testing.T) {
+	if proxyAAECustomSet != "proxy-aae-network-policies" {
+		t.Errorf("expected custom set proxy-aae-network-policies, got %q", proxyAAECustomSet)
+	}
+}
+
+func TestProxyAAEDefaultPolicies(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policies := proxyAAEDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	p := policies[0]
+
+	if p.Name != "proxy-aae" {
+		t.Errorf("expected name proxy-aae, got %q", p.Name)
+	}
+
+	labels := p.Spec.PodSelector.MatchLabels
+	if labels["app"] != "proxy-aae" {
+		t.Errorf("expected app=proxy-aae, got %q", labels["app"])
+	}
+
+	if len(p.Spec.PolicyTypes) != 2 {
+		t.Fatalf("expected 2 policy types, got %d", len(p.Spec.PolicyTypes))
+	}
+	if p.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress || p.Spec.PolicyTypes[1] != networkingv1.PolicyTypeEgress {
+		t.Errorf("expected [Ingress, Egress], got %v", p.Spec.PolicyTypes)
+	}
+
+	// Ingress: TCP 8080 from any
+	if len(p.Spec.Ingress) != 1 {
+		t.Fatalf("expected 1 ingress rule, got %d", len(p.Spec.Ingress))
+	}
+	ingressPorts := p.Spec.Ingress[0].Ports
+	if len(ingressPorts) != 1 {
+		t.Fatalf("expected 1 ingress port, got %d", len(ingressPorts))
+	}
+	if ingressPorts[0].Port.IntVal != 8080 {
+		t.Errorf("expected ingress port 8080, got %d", ingressPorts[0].Port.IntVal)
+	}
+	if *ingressPorts[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("expected TCP protocol, got %v", *ingressPorts[0].Protocol)
+	}
+	if len(p.Spec.Ingress[0].From) != 0 {
+		t.Errorf("expected ingress from any (no From restriction), got %v", p.Spec.Ingress[0].From)
+	}
+
+	// Egress: DNS + API server
+	if len(p.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules (DNS + API server), got %d", len(p.Spec.Egress))
+	}
+}
+
+func TestProxyAAEDefaultDenyPolicy(t *testing.T) {
+	p := proxyAAEDefaultDenyPolicy()
+
+	if p.Name != "proxy-aae-default-deny" {
+		t.Errorf("expected name proxy-aae-default-deny, got %q", p.Name)
+	}
+	if p.Spec.PodSelector.MatchLabels["app"] != "proxy-aae" {
+		t.Errorf("expected deny scoped to app=proxy-aae, got %v", p.Spec.PodSelector.MatchLabels)
+	}
+}
+
+func TestProxyAAEPolicies_OpenShift(t *testing.T) {
+	params := networkpolicy.OpenShiftPlatformDefaults()
+	policies := proxyAAEDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	egressDNS := policies[0].Spec.Egress[0]
+	if len(egressDNS.Ports) < 1 {
+		t.Fatal("expected DNS egress ports")
+	}
+	if egressDNS.Ports[0].Port.IntVal != 5353 {
+		t.Errorf("expected OpenShift DNS port 5353, got %d", egressDNS.Ports[0].Port.IntVal)
+	}
+}

--- a/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektonmulticlusterproxyaae/reconcile.go
@@ -26,6 +26,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	proxyAAEreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonmulticlusterproxyaae"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	pipelineInformer            pipelineinformer.TektonPipelineInformer
 	manifest                    mf.Manifest
 	extension                   common.Extension
+	platformParams              networkpolicy.PlatformParams
 	multiclusterProxyAAEVersion string
 	operatorVersion             string
 }
@@ -54,7 +56,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, proxy *v1alpha1.TektonMu
 	proxy.Status.SetVersion(r.multiclusterProxyAAEVersion)
 
 	if proxy.GetName() != v1alpha1.MultiClusterProxyAAEResourceName {
-		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
+		msg := fmt.Sprintf(
+			"Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.MultiClusterProxyAAEResourceName,
 			proxy.GetName(),
 		)
@@ -98,6 +101,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, proxy *v1alpha1.TektonMu
 		}
 		proxy.Status.MarkInstallerSetNotReady(msg)
 		return err
+	}
+
+	if err := r.reconcileNetworkPolicies(ctx, proxy); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		proxy.Status.MarkInstallerSetNotReady(msg)
+		return nil
 	}
 
 	if err := r.extension.PostReconcile(ctx, proxy); err != nil {

--- a/pkg/reconciler/kubernetes/tektonscheduler/controller.go
+++ b/pkg/reconciler/kubernetes/tektonscheduler/controller.go
@@ -21,6 +21,7 @@ import (
 
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -58,6 +59,11 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			logger.Fatal("Error while getting operator version", err)
 		}
 
+		params := networkpolicy.KubernetesPlatformDefaults()
+		if v1alpha1.IsOpenShiftPlatform() {
+			params = networkpolicy.OpenShiftPlatformDefaults()
+		}
+
 		tisClient := operatorclient.Get(ctx).OperatorV1alpha1().TektonInstallerSets()
 		metrics, _ := NewRecorder()
 		c := &Reconciler{
@@ -67,6 +73,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 			installerSetClient:     client.NewInstallerSetClient(tisClient, operatorVer, schedulerVer, v1alpha1.KindTektonScheduler, metrics),
 			extension:              generator(ctx),
 			manifest:               manifest,
+			platformParams:         params,
 			tektonSchedulerVersion: schedulerVer,
 			operatorVersion:        operatorVer,
 		}

--- a/pkg/reconciler/kubernetes/tektonscheduler/finalize.go
+++ b/pkg/reconciler/kubernetes/tektonscheduler/finalize.go
@@ -32,9 +32,9 @@ var _ tektonscheduler.Finalizer = (*Reconciler)(nil)
 func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.TektonScheduler) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
-	//Delete CRDs before deleting rest of resources so that any instance
-	//of CRDs which has finalizer set will get deleted before we remove
-	//the controller;s deployment for it
+	// Delete CRDs before deleting rest of resources so that any instance
+	// of CRDs which has finalizer set will get deleted before we remove
+	// the controller;s deployment for it
 	if err := r.manifest.Filter(mf.CRDs).Delete(); err != nil {
 		logger.Error("Failed to deleted CRDs for TektonScheduler")
 		return err
@@ -42,6 +42,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Tekton
 
 	if err := r.installerSetClient.CleanupMainSet(ctx); err != nil {
 		logger.Error("failed to cleanup main installerset: ", err)
+		return err
+	}
+
+	if err := r.installerSetClient.CleanupCustomSet(ctx, schedulerCustomSet); err != nil {
+		logger.Error("failed to cleanup network policy installerset: ", err)
 		return err
 	}
 

--- a/pkg/reconciler/kubernetes/tektonscheduler/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonscheduler/networkpolicies.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonscheduler
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const schedulerCustomSet = "scheduler-network-policies"
+
+func schedulerControllerDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	metricsPort := intstr.FromInt32(8443)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "scheduler-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: schedulerControllerSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func schedulerWebhookDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	webhookPort := intstr.FromInt32(9443)
+	metricsPort := intstr.FromInt32(8443)
+
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "scheduler-webhook"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: schedulerWebhookSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkpolicy.WebhookIngressRule("", webhookPort),
+					networkpolicy.PrometheusIngressRule(params, metricsPort),
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+var schedulerControllerSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{
+		"app.kubernetes.io/name": "tekton-kueue",
+		"control-plane":          "controller-manager",
+	},
+}
+
+var schedulerWebhookSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{
+		"app.kubernetes.io/name": "tekton-kueue-webhook",
+		"control-plane":          "controller-manager",
+	},
+}
+
+func schedulerDefaultDenyPolicies() []networkingv1.NetworkPolicy {
+	return []networkingv1.NetworkPolicy{
+		networkpolicy.DefaultDenyPolicy("scheduler-controller-default-deny", schedulerControllerSelector),
+		networkpolicy.DefaultDenyPolicy("scheduler-webhook-default-deny", schedulerWebhookSelector),
+	}
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, ts *v1alpha1.TektonScheduler) error {
+	if ts.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, schedulerCustomSet)
+	}
+	defaults := schedulerDefaultDenyPolicies()
+	defaults = append(defaults, schedulerControllerDefaultPolicies(r.platformParams)...)
+	defaults = append(defaults, schedulerWebhookDefaultPolicies(r.platformParams)...)
+
+	manifest, err := networkpolicy.Generate(
+		ts.Spec.NetworkPolicy,
+		ts.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, ts, schedulerCustomSet, &manifest, passthroughTransform, nil)
+}
+
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/kubernetes/tektonscheduler/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonscheduler/networkpolicies_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tektonscheduler
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestConstants(t *testing.T) {
+	if schedulerCustomSet != "scheduler-network-policies" {
+		t.Errorf("expected custom set scheduler-network-policies, got %q", schedulerCustomSet)
+	}
+}
+
+func TestSchedulerControllerDefaultPolicies(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policies := schedulerControllerDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	p := policies[0]
+
+	if p.Name != "scheduler-controller" {
+		t.Errorf("expected name scheduler-controller, got %q", p.Name)
+	}
+
+	labels := p.Spec.PodSelector.MatchLabels
+	if labels["app.kubernetes.io/name"] != "tekton-kueue" {
+		t.Errorf("expected app.kubernetes.io/name=tekton-kueue, got %q", labels["app.kubernetes.io/name"])
+	}
+	if labels["control-plane"] != "controller-manager" {
+		t.Errorf("expected control-plane=controller-manager, got %q", labels["control-plane"])
+	}
+
+	if len(p.Spec.PolicyTypes) != 2 {
+		t.Fatalf("expected 2 policy types, got %d", len(p.Spec.PolicyTypes))
+	}
+	if p.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress || p.Spec.PolicyTypes[1] != networkingv1.PolicyTypeEgress {
+		t.Errorf("expected [Ingress, Egress], got %v", p.Spec.PolicyTypes)
+	}
+
+	if len(p.Spec.Ingress) != 1 {
+		t.Fatalf("expected 1 ingress rule (Prometheus), got %d", len(p.Spec.Ingress))
+	}
+	if len(p.Spec.Ingress[0].Ports) != 1 || p.Spec.Ingress[0].Ports[0].Port.IntVal != 8443 {
+		t.Errorf("expected Prometheus ingress on port 8443, got %v", p.Spec.Ingress[0].Ports)
+	}
+
+	if len(p.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules (DNS + API server), got %d", len(p.Spec.Egress))
+	}
+}
+
+func TestSchedulerWebhookDefaultPolicies(t *testing.T) {
+	params := networkpolicy.KubernetesPlatformDefaults()
+	policies := schedulerWebhookDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	p := policies[0]
+
+	if p.Name != "scheduler-webhook" {
+		t.Errorf("expected name scheduler-webhook, got %q", p.Name)
+	}
+
+	labels := p.Spec.PodSelector.MatchLabels
+	if labels["app.kubernetes.io/name"] != "tekton-kueue-webhook" {
+		t.Errorf("expected app.kubernetes.io/name=tekton-kueue-webhook, got %q", labels["app.kubernetes.io/name"])
+	}
+	if labels["control-plane"] != "controller-manager" {
+		t.Errorf("expected control-plane=controller-manager, got %q", labels["control-plane"])
+	}
+
+	if len(p.Spec.Ingress) != 2 {
+		t.Fatalf("expected 2 ingress rules (webhook + Prometheus), got %d", len(p.Spec.Ingress))
+	}
+	if p.Spec.Ingress[0].Ports[0].Port.IntVal != 9443 {
+		t.Errorf("expected webhook ingress on port 9443, got %d", p.Spec.Ingress[0].Ports[0].Port.IntVal)
+	}
+	if p.Spec.Ingress[1].Ports[0].Port.IntVal != 8443 {
+		t.Errorf("expected Prometheus ingress on port 8443, got %d", p.Spec.Ingress[1].Ports[0].Port.IntVal)
+	}
+
+	if len(p.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules (DNS + API server), got %d", len(p.Spec.Egress))
+	}
+}
+
+func TestSchedulerDefaultDenyPolicies(t *testing.T) {
+	policies := schedulerDefaultDenyPolicies()
+
+	if len(policies) != 2 {
+		t.Fatalf("expected 2 default-deny policies, got %d", len(policies))
+	}
+
+	ctrl := policies[0]
+	if ctrl.Name != "scheduler-controller-default-deny" {
+		t.Errorf("expected name scheduler-controller-default-deny, got %q", ctrl.Name)
+	}
+	if ctrl.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"] != "tekton-kueue" {
+		t.Errorf("expected controller deny scoped to tekton-kueue, got %v", ctrl.Spec.PodSelector.MatchLabels)
+	}
+
+	wh := policies[1]
+	if wh.Name != "scheduler-webhook-default-deny" {
+		t.Errorf("expected name scheduler-webhook-default-deny, got %q", wh.Name)
+	}
+	if wh.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"] != "tekton-kueue-webhook" {
+		t.Errorf("expected webhook deny scoped to tekton-kueue-webhook, got %v", wh.Spec.PodSelector.MatchLabels)
+	}
+}
+
+func TestSchedulerControllerPolicies_OpenShift(t *testing.T) {
+	params := networkpolicy.OpenShiftPlatformDefaults()
+	policies := schedulerControllerDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+
+	egressDNS := policies[0].Spec.Egress[0]
+	if len(egressDNS.Ports) < 1 {
+		t.Fatal("expected DNS egress ports")
+	}
+	if egressDNS.Ports[0].Port.IntVal != 5353 {
+		t.Errorf("expected OpenShift DNS port 5353, got %d", egressDNS.Ports[0].Port.IntVal)
+	}
+}

--- a/pkg/reconciler/kubernetes/tektonscheduler/reconcile.go
+++ b/pkg/reconciler/kubernetes/tektonscheduler/reconcile.go
@@ -27,6 +27,7 @@ import (
 	pipelineinformer "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	TektonSchedulerreconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/tektonscheduler"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -48,6 +49,8 @@ type Reconciler struct {
 	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform
 	extension common.Extension
+	// platformParams holds platform-specific values for building NetworkPolicy rules
+	platformParams networkpolicy.PlatformParams
 	// version of scheduler which we are installing
 	tektonSchedulerVersion string
 	operatorVersion        string
@@ -64,7 +67,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, TektonScheduler *v1alpha
 	TektonScheduler.Status.SetVersion(r.tektonSchedulerVersion)
 
 	if TektonScheduler.GetName() != v1alpha1.TektonSchedulerResourceName {
-		msg := fmt.Sprintf("Resource ignored, Expected Name: %s, Got Name: %s",
+		msg := fmt.Sprintf(
+			"Resource ignored, Expected Name: %s, Got Name: %s",
 			v1alpha1.TektonSchedulerResourceName,
 			TektonScheduler.GetName(),
 		)
@@ -108,6 +112,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, TektonScheduler *v1alpha
 		return err
 	}
 
+	if err := r.reconcileNetworkPolicies(ctx, TektonScheduler); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		TektonScheduler.Status.MarkInstallerSetNotReady(msg)
+		return nil
+	}
+
 	if err := r.extension.PostReconcile(ctx, TektonScheduler); err != nil {
 		msg := fmt.Sprintf("PostReconciliation failed: %s", err.Error())
 		logger.Error(msg)
@@ -143,5 +157,4 @@ func (r *Reconciler) ensureDependenciesInstalled(TektonScheduler *v1alpha1.Tekto
 	}
 
 	return nil
-
 }

--- a/pkg/reconciler/openshift/syncerservice/controller.go
+++ b/pkg/reconciler/openshift/syncerservice/controller.go
@@ -26,6 +26,7 @@ import (
 	tektonPipelineInformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	syncerServiceReconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/syncerservice"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -63,6 +64,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		operatorClientSet:  operatorclient.Get(ctx),
 		extension:          OpenShiftExtension(ctx),
 		manifest:           manifest,
+		platformParams:     networkpolicy.OpenShiftPlatformDefaults(),
 		pipelineInformer:   tektonPipelineInformer.Get(ctx),
 		operatorVersion:    operatorVer,
 		syncerVersion:      syncerVer,

--- a/pkg/reconciler/openshift/syncerservice/finalize.go
+++ b/pkg/reconciler/openshift/syncerservice/finalize.go
@@ -45,6 +45,11 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Syncer
 		return err
 	}
 
+	if err := r.installerSetClient.CleanupCustomSet(ctx, syncerServiceCustomSet); err != nil {
+		logger.Error("Failed to cleanup network policy installerset", err)
+		return err
+	}
+
 	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}

--- a/pkg/reconciler/openshift/syncerservice/networkpolicies.go
+++ b/pkg/reconciler/openshift/syncerservice/networkpolicies.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncerservice
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const syncerServiceCustomSet = "syncer-service-network-policies"
+
+var syncerServicePodSelector = metav1.LabelSelector{
+	MatchLabels: map[string]string{"app": "workload-controller"},
+}
+
+func syncerServiceDefaultPolicies(params networkpolicy.PlatformParams) []networkingv1.NetworkPolicy {
+	return []networkingv1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "syncer-service-controller"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: syncerServicePodSelector,
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					networkpolicy.DNSEgressRule(params),
+					networkpolicy.APIServerEgressRule(),
+				},
+			},
+		},
+	}
+}
+
+func syncerServiceDefaultDenyPolicy() networkingv1.NetworkPolicy {
+	return networkpolicy.DefaultDenyPolicy("syncer-service-default-deny", syncerServicePodSelector)
+}
+
+func (r *Reconciler) reconcileNetworkPolicies(ctx context.Context, ss *v1alpha1.SyncerService) error {
+	if ss.Spec.NetworkPolicy.Disabled {
+		return r.installerSetClient.CleanupCustomSet(ctx, syncerServiceCustomSet)
+	}
+	defaults := []networkingv1.NetworkPolicy{
+		syncerServiceDefaultDenyPolicy(),
+	}
+	defaults = append(defaults, syncerServiceDefaultPolicies(r.platformParams)...)
+
+	manifest, err := networkpolicy.Generate(
+		ss.Spec.NetworkPolicy,
+		ss.Spec.GetTargetNamespace(),
+		defaults,
+	)
+	if err != nil {
+		return err
+	}
+	return r.installerSetClient.CustomSet(ctx, ss, syncerServiceCustomSet, &manifest, passthroughTransform, nil)
+}
+
+func passthroughTransform(_ context.Context, m *mf.Manifest, _ v1alpha1.TektonComponent) (*mf.Manifest, error) {
+	return m, nil
+}
+
+var _ client.FilterAndTransform = passthroughTransform

--- a/pkg/reconciler/openshift/syncerservice/networkpolicies_test.go
+++ b/pkg/reconciler/openshift/syncerservice/networkpolicies_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncerservice
+
+import (
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func TestConstants(t *testing.T) {
+	if syncerServiceCustomSet != "syncer-service-network-policies" {
+		t.Errorf("expected custom set syncer-service-network-policies, got %q", syncerServiceCustomSet)
+	}
+}
+
+func TestSyncerServiceDefaultPolicies(t *testing.T) {
+	params := networkpolicy.OpenShiftPlatformDefaults()
+	policies := syncerServiceDefaultPolicies(params)
+
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	p := policies[0]
+
+	if p.Name != "syncer-service-controller" {
+		t.Errorf("expected name syncer-service-controller, got %q", p.Name)
+	}
+
+	labels := p.Spec.PodSelector.MatchLabels
+	if labels["app"] != "workload-controller" {
+		t.Errorf("expected app=workload-controller, got %q", labels["app"])
+	}
+
+	// Egress-only: no ingress rules
+	if len(p.Spec.PolicyTypes) != 1 {
+		t.Fatalf("expected 1 policy type (Egress only), got %d", len(p.Spec.PolicyTypes))
+	}
+	if p.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+		t.Errorf("expected PolicyTypeEgress, got %v", p.Spec.PolicyTypes[0])
+	}
+	if len(p.Spec.Ingress) != 0 {
+		t.Errorf("expected no ingress rules, got %d", len(p.Spec.Ingress))
+	}
+
+	// Egress: DNS + API server
+	if len(p.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules (DNS + API server), got %d", len(p.Spec.Egress))
+	}
+
+	// Verify OpenShift DNS port 5353
+	egressDNS := p.Spec.Egress[0]
+	if len(egressDNS.Ports) < 1 {
+		t.Fatal("expected DNS egress ports")
+	}
+	if egressDNS.Ports[0].Port.IntVal != 5353 {
+		t.Errorf("expected OpenShift DNS port 5353, got %d", egressDNS.Ports[0].Port.IntVal)
+	}
+}
+
+func TestSyncerServiceDefaultDenyPolicy(t *testing.T) {
+	p := syncerServiceDefaultDenyPolicy()
+
+	if p.Name != "syncer-service-default-deny" {
+		t.Errorf("expected name syncer-service-default-deny, got %q", p.Name)
+	}
+	if p.Spec.PodSelector.MatchLabels["app"] != "workload-controller" {
+		t.Errorf("expected deny scoped to app=workload-controller, got %v", p.Spec.PodSelector.MatchLabels)
+	}
+}

--- a/pkg/reconciler/openshift/syncerservice/reconcile.go
+++ b/pkg/reconciler/openshift/syncerservice/reconcile.go
@@ -27,6 +27,7 @@ import (
 	operatorv1alpha1 "github.com/tektoncd/operator/pkg/client/informers/externalversions/operator/v1alpha1"
 	syncerservicereconciler "github.com/tektoncd/operator/pkg/client/injection/reconciler/operator/v1alpha1/syncerservice"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
+	"github.com/tektoncd/operator/pkg/reconciler/common/networkpolicy"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/logging"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	installerSetClient *client.InstallerSetClient
 	manifest           mf.Manifest
 	extension          common.Extension
+	platformParams     networkpolicy.PlatformParams
 	pipelineInformer   operatorv1alpha1.TektonPipelineInformer
 	operatorVersion    string
 	syncerVersion      string
@@ -110,6 +112,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ss *v1alpha1.SyncerServi
 	// Create/Update InstallerSet
 	if err := r.ensureInstallerSet(ctx, ss); err != nil {
 		return err
+	}
+
+	if err := r.reconcileNetworkPolicies(ctx, ss); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			return err
+		}
+		msg := fmt.Sprintf("NetworkPolicy reconciliation failed: %s", err.Error())
+		logger.Errorw("NetworkPolicy reconciliation failed", "error", err)
+		ss.Status.MarkInstallerSetNotReady(msg)
+		return nil
 	}
 
 	if err := r.extension.PostReconcile(ctx, ss); err != nil {

--- a/pkg/reconciler/shared/tektonconfig/multiclusterproxyaae/multiclusterproxyaae.go
+++ b/pkg/reconciler/shared/tektonconfig/multiclusterproxyaae/multiclusterproxyaae.go
@@ -119,6 +119,7 @@ func GetTektonMulticlusterProxyAAECR(config *v1alpha1.TektonConfig, operatorVers
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
 			MulticlusterProxyAAEOptions: config.Spec.MulticlusterProxyAAE,
+			NetworkPolicy:               config.Spec.NetworkPolicy,
 		},
 	}
 }
@@ -146,6 +147,10 @@ func UpdateTektonMulticlusterProxyAAE(ctx context.Context, old, new *v1alpha1.Te
 	}
 	if !reflect.DeepEqual(old.Spec.Options, new.Spec.Options) {
 		old.Spec.Options = new.Spec.Options
+		updated = true
+	}
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
 		updated = true
 	}
 	if old.ObjectMeta.OwnerReferences == nil {

--- a/pkg/reconciler/shared/tektonconfig/scheduler/scheduler.go
+++ b/pkg/reconciler/shared/tektonconfig/scheduler/scheduler.go
@@ -36,7 +36,6 @@ const (
 )
 
 func EnsureTektonSchedulerExists(ctx context.Context, clients op.TektonSchedulerInterface, newScheduler *v1alpha1.TektonScheduler) (*v1alpha1.TektonScheduler, error) {
-
 	// Update MultiKueueOverride
 	// If MultiCluster is enabled and MultiClusterRole=Hub then MultiKueueOverride should be true
 	newScheduler.Spec.Config.MultiKueueOverride = !newScheduler.Spec.MultiClusterDisabled && strings.EqualFold(string(newScheduler.Spec.MultiClusterRole), string(v1alpha1.MultiClusterRoleHub))
@@ -86,7 +85,8 @@ func GetTektonSchedulerCR(config *v1alpha1.TektonConfig, operatorVersion string)
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Scheduler: config.Spec.Scheduler,
+			Scheduler:     config.Spec.Scheduler,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 }
@@ -126,6 +126,11 @@ func UpdateScheduler(ctx context.Context, old *v1alpha1.TektonScheduler, new *v1
 
 	if !reflect.DeepEqual(old.Spec.MultiClusterConfig, new.Spec.MultiClusterConfig) {
 		old.Spec.MultiClusterConfig = new.Spec.MultiClusterConfig
+		updated = true
+	}
+
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
 		updated = true
 	}
 

--- a/pkg/reconciler/shared/tektonconfig/syncerservice/syncerservice.go
+++ b/pkg/reconciler/shared/tektonconfig/syncerservice/syncerservice.go
@@ -137,6 +137,11 @@ func UpdateSyncerService(ctx context.Context, old *v1alpha1.SyncerService, new *
 		updated = true
 	}
 
+	if !reflect.DeepEqual(old.Spec.NetworkPolicy, new.Spec.NetworkPolicy) {
+		old.Spec.NetworkPolicy = new.Spec.NetworkPolicy
+		updated = true
+	}
+
 	if old.ObjectMeta.OwnerReferences == nil {
 		old.ObjectMeta.OwnerReferences = new.ObjectMeta.OwnerReferences
 		updated = true
@@ -174,7 +179,8 @@ func GetSyncerServiceCR(config *v1alpha1.TektonConfig, operatorVersion string) *
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Config: config.Spec.Config,
+			Config:        config.Spec.Config,
+			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
 }

--- a/test/e2e/common/12_syncerservice_networkpolicy_test.go
+++ b/test/e2e/common/12_syncerservice_networkpolicy_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestSyncerServiceNetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	if !utils.IsOpenShift() {
+		t.Skip("MultiCluster components are OpenShift-only, skipping")
+	}
+	if _, err := clients.KubeClientSet.Discovery().ServerResourcesForGroupVersion("kueue.x-k8s.io/v1beta1"); err != nil {
+		t.Skipf("Kueue API (kueue.x-k8s.io/v1beta1) not available, skipping: %v", err)
+	}
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownSyncerService(clients, crNames.SyncerService) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownScheduler(clients, crNames.TektonScheduler) })
+	defer utils.TearDownSyncerService(clients, crNames.SyncerService)
+	defer utils.TearDownScheduler(clients, crNames.TektonScheduler)
+
+	utils.CleanupOnInterrupt(func() { resources.DeleteDummyWorkerCluster(clients) })
+	defer resources.DeleteDummyWorkerCluster(clients)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := clients.TektonConfig().Create(context.TODO(), &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: crNames.TektonConfig},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile:    v1alpha1.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{TargetNamespace: crNames.TargetNamespace},
+			Scheduler: v1alpha1.Scheduler{
+				Disabled: ptr.To(false),
+				MultiClusterConfig: v1alpha1.MultiClusterConfig{
+					MultiClusterDisabled: false,
+					MultiClusterRole:     v1alpha1.MultiClusterRoleHub,
+				},
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("TektonConfig %q failed to create: %v", crNames.TektonConfig, err)
+	}
+
+	resources.EnsureDummyWorkerCluster(t, clients)
+
+	resources.AssertTektonConfigCRReadyStatus(t, clients, crNames)
+	resources.AssertTektonSchedulerCRReadyStatus(t, clients, crNames)
+	resources.AssertSyncerServiceCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"syncer-service-default-deny",
+		"syncer-service-controller",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		ss, err := clients.SyncerServices().Get(context.TODO(), crNames.SyncerService, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get SyncerService: %v", err)
+		}
+		ss.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.SyncerServices().Update(context.TODO(), ss, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on SyncerService: %v", err)
+		}
+		resources.AssertSyncerServiceCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		ss, err := clients.SyncerServices().Get(context.TODO(), crNames.SyncerService, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get SyncerService: %v", err)
+		}
+		ss.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.SyncerServices().Update(context.TODO(), ss, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on SyncerService: %v", err)
+		}
+		resources.AssertSyncerServiceCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}

--- a/test/e2e/common/12_tektonmulticlusterproxyaae_networkpolicy_test.go
+++ b/test/e2e/common/12_tektonmulticlusterproxyaae_networkpolicy_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestTektonMulticlusterProxyAAENetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	if !utils.IsOpenShift() {
+		t.Skip("MultiCluster components are OpenShift-only, skipping")
+	}
+	if _, err := clients.KubeClientSet.Discovery().ServerResourcesForGroupVersion("kueue.x-k8s.io/v1beta1"); err != nil {
+		t.Skipf("Kueue API (kueue.x-k8s.io/v1beta1) not available, skipping: %v", err)
+	}
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownMulticlusterProxyAAE(clients, crNames.TektonMulticlusterProxyAAE) })
+	utils.CleanupOnInterrupt(func() { utils.TearDownScheduler(clients, crNames.TektonScheduler) })
+	defer utils.TearDownMulticlusterProxyAAE(clients, crNames.TektonMulticlusterProxyAAE)
+	defer utils.TearDownScheduler(clients, crNames.TektonScheduler)
+
+	utils.CleanupOnInterrupt(func() { resources.DeleteDummyWorkerCluster(clients) })
+	defer resources.DeleteDummyWorkerCluster(clients)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := clients.TektonConfig().Create(context.TODO(), &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: crNames.TektonConfig},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile:    v1alpha1.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{TargetNamespace: crNames.TargetNamespace},
+			Scheduler: v1alpha1.Scheduler{
+				Disabled: ptr.To(false),
+				MultiClusterConfig: v1alpha1.MultiClusterConfig{
+					MultiClusterDisabled: false,
+					MultiClusterRole:     v1alpha1.MultiClusterRoleHub,
+				},
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("TektonConfig %q failed to create: %v", crNames.TektonConfig, err)
+	}
+
+	resources.EnsureDummyWorkerCluster(t, clients)
+
+	resources.AssertTektonConfigCRReadyStatus(t, clients, crNames)
+	resources.AssertTektonSchedulerCRReadyStatus(t, clients, crNames)
+	resources.AssertTektonMulticlusterProxyAAECRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"proxy-aae-default-deny",
+		"proxy-aae",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		proxy, err := clients.TektonMulticlusterProxyAAEs().Get(context.TODO(), crNames.TektonMulticlusterProxyAAE, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonMulticlusterProxyAAE: %v", err)
+		}
+		proxy.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.TektonMulticlusterProxyAAEs().Update(context.TODO(), proxy, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on TektonMulticlusterProxyAAE: %v", err)
+		}
+		resources.AssertTektonMulticlusterProxyAAECRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		proxy, err := clients.TektonMulticlusterProxyAAEs().Get(context.TODO(), crNames.TektonMulticlusterProxyAAE, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonMulticlusterProxyAAE: %v", err)
+		}
+		proxy.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.TektonMulticlusterProxyAAEs().Update(context.TODO(), proxy, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on TektonMulticlusterProxyAAE: %v", err)
+		}
+		resources.AssertTektonMulticlusterProxyAAECRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}

--- a/test/e2e/common/12_tektonscheduler_networkpolicy_test.go
+++ b/test/e2e/common/12_tektonscheduler_networkpolicy_test.go
@@ -1,0 +1,111 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/client"
+	"github.com/tektoncd/operator/test/resources"
+	"github.com/tektoncd/operator/test/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestTektonSchedulerNetworkPolicy(t *testing.T) {
+	crNames := utils.GetResourceNames()
+	clients := client.Setup(t, crNames.TargetNamespace)
+
+	if !utils.IsOpenShift() {
+		t.Skip("MultiCluster components are OpenShift-only, skipping")
+	}
+	if _, err := clients.KubeClientSet.Discovery().ServerResourcesForGroupVersion("kueue.x-k8s.io/v1beta1"); err != nil {
+		t.Skipf("Kueue API (kueue.x-k8s.io/v1beta1) not available, skipping: %v", err)
+	}
+
+	utils.CleanupOnInterrupt(func() { utils.TearDownScheduler(clients, crNames.TektonScheduler) })
+	defer utils.TearDownScheduler(clients, crNames.TektonScheduler)
+
+	utils.CleanupOnInterrupt(func() { resources.DeleteDummyWorkerCluster(clients) })
+	defer resources.DeleteDummyWorkerCluster(clients)
+
+	resources.EnsureNoTektonConfigInstance(t, clients, crNames)
+
+	if _, err := clients.TektonConfig().Create(context.TODO(), &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: crNames.TektonConfig},
+		Spec: v1alpha1.TektonConfigSpec{
+			Profile:    v1alpha1.ProfileAll,
+			CommonSpec: v1alpha1.CommonSpec{TargetNamespace: crNames.TargetNamespace},
+			Scheduler: v1alpha1.Scheduler{
+				Disabled: ptr.To(false),
+				MultiClusterConfig: v1alpha1.MultiClusterConfig{
+					MultiClusterDisabled: false,
+					MultiClusterRole:     v1alpha1.MultiClusterRoleHub,
+				},
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("TektonConfig %q failed to create: %v", crNames.TektonConfig, err)
+	}
+
+	resources.EnsureDummyWorkerCluster(t, clients)
+
+	resources.AssertTektonConfigCRReadyStatus(t, clients, crNames)
+	resources.AssertTektonSchedulerCRReadyStatus(t, clients, crNames)
+
+	expectedPolicies := []string{
+		"scheduler-controller-default-deny",
+		"scheduler-webhook-default-deny",
+		"scheduler-controller",
+		"scheduler-webhook",
+	}
+
+	t.Run("default-policies-created", func(t *testing.T) {
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("disable-removes-policies", func(t *testing.T) {
+		ts, err := clients.TektonSchedulers().Get(context.TODO(), crNames.TektonScheduler, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonScheduler: %v", err)
+		}
+		ts.Spec.NetworkPolicy.Disabled = true
+		if _, err := clients.TektonSchedulers().Update(context.TODO(), ts, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to disable NetworkPolicy on TektonScheduler: %v", err)
+		}
+		resources.AssertTektonSchedulerCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesAbsent(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+
+	t.Run("reenable-restores-policies", func(t *testing.T) {
+		ts, err := clients.TektonSchedulers().Get(context.TODO(), crNames.TektonScheduler, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get TektonScheduler: %v", err)
+		}
+		ts.Spec.NetworkPolicy.Disabled = false
+		if _, err := clients.TektonSchedulers().Update(context.TODO(), ts, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("failed to re-enable NetworkPolicy on TektonScheduler: %v", err)
+		}
+		resources.AssertTektonSchedulerCRReadyStatus(t, clients, crNames)
+		resources.AssertNetworkPoliciesExist(t, clients, crNames.TargetNamespace, expectedPolicies)
+	})
+}

--- a/test/resources/multicluster_helpers.go
+++ b/test/resources/multicluster_helpers.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/tektoncd/operator/test/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	dummyWorkerSecretName  = "e2e-dummy-worker"
+	dummyWorkerClusterName = "e2e-dummy-worker"
+	kueueNamespaceK8s      = "kueue-system"
+	kueueNamespaceOCP      = "openshift-kueue-operator"
+)
+
+var multiKueueClusterGVR = schema.GroupVersionResource{
+	Group:    "kueue.x-k8s.io",
+	Version:  "v1beta2",
+	Resource: "multikueueclusters",
+}
+
+// KueueNamespace returns the namespace where Kueue components run.
+func KueueNamespace() string {
+	if utils.IsOpenShift() {
+		return kueueNamespaceOCP
+	}
+	return kueueNamespaceK8s
+}
+
+// EnsureDummyWorkerCluster creates a self-referential kubeconfig secret and
+// MultiKueueCluster CR so that proxy-aae can detect at least one worker
+// cluster and pass its readiness probe (/ready).
+func EnsureDummyWorkerCluster(t *testing.T, clients *utils.Clients) {
+	t.Helper()
+
+	ns := KueueNamespace()
+	cfg := clients.Config
+
+	// Resolve the cluster CA — Kueue rejects insecure-skip-tls-verify.
+	caData := cfg.CAData
+	if len(caData) == 0 && cfg.CAFile != "" {
+		var err error
+		caData, err = os.ReadFile(cfg.CAFile)
+		if err != nil {
+			t.Fatalf("failed to read CA file %s: %v", cfg.CAFile, err)
+		}
+	}
+	if len(caData) == 0 {
+		cm, err := clients.KubeClient.CoreV1().ConfigMaps(ns).Get(
+			context.TODO(), "kube-root-ca.crt", metav1.GetOptions{},
+		)
+		if err != nil {
+			t.Fatalf("failed to get kube-root-ca.crt ConfigMap in %s: %v", ns, err)
+		}
+		caData = []byte(cm.Data["ca.crt"])
+	}
+
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = cfg.Host
+	cluster.CertificateAuthorityData = caData
+
+	authInfo := clientcmdapi.NewAuthInfo()
+	authInfo.Token = cfg.BearerToken
+	authInfo.ClientCertificateData = cfg.CertData
+	authInfo.ClientKeyData = cfg.KeyData
+
+	kubeConfig := clientcmdapi.NewConfig()
+	kubeConfig.Clusters[dummyWorkerClusterName] = cluster
+	kubeConfig.AuthInfos[dummyWorkerClusterName] = authInfo
+	kubeConfig.Contexts[dummyWorkerClusterName] = &clientcmdapi.Context{
+		Cluster:  dummyWorkerClusterName,
+		AuthInfo: dummyWorkerClusterName,
+	}
+	kubeConfig.CurrentContext = dummyWorkerClusterName
+
+	kubeconfigBytes, err := clientcmd.Write(*kubeConfig)
+	if err != nil {
+		t.Fatalf("failed to serialize dummy worker kubeconfig: %v", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dummyWorkerSecretName,
+			Namespace: ns,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"kubeconfig": kubeconfigBytes,
+		},
+	}
+	_, err = clients.KubeClient.CoreV1().Secrets(ns).Create(context.TODO(), secret, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create dummy worker secret in %s: %v", ns, err)
+	}
+
+	mkc := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kueue.x-k8s.io/v1beta2",
+			"kind":       "MultiKueueCluster",
+			"metadata": map[string]interface{}{
+				"name": dummyWorkerClusterName,
+			},
+			"spec": map[string]interface{}{
+				"clusterSource": map[string]interface{}{
+					"kubeConfig": map[string]interface{}{
+						"locationType": "Secret",
+						"location":     dummyWorkerSecretName,
+					},
+				},
+			},
+		},
+	}
+	_, err = clients.Dynamic.Resource(multiKueueClusterGVR).Create(context.TODO(), mkc, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create MultiKueueCluster %s: %v", dummyWorkerClusterName, err)
+	}
+}
+
+// DeleteDummyWorkerCluster removes the dummy worker secret and
+// MultiKueueCluster created by EnsureDummyWorkerCluster.
+func DeleteDummyWorkerCluster(clients *utils.Clients) {
+	if clients == nil {
+		return
+	}
+	if clients.Dynamic != nil {
+		_ = clients.Dynamic.Resource(multiKueueClusterGVR).Delete(
+			context.TODO(), dummyWorkerClusterName, metav1.DeleteOptions{},
+		)
+	}
+	if clients.KubeClient != nil {
+		ns := KueueNamespace()
+		_ = clients.KubeClient.CoreV1().Secrets(ns).Delete(
+			context.TODO(), dummyWorkerSecretName, metav1.DeleteOptions{},
+		)
+	}
+}

--- a/test/resources/syncerservices.go
+++ b/test/resources/syncerservices.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	typedv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/utils"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/logging"
+)
+
+func EnsureSyncerServiceExists(clients typedv1alpha1.SyncerServiceInterface, names utils.ResourceNames) (*v1alpha1.SyncerService, error) {
+	ks, err := clients.Get(context.TODO(), names.SyncerService, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		ks := &v1alpha1.SyncerService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: names.SyncerService,
+			},
+			Spec: v1alpha1.SyncerServiceSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					TargetNamespace: names.TargetNamespace,
+				},
+			},
+		}
+		return clients.Create(context.TODO(), ks, metav1.CreateOptions{})
+	}
+	return ks, err
+}
+
+func WaitForSyncerServiceState(clients typedv1alpha1.SyncerServiceInterface, name string,
+	inState func(s *v1alpha1.SyncerService, err error) (bool, error),
+) (*v1alpha1.SyncerService, error) {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForSyncerServiceState/%s/%s", name, "SyncerServiceIsReady"))
+	defer span.End()
+
+	var lastState *v1alpha1.SyncerService
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		lastState, err := clients.Get(context.TODO(), name, metav1.GetOptions{})
+		return inState(lastState, err)
+	})
+
+	if waitErr != nil {
+		return lastState, fmt.Errorf("syncerservice %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return lastState, nil
+}
+
+func IsSyncerServiceReady(s *v1alpha1.SyncerService, err error) (bool, error) {
+	return s.Status.IsReady(), err
+}
+
+func AssertSyncerServiceCRReadyStatus(t *testing.T, clients *utils.Clients, names utils.ResourceNames) {
+	if _, err := WaitForSyncerServiceState(clients.SyncerServices(), names.SyncerService, IsSyncerServiceReady); err != nil {
+		t.Fatalf("SyncerServiceCR %q failed to get to the READY status: %v", names.SyncerService, err)
+	}
+}

--- a/test/resources/tektonmulticlusterproxyaaes.go
+++ b/test/resources/tektonmulticlusterproxyaaes.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	typedv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/utils"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/test/logging"
+)
+
+func EnsureTektonMulticlusterProxyAAEExists(clients typedv1alpha1.TektonMulticlusterProxyAAEInterface, names utils.ResourceNames) (*v1alpha1.TektonMulticlusterProxyAAE, error) {
+	ks, err := clients.Get(context.TODO(), names.TektonMulticlusterProxyAAE, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		ks := &v1alpha1.TektonMulticlusterProxyAAE{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: names.TektonMulticlusterProxyAAE,
+			},
+			Spec: v1alpha1.TektonMulticlusterProxyAAESpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					TargetNamespace: names.TargetNamespace,
+				},
+			},
+		}
+		return clients.Create(context.TODO(), ks, metav1.CreateOptions{})
+	}
+	return ks, err
+}
+
+func WaitForTektonMulticlusterProxyAAEState(clients typedv1alpha1.TektonMulticlusterProxyAAEInterface, name string,
+	inState func(s *v1alpha1.TektonMulticlusterProxyAAE, err error) (bool, error),
+) (*v1alpha1.TektonMulticlusterProxyAAE, error) {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForTektonMulticlusterProxyAAEState/%s/%s", name, "TektonMulticlusterProxyAAEIsReady"))
+	defer span.End()
+
+	var lastState *v1alpha1.TektonMulticlusterProxyAAE
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		lastState, err := clients.Get(context.TODO(), name, metav1.GetOptions{})
+		return inState(lastState, err)
+	})
+
+	if waitErr != nil {
+		return lastState, fmt.Errorf("tektonmulticlusterproxyaae %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return lastState, nil
+}
+
+func IsTektonMulticlusterProxyAAEReady(s *v1alpha1.TektonMulticlusterProxyAAE, err error) (bool, error) {
+	return s.Status.IsReady(), err
+}
+
+func AssertTektonMulticlusterProxyAAECRReadyStatus(t *testing.T, clients *utils.Clients, names utils.ResourceNames) {
+	if _, err := WaitForTektonMulticlusterProxyAAEState(clients.TektonMulticlusterProxyAAEs(), names.TektonMulticlusterProxyAAE, IsTektonMulticlusterProxyAAEReady); err != nil {
+		t.Fatalf("TektonMulticlusterProxyAAECR %q failed to get to the READY status: %v", names.TektonMulticlusterProxyAAE, err)
+	}
+}

--- a/test/resources/tektonschedulers.go
+++ b/test/resources/tektonschedulers.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	typedv1alpha1 "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	"github.com/tektoncd/operator/test/utils"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/test/logging"
+)
+
+func EnsureTektonSchedulerExists(clients typedv1alpha1.TektonSchedulerInterface, names utils.ResourceNames) (*v1alpha1.TektonScheduler, error) {
+	ks, err := clients.Get(context.TODO(), names.TektonScheduler, metav1.GetOptions{})
+	if apierrs.IsNotFound(err) {
+		ks := &v1alpha1.TektonScheduler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: names.TektonScheduler,
+			},
+			Spec: v1alpha1.TektonSchedulerSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					TargetNamespace: names.TargetNamespace,
+				},
+				Scheduler: v1alpha1.Scheduler{
+					Disabled: ptr.To(false),
+					MultiClusterConfig: v1alpha1.MultiClusterConfig{
+						MultiClusterDisabled: true,
+					},
+				},
+			},
+		}
+		return clients.Create(context.TODO(), ks, metav1.CreateOptions{})
+	}
+	return ks, err
+}
+
+func WaitForTektonSchedulerState(clients typedv1alpha1.TektonSchedulerInterface, name string,
+	inState func(s *v1alpha1.TektonScheduler, err error) (bool, error),
+) (*v1alpha1.TektonScheduler, error) {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForTektonSchedulerState/%s/%s", name, "TektonSchedulerIsReady"))
+	defer span.End()
+
+	var lastState *v1alpha1.TektonScheduler
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), utils.Interval, utils.Timeout, true, func(ctx context.Context) (bool, error) {
+		lastState, err := clients.Get(context.TODO(), name, metav1.GetOptions{})
+		return inState(lastState, err)
+	})
+
+	if waitErr != nil {
+		return lastState, fmt.Errorf("tektonscheduler %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return lastState, nil
+}
+
+func IsTektonSchedulerReady(s *v1alpha1.TektonScheduler, err error) (bool, error) {
+	return s.Status.IsReady(), err
+}
+
+func AssertTektonSchedulerCRReadyStatus(t *testing.T, clients *utils.Clients, names utils.ResourceNames) {
+	if _, err := WaitForTektonSchedulerState(clients.TektonSchedulers(), names.TektonScheduler, IsTektonSchedulerReady); err != nil {
+		t.Fatalf("TektonSchedulerCR %q failed to get to the READY status: %v", names.TektonScheduler, err)
+	}
+}

--- a/test/utils/cleanup.go
+++ b/test/utils/cleanup.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-type crDeleteVerifier wait.ConditionFunc
-type deploymentDeleteVerifier wait.ConditionFunc
-type crGetFunc func(ctx context.Context) error
+type (
+	crDeleteVerifier         wait.ConditionFunc
+	deploymentDeleteVerifier wait.ConditionFunc
+	crGetFunc                func(ctx context.Context) error
+)
 
 // CleanupOnInterrupt will execute the function cleanup if an interrupt signal is caught
 func CleanupOnInterrupt(cleanup func()) {
@@ -169,7 +171,6 @@ func TearDownAddon(clients *Clients, name string) {
 	if err != nil {
 		fmt.Printf("error waiting from tearDown of TektonAddon resource, name: %s, error: %v", name, err)
 	}
-
 }
 
 // TearDownNamespace will delete created test Namespace
@@ -204,7 +205,6 @@ func TearDownNamespace(clients *Clients, name string) {
 		}
 		return false, nil
 	})
-
 	if err != nil {
 		fmt.Printf("error waiting from tearDown of Namespace resource, name: %s, error: %v", name, err)
 	}
@@ -336,6 +336,7 @@ func TearDownManualApprovalGate(clients *Clients, name string) {
 		fmt.Printf("error waiting from tearDown of ManualApprovalGate resource, name: %s, error: %v", name, err)
 	}
 }
+
 func TearDownTektonPruner(clients *Clients, name string) {
 	ctx := context.Background()
 	if clients == nil || clients.Operator == nil {
@@ -367,6 +368,99 @@ func TearDownTektonPruner(clients *Clients, name string) {
 	}
 }
 
+func TearDownScheduler(clients *Clients, name string) {
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	ts, err := clients.TektonSchedulers().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonScheduler instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := ts.Spec.TargetNamespace
+
+	err = clients.TektonSchedulers().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonScheduler during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonSchedulers().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonSchedulerDeploymentLabel)
+	err = waitUntilFullDeletion(crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonScheduler resource, name: %s, error: %v", name, err)
+	}
+}
+
+func TearDownMulticlusterProxyAAE(clients *Clients, name string) {
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	proxy, err := clients.TektonMulticlusterProxyAAEs().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get TektonMulticlusterProxyAAE instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := proxy.Spec.TargetNamespace
+
+	err = clients.TektonMulticlusterProxyAAEs().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete TektonMulticlusterProxyAAE during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.TektonMulticlusterProxyAAEs().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, TektonMulticlusterProxyAAEDeploymentLabel)
+	err = waitUntilFullDeletion(crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of TektonMulticlusterProxyAAE resource, name: %s, error: %v", name, err)
+	}
+}
+
+func TearDownSyncerService(clients *Clients, name string) {
+	ctx := context.Background()
+	if clients == nil || clients.Operator == nil {
+		return
+	}
+
+	ss, err := clients.SyncerServices().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			fmt.Printf("error trying to get SyncerService instance during teardown, name: %s, error: %v", name, err)
+		}
+		return
+	}
+	targetNamespace := ss.Spec.TargetNamespace
+
+	err = clients.SyncerServices().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Printf("error trying to delete SyncerService during teardown, name: %s, error: %v", name, err)
+		return
+	}
+	crdf := newCRDeleteVerifier(ctx, func(ctx context.Context) error {
+		_, err := clients.SyncerServices().Get(ctx, name, metav1.GetOptions{})
+		return err
+	})
+	ddf := newDeploymentDeleteVerifier(ctx, clients, targetNamespace, SyncerServiceDeploymentLabel)
+	err = waitUntilFullDeletion(crdf, ddf)
+	if err != nil {
+		fmt.Printf("error waiting from tearDown of SyncerService resource, name: %s, error: %v", name, err)
+	}
+}
+
 func newCRDeleteVerifier(ctx context.Context, f crGetFunc) crDeleteVerifier {
 	return func() (bool, error) {
 		err := f(ctx)
@@ -385,7 +479,6 @@ func newDeploymentDeleteVerifier(ctx context.Context, c *Clients, namespace, lab
 		deployemnts, err := c.KubeClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
-
 		if err != nil {
 			return false, err
 		}

--- a/test/utils/clients.go
+++ b/test/utils/clients.go
@@ -89,7 +89,8 @@ func buildClientConfig(kubeConfigPath string, clusterName string) (*rest.Config,
 	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
-		&overrides).ClientConfig()
+		&overrides,
+	).ClientConfig()
 }
 
 func newTektonOperatorAlphaClients(cfg *rest.Config) (operatorv1alpha1.OperatorV1alpha1Interface, error) {
@@ -131,6 +132,7 @@ func (c *Clients) TektonDashboard() operatorv1alpha1.TektonDashboardInterface {
 func (c *Clients) TektonDashboardAll() operatorv1alpha1.TektonDashboardInterface {
 	return c.Operator.TektonDashboards()
 }
+
 func (c *Clients) TektonAddon() operatorv1alpha1.TektonAddonInterface {
 	return c.Operator.TektonAddons()
 }
@@ -162,9 +164,11 @@ func (c *Clients) TektonChains() operatorv1alpha1.TektonChainInterface {
 func (c *Clients) TektonChainsAll() operatorv1alpha1.TektonChainInterface {
 	return c.Operator.TektonChains()
 }
+
 func (c *Clients) TektonPruner() operatorv1alpha1.TektonPrunerInterface {
 	return c.Operator.TektonPruners()
 }
+
 func (c *Clients) TektonPrunerAll() operatorv1alpha1.TektonPrunerInterface {
 	return c.Operator.TektonPruners()
 }
@@ -187,4 +191,28 @@ func (c *Clients) TektonInstallerSetAll() operatorv1alpha1.TektonInstallerSetInt
 
 func (c *Clients) OpenShiftPipelinesAsCode() operatorv1alpha1.OpenShiftPipelinesAsCodeInterface {
 	return c.Operator.OpenShiftPipelinesAsCodes()
+}
+
+func (c *Clients) TektonSchedulers() operatorv1alpha1.TektonSchedulerInterface {
+	return c.Operator.TektonSchedulers()
+}
+
+func (c *Clients) TektonSchedulersAll() operatorv1alpha1.TektonSchedulerInterface {
+	return c.Operator.TektonSchedulers()
+}
+
+func (c *Clients) TektonMulticlusterProxyAAEs() operatorv1alpha1.TektonMulticlusterProxyAAEInterface {
+	return c.Operator.TektonMulticlusterProxyAAEs()
+}
+
+func (c *Clients) TektonMulticlusterProxyAAEsAll() operatorv1alpha1.TektonMulticlusterProxyAAEInterface {
+	return c.Operator.TektonMulticlusterProxyAAEs()
+}
+
+func (c *Clients) SyncerServices() operatorv1alpha1.SyncerServiceInterface {
+	return c.Operator.SyncerServices()
+}
+
+func (c *Clients) SyncerServicesAll() operatorv1alpha1.SyncerServiceInterface {
+	return c.Operator.SyncerServices()
 }

--- a/test/utils/e2e_flags.go
+++ b/test/utils/e2e_flags.go
@@ -24,14 +24,17 @@ import (
 )
 
 var (
-	TektonPipelineDeploymentLabel     = labelString(v1alpha1.OperandTektoncdPipeline)
-	TektonTriggerDeploymentLabel      = labelString(v1alpha1.OperandTektoncdTriggers)
-	TektonDashboardDeploymentLabel    = labelString(v1alpha1.OperandTektoncdDashboard)
-	TektonChainDeploymentLabel        = labelString(v1alpha1.OperandTektoncdChains)
-	TektonResultsDeploymentLabel      = labelString(v1alpha1.OperandTektoncdResults)
-	ManualApprovalGateDeploymentLabel = labelString(v1alpha1.ManualApprovalGates)
-	TektonPrunerDeploymentLabel       = labelString(v1alpha1.TektonPrunerResourceName)
-	TektonAddonDeploymentLabel        = labelString(openshift.OperandOpenShiftPipelinesAddons)
+	TektonPipelineDeploymentLabel             = labelString(v1alpha1.OperandTektoncdPipeline)
+	TektonTriggerDeploymentLabel              = labelString(v1alpha1.OperandTektoncdTriggers)
+	TektonDashboardDeploymentLabel            = labelString(v1alpha1.OperandTektoncdDashboard)
+	TektonChainDeploymentLabel                = labelString(v1alpha1.OperandTektoncdChains)
+	TektonResultsDeploymentLabel              = labelString(v1alpha1.OperandTektoncdResults)
+	ManualApprovalGateDeploymentLabel         = labelString(v1alpha1.ManualApprovalGates)
+	TektonPrunerDeploymentLabel               = labelString(v1alpha1.TektonPrunerResourceName)
+	TektonAddonDeploymentLabel                = labelString(openshift.OperandOpenShiftPipelinesAddons)
+	TektonSchedulerDeploymentLabel            = labelString(v1alpha1.TektonSchedulerResourceName)
+	TektonMulticlusterProxyAAEDeploymentLabel = labelString(v1alpha1.MultiClusterProxyAAEResourceName)
+	SyncerServiceDeploymentLabel              = labelString(v1alpha1.OperandSyncerService)
 )
 
 func labelString(operandName string) string {

--- a/test/utils/names.go
+++ b/test/utils/names.go
@@ -20,36 +20,42 @@ import "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 
 // ResourceNames holds names of various resources.
 type ResourceNames struct {
-	TektonPipeline           string
-	TektonTrigger            string
-	TektonDashboard          string
-	TektonAddon              string
-	TektonConfig             string
-	TektonPruner             string
-	TektonResult             string
-	TektonChain              string
-	Namespace                string
-	TargetNamespace          string
-	OperatorPodSelectorLabel string
-	OpenShiftPipelinesAsCode string
-	ManualApprovalGate       string
+	TektonPipeline             string
+	TektonTrigger              string
+	TektonDashboard            string
+	TektonAddon                string
+	TektonConfig               string
+	TektonPruner               string
+	TektonResult               string
+	TektonChain                string
+	TektonScheduler            string
+	TektonMulticlusterProxyAAE string
+	SyncerService              string
+	Namespace                  string
+	TargetNamespace            string
+	OperatorPodSelectorLabel   string
+	OpenShiftPipelinesAsCode   string
+	ManualApprovalGate         string
 }
 
 func GetResourceNames() ResourceNames {
 	resourceNames := ResourceNames{
-		TektonConfig:             v1alpha1.ConfigResourceName,
-		TektonPipeline:           v1alpha1.PipelineResourceName,
-		TektonTrigger:            v1alpha1.TriggerResourceName,
-		TektonDashboard:          v1alpha1.DashboardResourceName,
-		TektonAddon:              v1alpha1.AddonResourceName,
-		TektonPruner:             v1alpha1.TektonPrunerResourceName,
-		TektonResult:             v1alpha1.ResultResourceName,
-		TektonChain:              v1alpha1.ChainResourceName,
-		ManualApprovalGate:       v1alpha1.ManualApprovalGates,
-		OpenShiftPipelinesAsCode: v1alpha1.OpenShiftPipelinesAsCodeName,
-		Namespace:                "tekton-operator",
-		TargetNamespace:          "tekton-pipelines",
-		OperatorPodSelectorLabel: "name=tekton-operator",
+		TektonConfig:               v1alpha1.ConfigResourceName,
+		TektonPipeline:             v1alpha1.PipelineResourceName,
+		TektonTrigger:              v1alpha1.TriggerResourceName,
+		TektonDashboard:            v1alpha1.DashboardResourceName,
+		TektonAddon:                v1alpha1.AddonResourceName,
+		TektonPruner:               v1alpha1.TektonPrunerResourceName,
+		TektonResult:               v1alpha1.ResultResourceName,
+		TektonChain:                v1alpha1.ChainResourceName,
+		TektonScheduler:            v1alpha1.TektonSchedulerResourceName,
+		TektonMulticlusterProxyAAE: v1alpha1.MultiClusterProxyAAEResourceName,
+		SyncerService:              v1alpha1.SyncerServiceResourceName,
+		ManualApprovalGate:         v1alpha1.ManualApprovalGates,
+		OpenShiftPipelinesAsCode:   v1alpha1.OpenShiftPipelinesAsCodeName,
+		Namespace:                  "tekton-operator",
+		TargetNamespace:            "tekton-pipelines",
+		OperatorPodSelectorLabel:   "name=tekton-operator",
 	}
 	if IsOpenShift() {
 		resourceNames.Namespace = "openshift-operators"


### PR DESCRIPTION
Add reconciler-based NetworkPolicy management for three components:

- TektonScheduler: default-deny + controller (Prometheus 8443) + webhook (9443, Prometheus 8443) policies in tekton-kueue namespace
- TektonMulticlusterProxyAAE: default-deny + proxy (ingress 8080) policies in proxy-aae namespace
- SyncerService (OpenShift only): default-deny + controller (egress-only) policies in syncer-service namespace

Each component gets spec.networkPolicy (NetworkPolicyConfig) wired from TektonConfig, with validation, CustomSet-based InstallerSet management, and FinalizeKind cleanup.


Assisted-by: Claude Code (claude-opus-4-6)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Add NetworkPolicy support for TektonScheduler, TektonMulticlusterProxyAAE, and SyncerService components, giving each a default-deny policy plus targeted allow rules for required traffic.
```
