### PR TITLE
fix(hack): stop sync-helm-crds.sh reviving dead manual CRDs

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -1446,9 +1446,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, which is the only component with
-                  NetworkPolicy reconciliation implemented. Other components (Pipeline, Chains,
-                  Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  only components with NetworkPolicy reconciliation implemented. Other
+                  components (Chains, Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -573,9 +573,9 @@ spec:
               networkPolicy:
                 description: |-
                   NetworkPolicy configures NetworkPolicy resources for the operand namespace.
-                  This field is propagated to TektonTrigger, which is the only component with
-                  NetworkPolicy reconciliation implemented. Other components (Pipeline, Chains,
-                  Results, Dashboard) do not yet act on this field.
+                  This field is propagated to TektonTrigger and TektonPipeline, which are the
+                  only components with NetworkPolicy reconciliation implemented. Other
+                  components (Chains, Results, Dashboard) do not yet act on this field.
                 properties:
                   disabled:
                     description: |-

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -14,9 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script syncs generated CRDs from config/base/generated-crds/ into:
-#   1. config/base/, config/kubernetes/base/, config/openshift/base/ (kustomize source-of-truth)
-#   2. charts/tekton-operator/templates/ (Helm chart CRDs)
+# This script syncs generated CRDs from config/base/generated-crds/ into
+# charts/tekton-operator/templates/ (Helm chart CRDs).
+#
+# kustomize consumes config/base/generated-crds/*.yaml directly (see
+# config/base/kustomization.yaml, config/kubernetes/base/kustomization.yaml,
+# config/openshift/base/kustomization.yaml) — there is no separate manual copy
+# to keep in sync there. See commit 1ae0906b3 ("Cleanup manual CRDs and use
+# generated CRDs in kustomize"), which removed those manual config/*_crd.yaml
+# files; this script must not recreate them.
 #
 # Prerequisites: Run `make generate-crds` first (or use `make sync-helm-crds` which calls this).
 
@@ -24,9 +30,6 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GENERATED_DIR="${REPO_ROOT}/config/base/generated-crds"
-BASE_DIR="${REPO_ROOT}/config/base"
-K8S_DIR="${REPO_ROOT}/config/kubernetes/base"
-OPENSHIFT_DIR="${REPO_ROOT}/config/openshift/base"
 HELM_DIR="${REPO_ROOT}/charts/tekton-operator/templates"
 
 # inject_labels adds the standard labels after the metadata.name line in a generated CRD
@@ -50,33 +53,6 @@ inject_labels() {
 # strip_leading_separator removes the leading "---" from controller-gen output
 strip_leading_separator() {
   sed '1{/^---$/d;}'
-}
-
-# write_config_crd writes a CRD to the appropriate config/ directory with copyright header and labels
-write_config_crd() {
-  local src_file="$1"
-  local dest_dir="$2"
-  local dest_file="$3"
-
-  cat > "${dest_dir}/${dest_file}" <<'HEADER'
-# Copyright 2025 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-HEADER
-
-  inject_labels "$src_file" | strip_leading_separator >> "${dest_dir}/${dest_file}"
-  echo "  Updated: ${dest_dir}/${dest_file}"
 }
 
 # strip_int_formats removes "format: int32" and "format: int64" lines from CRD schemas.
@@ -106,33 +82,8 @@ assemble_helm_crds() {
 echo "Syncing generated CRDs..."
 echo ""
 
-# Step 1: Update config/ directories
-echo "Step 1: Updating config/ CRD files..."
-
-# base CRDs (common to both kubernetes and openshift)
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_manualapprovalgates.yaml"         "$BASE_DIR"      "300-operator_v1alpha1_manualapprovalgate_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonchains.yaml"                "$BASE_DIR"      "300-operator_v1alpha1_chain_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonconfigs.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_config_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektoninstallersets.yaml"          "$BASE_DIR"      "300-operator_v1alpha1_installer_set_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonpipelines.yaml"             "$BASE_DIR"      "300-operator_v1alpha1_pipeline_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonresults.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_result_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektontriggers.yaml"              "$BASE_DIR"      "300-operator_v1alpha1_trigger_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonpruners.yaml"               "$BASE_DIR"      "300-operator_v1alpha1_pruner_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonschedulers.yaml"            "$BASE_DIR"      "300-operator_v1alpha1_scheduler_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" "$BASE_DIR"      "300-operator_v1alpha1_multiclusterproxyaae_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_syncerservices.yaml"              "$BASE_DIR"      "300-operator_v1alpha1_syncerservice_crd.yaml"
-
-# kubernetes-only CRDs
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektondashboards.yaml"            "$K8S_DIR"       "300-operator_v1alpha1_dashboard_crd.yaml"
-
-# openshift-only CRDs
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_tektonaddons.yaml"                "$OPENSHIFT_DIR" "300-operator_v1alpha1_addon_crd.yaml"
-write_config_crd "${GENERATED_DIR}/operator.tekton.dev_openshiftpipelinesascodes.yaml"   "$OPENSHIFT_DIR" "300-operator_v1alpha1_openshiftpipelinesascode_crd.yaml"
-
-echo ""
-
-# Step 2: Assemble Helm chart CRDs
-echo "Step 2: Assembling Helm chart CRD files..."
+# Step 1: Assemble Helm chart CRDs
+echo "Step 1: Assembling Helm chart CRD files..."
 
 assemble_helm_crds \
   "${HELM_DIR}/kubernetes-crds.yaml" \
@@ -168,8 +119,8 @@ assemble_helm_crds \
   "operator.tekton.dev_tektonmulticlusterproxyaaes.yaml" \
   "operator.tekton.dev_syncerservices.yaml"
 
-# Step 3: Validate CRD sizes (etcd has a 256KB object size limit)
-echo "Step 3: Validating CRD sizes..."
+# Step 2: Validate CRD sizes (etcd has a 256KB object size limit)
+echo "Step 2: Validating CRD sizes..."
 
 MAX_SIZE=262144 # 256KB
 FAILED=0

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -225,5 +225,6 @@ type Hub struct {
 	// +optional
 	Params []Param `json:"params,omitempty"`
 	// options holds additions fields and these fields will be updated on the manifests
-	Options AdditionalOptions `json:"options"`
+	// +optional
+	Options AdditionalOptions `json:"options,omitempty"`
 }


### PR DESCRIPTION
# Changes

## 1. `hack/sync-helm-crds.sh` still regenerated dead manual CRD copies

`hack/sync-helm-crds.sh` still regenerated the manual per-component CRD
copies under `config/base/`, `config/kubernetes/base/`, and
`config/openshift/base/` (`300-operator_v1alpha1_<component>_crd.yaml`).

Commit 1ae0906b3 ("Cleanup manual CRDs and use generated CRDs in
kustomize") deleted those files and pointed every `kustomization.yaml`
at `config/base/generated-crds/*.yaml` directly, but never updated
this script to match. As a result, running `make sync-helm-crds` (a
documented prerequisite for any CRD-affecting API change) silently
resurrects ~4,700 lines of unreferenced, dead manifests on every use
— nothing in the repo consumes them (verified via `git grep` across
the tree; the only reference was the script itself).

This surfaced concretely in
https://github.com/tektoncd/operator/pull/3828, where an unrelated
`OpenShiftPipelinesAsCode` NetworkPolicy change ballooned into a
~8,900-line diff because the author correctly ran `make
sync-helm-crds` and the stale script did the rest.

This PR drops the dead `write_config_crd` step (and the now-unused
`BASE_DIR`/`K8S_DIR`/`OPENSHIFT_DIR` variables) so the script only
does what's still needed: assembling the Helm chart CRD bundles
(`charts/tekton-operator/templates/{kubernetes,openshift}-crds.yaml`)
from `config/base/generated-crds/`, which remains kustomize's sole
source of truth.

## 2. `TektonConfig.spec.hub.options` was implicitly required

While investigating #1, I found that running `make generate-crds` on
unmodified `main` (independent of any other PR) produces a
`required: [options]` entry under `spec.hub` in
`config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml` —
the file kustomize applies directly to clusters. That would reject
any `TektonConfig` CR that doesn't explicitly set `spec.hub.options`,
a breaking regression for existing users on upgrade.

Root cause: `Hub.Options` in `tektonconfig_types.go` was the only
`Options AdditionalOptions` field across all components missing the
`// +optional` marker (every other component — Pipeline, Trigger,
Chain, Dashboard, Addon, ManualApprovalGate, Pruner, Scheduler,
MulticlusterProxyAAE, SyncerService — has it). Almost certainly an
oversight from the earlier "fix: options field should be optional in
all components" work.

Fixed by adding `+optional`/`omitempty` to match every other
component, then regenerating `operator.tekton.dev_tektonconfigs.yaml`
and `charts/tekton-operator/templates/kubernetes-crds.yaml` via
`make sync-helm-crds`. The regeneration also picks up an unrelated,
already-correct doc fix: the `networkPolicy` field description now
mentions `TektonPipeline` alongside `TektonTrigger`.

`charts/tekton-operator/templates/openshift-crds.yaml` is
intentionally left untouched: it has independently drifted to bundle
only 3 of the 13 CRDs it should, and re-syncing it pulls in a large,
unrelated diff that deserves its own review/PR.

## Verification

- `bash -n hack/sync-helm-crds.sh` — syntax OK
- `go build ./pkg/...` and `go vet ./pkg/apis/operator/v1alpha1/...` — clean
- `go test ./pkg/apis/operator/v1alpha1/...` — no new failures (3
  pre-existing failures in `TestSetPACControllerDefaultSettings*`
  remain, caused by an unrelated `pipelines-as-code` v0.48.0→v0.48.1
  default `hub-catalog-type` change, already broken on unmodified
  `main`)
- Ran the fixed script against `main`: no `config/*/base/*_crd.yaml`
  files are recreated, and (before the hub.options fix)
  `kubernetes-crds.yaml` regenerated byte-for-byte identical to
  what's committed, confirming it was already in sync

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)