### PR TITLE
fix(common): propagate config to StatefulSets too

### DIFF
--- a/pkg/reconciler/common/testdata/test-add-configurations.yaml
+++ b/pkg/reconciler/common/testdata/test-add-configurations.yaml
@@ -24,3 +24,22 @@ spec:
           args: [
             "-git", "git"
           ]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  serviceName: postgres
+  selector:
+    matchLabels:
+      run: test-statefulset
+  template:
+    metadata:
+      labels:
+        run: test-statefulset
+    spec:
+      containers:
+        - image: busybox
+          name: postgres

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -725,27 +725,48 @@ func InjectLabelOnNamespace(label string) mf.Transformer {
 	}
 }
 
+// AddConfiguration propagates NodeSelector, Tolerations and PriorityClassName from
+// the component Config onto workload pod templates. It handles both Deployment and
+// StatefulSet so that components which run as a StatefulSet natively (e.g. postgres)
+// or switch between the two at runtime (e.g. horizontal scaling via StatefulsetOrdinals)
+// are covered without depending on transformer ordering.
 func AddConfiguration(config v1alpha1.Config) mf.Transformer {
+	applyConfig := func(spec *corev1.PodSpec) {
+		spec.NodeSelector = config.NodeSelector
+		spec.Tolerations = config.Tolerations
+		spec.PriorityClassName = config.PriorityClassName
+	}
+
 	return func(u *unstructured.Unstructured) error {
-		if u.GetKind() != "Deployment" {
-			return nil
-		}
+		switch u.GetKind() {
+		case "Deployment":
+			d := &appsv1.Deployment{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, d); err != nil {
+				return err
+			}
 
-		d := &appsv1.Deployment{}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, d)
-		if err != nil {
-			return err
-		}
+			applyConfig(&d.Spec.Template.Spec)
 
-		d.Spec.Template.Spec.NodeSelector = config.NodeSelector
-		d.Spec.Template.Spec.Tolerations = config.Tolerations
-		d.Spec.Template.Spec.PriorityClassName = config.PriorityClassName
+			unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+			if err != nil {
+				return err
+			}
+			u.SetUnstructuredContent(unstrObj)
 
-		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
-		if err != nil {
-			return err
+		case "StatefulSet":
+			s := &appsv1.StatefulSet{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, s); err != nil {
+				return err
+			}
+
+			applyConfig(&s.Spec.Template.Spec)
+
+			unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(s)
+			if err != nil {
+				return err
+			}
+			u.SetUnstructuredContent(unstrObj)
 		}
-		u.SetUnstructuredContent(unstrObj)
 
 		return nil
 	}

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -1033,6 +1033,15 @@ func TestAddConfiguration(t *testing.T) {
 	assert.Equal(t, d.Spec.Template.Spec.NodeSelector["foo"], config.NodeSelector["foo"])
 	assert.Equal(t, d.Spec.Template.Spec.Tolerations[0].Key, config.Tolerations[0].Key)
 	assert.Equal(t, d.Spec.Template.Spec.PriorityClassName, config.PriorityClassName)
+
+	// StatefulSets (e.g. tekton-results-postgres) must receive the same
+	// NodeSelector/Tolerations/PriorityClassName propagation as Deployments.
+	s := &appsv1.StatefulSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[1].Object, s)
+	assertNoError(t, err)
+	assert.Equal(t, s.Spec.Template.Spec.NodeSelector["foo"], config.NodeSelector["foo"])
+	assert.Equal(t, s.Spec.Template.Spec.Tolerations[0].Key, config.Tolerations[0].Key)
+	assert.Equal(t, s.Spec.Template.Spec.PriorityClassName, config.PriorityClassName)
 }
 
 func TestAddPSA(t *testing.T) {


### PR DESCRIPTION
AddConfiguration only set NodeSelector, Tolerations and PriorityClassName on Deployments, so the tekton-results-postgres StatefulSet never picked up TektonResult.spec.config.nodeSelector. It worked for other StatefulSet-based controllers only by luck of transformer ordering during Deployment-to-StatefulSet conversion.

Handle StatefulSet alongside Deployment so propagation no longer depends on that ordering.

Assisted-by: Claude Sonnet 5 (via Claude Code)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
