### PR TITLE
[cherry-pick: release-v0.79.x] build(release-pipeline): bump plumbing pin for release title fix

### DIFF
--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -56,6 +56,13 @@ spec:
   - name: components
     description: Components file to use
     default: components.yaml
+  - name: draft
+    description: |
+      Whether to create the GitHub release as a draft for manual review
+      (the default, preserving existing behavior). Set to "false" to
+      publish the release directly instead, e.g. for routine patch
+      releases that don't need manual curation.
+    default: "true"
   workspaces:
   - name: workarea
     description: The workspace where the repo will be cloned.
@@ -612,6 +619,8 @@ spec:
       value: $(tasks.prepare-draft-release.results.previous-tag)
     - name: rekor-uuid
       value: $(tasks.wait-for-chains.results.rekor-uuid)
+    - name: draft
+      value: $(params.draft)
     - name: source-subpath
       value: git
     - name: release-subpath

--- a/tekton/operator-release-pipeline.yaml
+++ b/tekton/operator-release-pipeline.yaml
@@ -596,7 +596,7 @@ spec:
       - name: url
         value: https://github.com/tektoncd/plumbing
       - name: revision
-        value: 7abffd25eb2e578e6698a9ff13470d04906f79e6
+        value: bc8a1039c385499f8b286b27d8b873308ca4f67c
       - name: pathInRepo
         value: tekton/resources/release/base/github_release_oci.yaml
     params:


### PR DESCRIPTION
# Changes

Manual cherry-pick of #3803 onto `release-v0.79.x`. The automatic cherry-pick bot failed on this branch:

```
CONFLICT (modify/delete): .tekton/release-patch.yaml deleted in HEAD and modified in b3fc7a412
```

`release-v0.79.x` doesn't have a `.tekton/` directory (it predates the Pipelines-as-Code release automation), so the `.tekton/release-patch.yaml` hunk from the second commit doesn't apply here. I dropped that hunk and kept the `tekton/operator-release-pipeline.yaml` changes from both commits, which apply cleanly:

* Bump the pinned `tektoncd/plumbing` revision used by `create-draft-release` from `7abffd2` to `bc8a103`, picking up the fix from tektoncd/plumbing#3519 that drops the redundant quoted title line from the release body and stops marking draft releases as `--prerelease`.
* Add a `draft` param to the `operator-release` Pipeline (default `"true"`, preserving current behavior) and wire it through to the `create-draft-release` task, so it can be explicitly set to `"false"` when running the pipeline manually on this branch.

# Submitter Checklist

* [x] Run `make test lint` before submitting a PR
* [ ] Includes tests (if functionality changed/added)
* [ ] Includes docs (if user facing)
* [x] Commit messages follow commit message best practices

# Release Notes

```
NONE
```

Made with [Cursor](https://cursor.com)