### PR TITLE
feat(chains): expose storage.oci.encoding-format in CRD

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -65,11 +65,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1202,11 +1672,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1316,6 +2256,8 @@ spec:
               storage.grafeas.noteid:
                 type: string
               storage.grafeas.projectid:
+                type: string
+              storage.oci.encoding-format:
                 type: string
               storage.oci.repository:
                 type: string
@@ -1773,6 +2715,8 @@ spec:
                   storage.grafeas.noteid:
                     type: string
                   storage.grafeas.projectid:
+                    type: string
+                  storage.oci.encoding-format:
                     type: string
                   storage.oci.repository:
                     type: string
@@ -6042,11 +6986,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -65,11 +65,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1396,11 +1866,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -1510,6 +2450,8 @@ spec:
               storage.grafeas.noteid:
                 type: string
               storage.grafeas.projectid:
+                type: string
+              storage.oci.encoding-format:
                 type: string
               storage.oci.repository:
                 type: string
@@ -1967,6 +2909,8 @@ spec:
                   storage.grafeas.noteid:
                     type: string
                   storage.grafeas.projectid:
+                    type: string
+                  storage.oci.encoding-format:
                     type: string
                   storage.oci.repository:
                     type: string
@@ -6021,11 +6965,481 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_manualapprovalgates.yaml
@@ -61,11 +61,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonchains.yaml
@@ -301,11 +301,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:
@@ -417,6 +889,8 @@ spec:
               storage.grafeas.noteid:
                 type: string
               storage.grafeas.projectid:
+                type: string
+              storage.oci.encoding-format:
                 type: string
               storage.oci.repository:
                 type: string

--- a/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonconfigs.yaml
@@ -374,6 +374,8 @@ spec:
                     type: string
                   storage.grafeas.projectid:
                     type: string
+                  storage.oci.encoding-format:
+                    type: string
                   storage.oci.repository:
                     type: string
                   storage.oci.repository.insecure:

--- a/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
+++ b/config/base/generated-crds/operator.tekton.dev_tektonpruners.yaml
@@ -253,11 +253,483 @@ spec:
                       Existing policies are removed on the next reconcile.
                     type: boolean
                   policies:
+                    additionalProperties:
+                      description: NetworkPolicySpec provides the specification of
+                        a NetworkPolicy
+                      properties:
+                        egress:
+                          description: |-
+                            egress is a list of egress rules to be applied to the selected pods. Outgoing traffic
+                            is allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+                            otherwise allows the traffic), OR if the traffic matches at least one egress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                              This type is beta-level in 1.8
+                            properties:
+                              ports:
+                                description: |-
+                                  ports is a list of destination ports for outgoing traffic.
+                                  Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              to:
+                                description: |-
+                                  to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all destinations (traffic not restricted by
+                                  destination). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the to list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ingress:
+                          description: |-
+                            ingress is a list of ingress rules to be applied to the selected pods.
+                            Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
+                            (and cluster policy otherwise allows the traffic), OR if the traffic source is
+                            the pod's local node, OR if the traffic matches at least one ingress rule
+                            across all of the NetworkPolicy objects whose podSelector matches the pod. If
+                            this field is empty then this NetworkPolicy does not allow any traffic (and serves
+                            solely to ensure that the pods it selects are isolated by default)
+                          items:
+                            description: |-
+                              NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+                              matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                            properties:
+                              from:
+                                description: |-
+                                  from is a list of sources which should be able to access the pods selected for this rule.
+                                  Items in this list are combined using a logical OR operation. If this field is
+                                  empty or missing, this rule matches all sources (traffic not restricted by
+                                  source). If this field is present and contains at least one item, this rule
+                                  allows traffic only if the traffic matches at least one item in the from list.
+                                items:
+                                  description: |-
+                                    NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                    fields are allowed
+                                  properties:
+                                    ipBlock:
+                                      description: |-
+                                        ipBlock defines policy on a particular IPBlock. If this field is set then
+                                        neither of the other fields can be.
+                                      properties:
+                                        cidr:
+                                          description: |-
+                                            cidr is a string representing the IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          type: string
+                                        except:
+                                          description: |-
+                                            except is a slice of CIDRs that should not be included within an IPBlock
+                                            Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                            Except values will be rejected if they are outside the cidr range
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - cidr
+                                      type: object
+                                    namespaceSelector:
+                                      description: |-
+                                        namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                        standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                        If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                        Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    podSelector:
+                                      description: |-
+                                        podSelector is a label selector which selects pods. This field follows standard label
+                                        selector semantics; if present but empty, it selects all pods.
+
+                                        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                        the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                        Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  ports is a list of ports which should be made accessible on the pods selected for
+                                  this rule. Each item in this list is combined using a logical OR. If this field is
+                                  empty or missing, this rule matches all ports (traffic not restricted by port).
+                                  If this field is present and contains at least one item, then this rule allows
+                                  traffic only if the traffic matches at least one port in the list.
+                                items:
+                                  description: NetworkPolicyPort describes a port
+                                    to allow traffic on
+                                  properties:
+                                    endPort:
+                                      description: |-
+                                        endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                        should be allowed by the policy. This field cannot be defined if the port field
+                                        is not defined or if the port field is defined as a named (string) port.
+                                        The endPort must be equal or greater than port.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        port represents the port on the given protocol. This can either be a numerical or named
+                                        port on a pod. If this field is not provided, this matches all port names and
+                                        numbers.
+                                        If present, only traffic on the specified protocol AND port will be matched.
+                                      x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                        If not specified, this field defaults to TCP.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        podSelector:
+                          description: |-
+                            podSelector selects the pods to which this NetworkPolicy object applies.
+                            The array of rules is applied to any pods selected by this field. An empty
+                            selector matches all pods in the policy's namespace.
+                            Multiple network policies can select the same set of pods. In this case,
+                            the ingress rules for each are combined additively.
+                            This field is optional. If it is not specified, it defaults to an empty selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        policyTypes:
+                          description: |-
+                            policyTypes is a list of rule types that the NetworkPolicy relates to.
+                            Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                            If this field is not specified, it will default based on the existence of ingress or egress rules;
+                            policies that contain an egress section are assumed to affect egress, and all policies
+                            (whether or not they contain an ingress section) are assumed to affect ingress.
+                            If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+                            Likewise, if you want to write a policy that specifies that no egress is allowed,
+                            you must specify a policyTypes value that include "Egress" (since such a policy would not include
+                            an egress section and would otherwise default to just [ "Ingress" ]).
+                            This field is beta-level in 1.8
+                          items:
+                            description: |-
+                              PolicyType string describes the NetworkPolicy type
+                              This type is beta-level in 1.8
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
                     description: |-
                       Policies merges with the operator's default NetworkPolicies by name.
                       A key matching a default policy name replaces that default entirely.
                       A key not matching any default is added alongside the defaults.
                       If nil or empty, all operator defaults are applied unchanged.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               options:

--- a/docs/TektonChain.md
+++ b/docs/TektonChain.md
@@ -96,6 +96,7 @@ spec:
   storage.gcs.bucket: #value
   storage.oci.repository: #value
   storage.oci.repository.insecure: #value (boolean - true/false)
+  storage.oci.encoding-format: #value (dsse or sigstore-bundle, default: dsse)
   storage.docdb.url: #value
   storage.docdb.mongo-server-url: #value
   storage.docdb.mongo-server-url-dir: #value

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -283,6 +283,7 @@ chain:
   storage.gcs.bucket: #value
   storage.oci.repository: #value
   storage.oci.repository.insecure: #value (boolean - true/false)
+  storage.oci.encoding-format: #value (dsse or sigstore-bundle, default: dsse)
   storage.docdb.url: #value
   storage.grafeas.projectid: #value
   storage.grafeas.noteid: #value

--- a/pkg/apis/operator/v1alpha1/tektonchain_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_types.go
@@ -108,6 +108,7 @@ type ChainProperties struct {
 	StorageGCSBucket              string `json:"storage.gcs.bucket,omitempty"`
 	StorageOCIRepository          string `json:"storage.oci.repository,omitempty"`
 	StorageOCIRepositoryInsecure  *bool  `json:"storage.oci.repository.insecure,omitempty"`
+	StorageOCIEncodingFormat      string `json:"storage.oci.encoding-format,omitempty"`
 	StorageDocDBURL               string `json:"storage.docdb.url,omitempty"`
 	StorageDocDBMongoServerURL    string `json:"storage.docdb.mongo-server-url,omitempty"`
 	StorageDocDBMongoServerURLDir string `json:"storage.docdb.mongo-server-url-dir,omitempty"`

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation.go
@@ -34,6 +34,7 @@ var (
 	allowedArtifactsStorage                         = sets.NewString("", "tekton", "oci", "gcs", "docdb", "grafeas", "kafka")
 	allowedControllerEnvs                           = sets.NewString("MONGO_SERVER_URL")
 	allowedBuildDefinitionType                      = sets.NewString("", "https://tekton.dev/chains/v2/slsa", "https://tekton.dev/chains/v2/slsa-tekton")
+	allowedStorageOCIEncodingFormat                 = sets.NewString("", "dsse", "sigstore-bundle")
 )
 
 func (tc *TektonChain) Validate(ctx context.Context) (errs *apis.FieldError) {
@@ -130,6 +131,10 @@ func (tcs *TektonChainSpec) ValidateChainConfig(path string) (errs *apis.FieldEr
 		if tcs.ArtifactsOCISigner != "x509" && tcs.ArtifactsOCISigner != "kms" {
 			errs = errs.Also(apis.ErrInvalidValue(tcs.ArtifactsOCISigner, path+".artifacts.oci.signer"))
 		}
+	}
+
+	if !allowedStorageOCIEncodingFormat.Has(tcs.StorageOCIEncodingFormat) {
+		errs = errs.Also(apis.ErrInvalidValue(tcs.StorageOCIEncodingFormat, path+".storage.oci.encoding-format"))
 	}
 
 	if !allowedX509SignerFulcioProvider.Has(tcs.X509SignerFulcioProvider) {

--- a/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonchain_validation_test.go
@@ -366,6 +366,44 @@ func Test_ValidateTektonChain_ConfigBuildDefinitionType(t *testing.T) {
 	}
 }
 
+func Test_ValidateTektonChain_InvalidStorageOCIEncodingFormat(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+	tc.Spec.Chain.ChainProperties.StorageOCIEncodingFormat = "unknown-format"
+	err := tc.Validate(context.TODO())
+	assert.Equal(t, "invalid value: unknown-format: spec.storage.oci.encoding-format", err.Error())
+}
+
+func Test_ValidateTektonChain_ValidStorageOCIEncodingFormat(t *testing.T) {
+	tc := &TektonChain{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chain",
+			Namespace: "namespace",
+		},
+		Spec: TektonChainSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+		},
+	}
+	for _, format := range []string{"dsse", "sigstore-bundle"} {
+		tc.Spec.Chain.ChainProperties.StorageOCIEncodingFormat = format
+		err := tc.Validate(context.TODO())
+		if err != nil {
+			t.Errorf("ValidateTektonChain.Validate() expected no error for encoding-format %q, but got: %v", format, err)
+		}
+	}
+}
+
 func Test_ValidateTektonChain_InvalidControllerEnv(t *testing.T) {
 	tc := &TektonChain{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
  tektoncd/chains#1691 added a new `storage.oci.encoding-format` config
  key that controls how Chains serializes OCI signatures and attestations:
  `dsse` (default, tag-based) or `sigstore-bundle` (OCI 1.1 Referrers API).

  This PR exposes that key through the operator so it can be set via the
  TektonChain and TektonConfig CRDs.

  ### What was added

  - **`ChainProperties.StorageOCIEncodingFormat`** (`tektonchain_types.go`)
    — new `string` field with JSON tag `"storage.oci.encoding-format,omitempty"`.
    The existing `AddConfigMapValues` transformer picks this up automatically
    via reflection — no changes to `transform.go` or `transformers.go`.

  - **CRD validation** (`tektonchain_validation.go`) — rejects values
    other than `""`, `"dsse"`, and `"sigstore-bundle"` at admission time.

  - **Validation tests** (`tektonchain_validation_test.go`) — invalid
    value is rejected; both valid values are accepted.

  - **Documentation** (`TektonChain.md`, `TektonConfig.md`) — field
    added to the example YAML.

  ### What was NOT changed

  - `transform.go` / `transformers.go` — not needed (reflection)
  - `tektonchain_defaults.go` — not needed (Chains defaults to `dsse`
    when the key is absent)
  - No new dependencies

  ### Related

  - tektoncd/chains#1691 — feat: add OCI 1.1 Referrers API support
  - tektoncd/chains#1831 — fix: forward RekorEntry to signature bundle
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
expose `storage.oci.encoding-format` config key in TektonChain and TektonConfig CRDs — allows configuring OCI 1.1 Referrers API storage via the operator
```


/kind feature