### PR TITLE
fix(kustomize): move platform-specific CRDs to shared base

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -44,4 +44,6 @@ resources:
 - generated-crds/operator.tekton.dev_tektonpruners.yaml
 - generated-crds/operator.tekton.dev_tektonresults.yaml
 - generated-crds/operator.tekton.dev_tektonschedulers.yaml
+- generated-crds/operator.tekton.dev_tektondashboards.yaml
+- generated-crds/operator.tekton.dev_tektonaddons.yaml
 - generated-crds/operator.tekton.dev_tektontriggers.yaml

--- a/config/kubernetes/base/kustomization.yaml
+++ b/config/kubernetes/base/kustomization.yaml
@@ -30,7 +30,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/
-- ../../base/generated-crds/operator.tekton.dev_tektondashboards.yaml
 - ../../webhooks/
 - operator_service.yaml
 - pipelinesascode.yaml

--- a/config/openshift/base/kustomization.yaml
+++ b/config/openshift/base/kustomization.yaml
@@ -52,7 +52,6 @@ patchesStrategicMerge:
 
 resources:
 - ../../base/
-- ../../base/generated-crds/operator.tekton.dev_tektonaddons.yaml
 - ../../webhooks
 - operator_service.yaml
 - operator_servicemonitor.yaml


### PR DESCRIPTION
# Changes

Newer kustomize versions enforce a security restriction that rejects
direct file references pointing outside the kustomization root.
`config/kubernetes/base` and `config/openshift/base` both referenced
CRD files via `../../base/generated-crds/...`, which violates that
restriction and caused `kustomize build` to silently fail during
releases (the error was swallowed because the pipeline does not set
`pipefail`).

This manifested as the `koparse` step failing with:
```
Expected images did not match: Images [...] were expected but missing.
```
because `ko resolve` received empty stdin (from the failed kustomize
pipe) and produced an empty `release.yaml`.

Move `tektondashboards` and `tektonaddons` CRDs from their platform-specific
`kustomization.yaml` files into `config/base/kustomization.yaml` where
`controller-gen` already writes all generated CRDs. The extra CRDs on
each platform are harmless — their reconcilers are platform-gated.

Root cause introduced by: 1ae0906 (Cleanup manual CRDs and use generated
CRDs in kustomize)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

Made with [Cursor](https://cursor.com)