### PR TITLE
fix(tektonconfig): stop logging requeue as error

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/tektonconfig.go
+++ b/pkg/reconciler/shared/tektonconfig/tektonconfig.go
@@ -408,6 +408,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tc *v1alpha1.TektonConfi
 
 	// Post-reconcile extension hooks
 	if err := r.extension.PostReconcile(ctx, tc); err != nil {
+		if err == v1alpha1.REQUEUE_EVENT_AFTER {
+			logger.Infow("Post-reconcile hook requested requeue", "error", err)
+			return err
+		}
 		logger.Errorw("Post-reconcile hook failed", "error", err)
 		return err
 	}


### PR DESCRIPTION
# Changes

Fixed `TektonConfig`'s `PostReconcile` step logging every expected "not ready yet" retry at ERROR level with a full stack trace. On a fresh install, the extension's `PostReconcile` hook polls dependent CRs (`TektonDashboard`, `TektonAddon`, `OpenShiftPipelinesAsCode`) that aren't ready yet, and signals this transient condition by returning the `v1alpha1.REQUEUE_EVENT_AFTER` sentinel — per this repo's convention that it means "retry later", not a failure. `ReconcileKind` was logging every such return as an error ("Post-reconcile hook failed"), repeating every ~10s until the dependency became ready and flooding the operator's logs during a routine install.

This change checks for the `v1alpha1.REQUEUE_EVENT_AFTER` sentinel before logging, matching the pattern already used elsewhere in this file (e.g. the `PreReconcile` hook) and throughout the reconciler package (e.g. `tektonpipeline`, `tektontrigger`, `manualapprovalgate`). When `PostReconcile` returns this sentinel, the log level is now Info instead of Error. The returned error value is unchanged in both branches, so requeue/retry behavior is identical before and after this change; only the log severity for this benign, expected condition changes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #3125