### PR TITLE
fix(tektonconfig): keep prune-per-resource=false in spec

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types.go
@@ -59,7 +59,7 @@ type Prune struct {
 	Disabled bool `json:"disabled"`
 	// apply the prune job to the individual resources
 	// +optional
-	PrunePerResource bool `json:"prune-per-resource,omitempty"`
+	PrunePerResource bool `json:"prune-per-resource"`
 	// The resources which need to be pruned
 	Resources []string `json:"resources,omitempty"`
 	// The number of resource to keep

--- a/pkg/apis/operator/v1alpha1/tektonconfig_types_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_types_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestPrune_PrunePerResourceJSONRoundTrip guards against the "prune-per-resource"
+// field being dropped when explicitly set to false. The admission webhook computes
+// a round-trip patch by marshaling a freshly unmarshaled copy of the request object
+// and diffing it against the original bytes; a `false` value on a field tagged
+// `omitempty` is indistinguishable from an unset field once marshaled, so the
+// webhook would emit a patch removing the key from the stored object.
+func TestPrune_PrunePerResourceJSONRoundTrip(t *testing.T) {
+	raw := []byte(`{"disabled":false,"prune-per-resource":false}`)
+
+	var p Prune
+	err := json.Unmarshal(raw, &p)
+	assert.NilError(t, err)
+	assert.Equal(t, p.PrunePerResource, false)
+
+	out, err := json.Marshal(p)
+	assert.NilError(t, err)
+
+	var roundTripped map[string]interface{}
+	err = json.Unmarshal(out, &roundTripped)
+	assert.NilError(t, err)
+
+	_, present := roundTripped["prune-per-resource"]
+	assert.Assert(t, present, "prune-per-resource key was dropped from marshaled JSON when false: %s", string(out))
+}


### PR DESCRIPTION
# Changes

Fixes a bug where setting `spec.pruner.prune-per-resource` to `false` on a `TektonConfig` CR caused the field to disappear from the stored spec after being applied.

The `PrunePerResource` field was tagged `json:"prune-per-resource,omitempty"`. Since Go's zero value for `bool` is `false`, `omitempty` dropped the key whenever the value was `false`. The operator's Knative-based mutating webhook computes a "round trip patch" before running `SetDefaults`: it diffs the raw admission request bytes against `json.Marshal(json.Unmarshal(bytes))`, and any key that disappears in that round trip becomes a JSON Patch "remove" op applied to the admitted object (see `vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/defaulting.go`, `roundTripPatch`). An explicit `false` was therefore stripped from the persisted `TektonConfig` spec on every apply.

Dropping `omitempty` fixes the round trip so the field survives. The existing `+optional` marker above the field keeps it optional in the generated CRD schema (confirmed no diff to `config/base/generated-crds` or the Helm chart CRDs after regenerating with `make generate-crds` and `hack/sync-helm-crds.sh`).

This only changes how the value is persisted: a missing key and an explicit `false` already decoded to the same Go zero value everywhere `PrunePerResource` is read (`pkg/reconciler/common/prune.go`), so there is no separate pruning behavior change beyond the field no longer vanishing from the spec.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fixed a bug where setting `spec.pruner.prune-per-resource: false` on a `TektonConfig` CR was dropped from the stored spec after being applied.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #3202