### PR TITLE
fix(tektonresult): default watcher logs_api from spec

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
@@ -41,6 +41,14 @@ func (c *Result) setDefaults() {
 		c.RouteTLSTermination = "edge"
 	}
 
+	// The Watcher only forwards logs to the API server when its own
+	// logs_api flag is set; enabling the API server's logs_api alone does
+	// not do this. Default the Watcher to match unless the user set
+	// watcher.logs_api explicitly.
+	if c.LogsAPI != nil && c.Watcher.LogsAPI == nil {
+		c.Watcher.LogsAPI = c.LogsAPI
+	}
+
 	c.setPerformanceDefaults()
 }
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
@@ -127,6 +127,98 @@ func TestResult_SetDefaultsRoutes(t *testing.T) {
 	}
 }
 
+func TestResult_SetDefaultsWatcherLogsAPI(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *Result
+		want *Result
+	}{
+		{
+			name: "propagates enabled logs_api to watcher when unset",
+			r: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:      ptr.Bool(true),
+					RouteEnabled: ptr.Bool(true),
+				},
+			},
+			want: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:             ptr.Bool(true),
+					RouteEnabled:        ptr.Bool(true),
+					RouteTLSTermination: "edge",
+				},
+				Watcher: ResultsWatcherProperties{
+					LogsAPI: ptr.Bool(true),
+				},
+			},
+		},
+		{
+			name: "propagates disabled logs_api to watcher when unset",
+			r: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:      ptr.Bool(false),
+					RouteEnabled: ptr.Bool(true),
+				},
+			},
+			want: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:             ptr.Bool(false),
+					RouteEnabled:        ptr.Bool(true),
+					RouteTLSTermination: "edge",
+				},
+				Watcher: ResultsWatcherProperties{
+					LogsAPI: ptr.Bool(false),
+				},
+			},
+		},
+		{
+			name: "does not override an explicit watcher logs_api",
+			r: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:      ptr.Bool(true),
+					RouteEnabled: ptr.Bool(true),
+				},
+				Watcher: ResultsWatcherProperties{
+					LogsAPI: ptr.Bool(false),
+				},
+			},
+			want: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					LogsAPI:             ptr.Bool(true),
+					RouteEnabled:        ptr.Bool(true),
+					RouteTLSTermination: "edge",
+				},
+				Watcher: ResultsWatcherProperties{
+					LogsAPI: ptr.Bool(false),
+				},
+			},
+		},
+		{
+			name: "leaves watcher logs_api unset when API logs_api is unset",
+			r: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled: ptr.Bool(true),
+				},
+			},
+			want: &Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(true),
+					RouteTLSTermination: "edge",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.r.setDefaults()
+			if d := cmp.Diff(tt.want, tt.r); d != "" {
+				t.Errorf("failed to set defaults %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
 func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 	threeReplicas := int32(3)
 	threeBuckets := uint(3)


### PR DESCRIPTION
# Changes

Fixes a bug where setting `spec.logs_api: true` on a `TektonResult` (or via `TektonConfig`) enabled the `LOGS_API` env var on the `tekton-results-api` deployment, but did not propagate to the `tekton-results-watcher` deployment's separate `-logs_api` flag (which defaults to `false`). As a result, users following the documented example of only setting the top-level `logs_api` ended up with an API server that had logging enabled but a Watcher that never forwarded logs, so logs were never stored.

`Result.setDefaults()` now defaults `Result.Watcher.LogsAPI` from the top-level `ResultsAPIProperties.LogsAPI` whenever the user has not explicitly set `spec.watcher.logs_api`, mirroring the existing `RouteEnabled`/`RouteTLSTermination` defaulting in the same function. An explicit `spec.watcher.logs_api` value is never overridden.

Note: this defaulting runs wherever `Result.setDefaults()` runs today (i.e. when a `TektonResult` is created/updated via `TektonConfig`, the documented install path). `TektonResult.SetDefaults` does not call `Result.setDefaults()`, so a CR applied directly as a standalone `kind: TektonResult` does not get this (or the pre-existing `RouteEnabled`) default — that gap predates this change and is not addressed here.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix TektonResult so that setting `spec.logs_api: true` also defaults the tekton-results-watcher's log forwarding flag, ensuring TaskRun/PipelineRun logs are actually stored when the top-level `logs_api` option is enabled.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #2600