### PR TITLE
ci(bump-payload): limit PRs to OSP branches

### DIFF
--- a/.github/scripts/osp-supported-operator-branches.sh
+++ b/.github/scripts/osp-supported-operator-branches.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Print a JSON array of OSP-supported operator release branches
+# (branches.operator.upstream from openshift-pipelines/hack release configs).
+# Source: https://github.com/openshift-pipelines/hack/tree/main/config/downstream/releases
+#
+# Fetches only the release YAML files via the GitHub Contents API (not the
+# full repo tarball). Set GITHUB_TOKEN to avoid anonymous API rate limits.
+set -euo pipefail
+
+API_URL="https://api.github.com/repos/openshift-pipelines/hack/contents/config/downstream/releases"
+
+AUTH_ARGS=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+BRANCHES=$(
+  curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    "${AUTH_ARGS[@]}" \
+    "${API_URL}" \
+    | jq -r '.[].download_url // empty' \
+    | while read -r url; do
+        [[ -n "${url}" ]] || continue
+        curl -fsSL "${url}"
+      done \
+    | awk '
+      /^[[:space:]]*operator:[[:space:]]*$/ { in_op=1; next }
+      in_op && /^[[:space:]]*upstream:[[:space:]]*/ {
+        sub(/^[[:space:]]*upstream:[[:space:]]*/, "")
+        gsub(/[[:space:]].*/, "")
+        if ($0 ~ /^release-/) print
+        in_op=0
+      }
+      in_op && NF && !/^[[:space:]]*#/ && !/^[[:space:]]*upstream:/ { in_op=0 }
+    ' \
+    | sort -u
+)
+
+[[ -n "${BRANCHES}" ]] || {
+  echo "error: no OSP operator release branches found" >&2
+  exit 1
+}
+
+printf '%s\n' "${BRANCHES}" | jq -R . | jq -sc .

--- a/.github/workflows/bump-payload-on-releases.yaml
+++ b/.github/workflows/bump-payload-on-releases.yaml
@@ -11,14 +11,27 @@ permissions: {}
 jobs:
   build-release-matrix:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     if: github.repository_owner == 'tektoncd'  # do not run this elsewhere
     steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        ref: main
+        persist-credentials: false
+        sparse-checkout: |
+          .github/scripts/osp-supported-operator-branches.sh
     - id: set-matrix
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        SUPPORTED_BRANCHES=$(git ls-remote --heads https://github.com/tektoncd/operator 'release-*' | awk '{ print $2 }' | cut -d/ -f3- | grep '^release-v[0-9]\+\.[0-9]\+' | grep -v '^release-v0\.2[0-9]\|^release-v0\.5[0-9]\|^release-v0\.6[0-7]' | jq -cRs 'split("\n")[:-1]')
-        echo "Supported Branches: ${SUPPORTED_BRANCHES}"
-        echo "branches=${SUPPORTED_BRANCHES}" >> $GITHUB_OUTPUT
+        # Branch matrix comes from OSP release configs (operator.upstream), not
+        # every tektoncd/operator release-* branch. Source of truth:
+        # https://github.com/openshift-pipelines/hack/tree/main/config/downstream/releases
+        chmod +x .github/scripts/osp-supported-operator-branches.sh
+        SUPPORTED_BRANCHES=$(.github/scripts/osp-supported-operator-branches.sh)
+        echo "Supported Branches (OSP): ${SUPPORTED_BRANCHES}"
+        echo "branches=${SUPPORTED_BRANCHES}" >> "$GITHUB_OUTPUT"
     outputs:
       branches: ${{ steps.set-matrix.outputs.branches }}
   bump-payloads:
@@ -30,7 +43,6 @@ jobs:
     strategy:
       matrix:
         branch: ${{ fromJSON(needs.build-release-matrix.outputs.branches) }}
-        # branch: [release-v0.62.x, release-v0.63.x]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:


### PR DESCRIPTION
Derive the release-branch matrix from openshift-pipelines/hack downstream release configs (operator.upstream) instead of listing every tektoncd/operator release-* branch. Fetch only those YAML files via the GitHub API. Avoids bump PRs for unsupported branches such as release-v0.76.x.


Assisted-by: Composer (via Cursor)

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
