### PR TITLE
fix(common): Preserve param substitution in step images during replacement

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -443,6 +443,10 @@ func replaceStepsImages(steps []interface{}, override map[string]string, logger 
 			}
 			continue
 		}
+		if existing, ok := step["image"].(string); ok && (strings.Contains(existing, "$(params.") || strings.Contains(existing, "$(inputs.params.")) {
+			logger.Debugf("Skipping image replacement for step %s, image contains param substitution", name)
+			continue
+		}
 		step["image"] = image
 	}
 }

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -223,6 +223,20 @@ func TestReplaceImages(t *testing.T) {
 		assertStatefulSetContainersHasImage(t, newManifest.Resources(), "sidecar", "busybox")
 	})
 
+	t.Run("skip replacement when step image contains param substitution", func(t *testing.T) {
+		image := "foo.bar/image/builder"
+		images := map[string]string{
+			"build": image,
+		}
+		testData := path.Join("testdata", "test-replace-addon-image.yaml")
+
+		manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+		assertNoError(t, err)
+		newManifest, err := manifest.Transform(TaskImages(context.TODO(), images))
+		assertNoError(t, err)
+		assertTaskImage(t, newManifest.Resources(), "build", "$(inputs.params.BUILDER_IMAGE)")
+	})
+
 	t.Run("replace task addons param image", func(t *testing.T) {
 		paramName := ParamPrefix + "builder_image"
 		image := "foo.bar/image/buildah"


### PR DESCRIPTION
# Changes

The replaceStepsImages transformer unconditionally overwrites step images with pinned digests from environment variables. This breaks tasks like maven that use  in the image field
to allow users to select a Java version at runtime.

Add a guard to skip image replacement when the existing step image contains Tekton parameter references, so that parameter substitution is preserved and resolved correctly at runtime.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


# Release Notes

```release-note
Fix operator image replacement overwriting parameter substitution in Task step images
```
