### PR TITLE
fix: use infra.tekton.dev for component release fetches

### DIFF
--- a/hack/fetch-releases.sh
+++ b/hack/fetch-releases.sh
@@ -43,15 +43,15 @@ release_yaml() {
     case $version in
       nightly)
         dirVersion="0.0.0-nightly"
-        url="https://storage.googleapis.com/tekton-releases-nightly/${comp}/latest/${releaseFileName}.yaml"
+        url="https://infra.tekton.dev/tekton-nightly/${comp}/latest/${releaseFileName}.yaml"
         ;;
       latest)
         dirVersion="0.0.0-latest"
-        url="https://storage.googleapis.com/tekton-releases/${comp}/latest/${releaseFileName}.yaml"
+        url="https://infra.tekton.dev/tekton-releases/${comp}/latest/${releaseFileName}.yaml"
         ;;
       *)
         dirVersion=${version//v}
-        url="https://storage.googleapis.com/tekton-releases/${comp}/previous/${version}/${releaseFileName}.yaml"
+        url="https://infra.tekton.dev/tekton-releases/${comp}/previous/${version}/${releaseFileName}.yaml"
         ;;
     esac
 
@@ -83,7 +83,7 @@ release_yaml() {
     # create a directory
     mkdir -p ${dirPath} || true
 
-    http_response=$(curl -s -o ${dest} -w "%{http_code}" ${url})
+    http_response=$(curl -s -L -o ${dest} -w "%{http_code}" ${url})
     echo url: ${url}
 
     if [[ $http_response != "200" ]]; then


### PR DESCRIPTION
## Summary

- Fixes `ko-resolve` CI failure in #3899 caused by `get-releases` returning 404 for pipeline v1.0.4 and chains v0.25.2
- Replaces legacy `storage.googleapis.com` URLs with `infra.tekton.dev` in `hack/fetch-releases.sh`, matching `main`
- Follows redirects with `curl -L`

## Test plan

- [x] Verified locally: `make TARGET=kubernetes get-releases` succeeds with pipeline v1.0.4 and chains v0.25.2
- [ ] CI `ko-resolve` job passes after merge
- [ ] Re-run CI on #3899 after this is merged