### PR TITLE
[release-v0.81.x] Security: Fix GovCloud Go module vulnerability (compress GHSA-259r-337f-4rfw)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.0.0 // indirect
 	github.com/lestrrat-go/dsig-secp256k1 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -839,8 +839,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/konflux-ci/tekton-kueue v0.3.1 h1:QaK7u7kVJXPHpP4X+aJ8b6m47gy2yiNBQyI6MV1UY0s=
 github.com/konflux-ci/tekton-kueue v0.3.1/go.mod h1:5k6DNmxgcJfhVhHG8iIC0vOeU4xL1GLWQ9tMSp9jE3E=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -838,7 +838,7 @@ github.com/kballard/go-shellquote
 # github.com/kelseyhightower/envconfig v1.4.0
 ## explicit
 github.com/kelseyhightower/envconfig
-# github.com/klauspost/compress v1.18.6
+# github.com/klauspost/compress v1.18.7
 ## explicit; go 1.24
 github.com/klauspost/compress
 github.com/klauspost/compress/fse


### PR DESCRIPTION
# Changes

Fix `github.com/klauspost/compress` vulnerability identified in GovCloud
FedRAMP compliance scan (SRVKP-13173).

| CVE/Advisory | Package | Previous | Fixed |
|---|---|---|---|
| GHSA-259r-337f-4rfw | github.com/klauspost/compress | v1.18.6 | v1.18.7 |

> Note: The other four CVEs from SRVKP-13178 / SRVKP-13179 (go-chi/chi,
> sigstore-go, cel-go, otel) are already fixed in this branch.

### Jira Issues

SRVKP-13173

### Vulnerability Scan

* **Tool**: govulncheck@v1.6.0, GOTOOLCHAIN=go1.26.5

### Test Results

**Status**: ✅ All tests passed
**Command**: `go test -short ./pkg/...`

### Risk Assessment

**Low** — Patch bump to one indirect Go module dependency.

# Submitter Checklist

* Run `make test lint` before submitting a PR
* Includes tests (if functionality changed/added)
* Includes docs (if user facing)
* Commit messages follow commit message best practices

# Release Notes

```
Security: bump github.com/klauspost/compress to v1.18.7 (GHSA-259r-337f-4rfw)
```

---

🤖 Generated by CVE Fixer Workflow

Made with [Cursor](https://cursor.com)