### PR TITLE
feat(results): Add unit test for StatefulSet conversion and buckets auto-defaulting parity with Pipeline

### DIFF
--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -296,19 +296,19 @@ spec:
     statefulset-ordinals: false
 
 ```
-These fields are optional and there is no default values. If user passes them, operator will include most of fields into the deployment `tekton-results-watcher` under the container `watcher` as arguments(duplicate name? No, container and deployment has the same name), otherwise result watcher controller's default values will be considered. and `buckets` field is updated into `tekton-results-config-leader-election` config-map under the namespace `tekton-pipelines`.
+These fields are optional and there is no default values. If user passes them, operator will include most of fields into the `tekton-results-watcher` workload (Deployment by default, or StatefulSet when `statefulset-ordinals` is enabled) under the container `watcher` as arguments, otherwise results watcher controller's default values will be considered. The `buckets` field is updated into `tekton-results-config-leader-election` config-map under the namespace `tekton-pipelines`.
 
 * `disable-ha` - enable or disable ha feature, defaults in results watcher controller is `disable-ha=false`
-* `buckets` - buckets is the number of buckets used to partition key space of each reconciler. If this number is M and the replica number of the controller is N, the N replicas will compete for the M buckets. The owner of a bucket will take care of the reconciling for the keys partitioned into that bucket. The maximum value of `buckets` at this time is `10`. default value in pipeline controller is `1`
-* `replicas` - results watcher controller deployment replicas count
-* `statefulset-ordinals` - enables StatefulSet Ordinals mode for the Tekton Results Watcher Controller. When set to true, the Results Watcher Controller is deployed as a StatefulSet, allowing for multiple replicas to be configured with a load-balancing mode. This ensures that the load is evenly distributed across replicas, and the number of buckets is enforced to match the number of replicas.
-  Moreover, There are two mechanisms available for scaling Results Watcher Controller horizontally:
+* `buckets` - buckets is the number of buckets used to partition key space of each reconciler. If this number is M and the replica number of the controller is N, the N replicas will compete for the M buckets. The owner of a bucket will take care of the reconciling for the keys partitioned into that bucket. The maximum value of `buckets` at this time is `10`. Default value in results watcher controller is `1`. When `statefulset-ordinals` is enabled and `replicas` is greater than 1, `buckets` is automatically defaulted to match `replicas` (consistent with Pipeline's behavior).
+* `replicas` - results watcher controller replicas count
+* `statefulset-ordinals` - enables StatefulSet Ordinals mode for the Tekton Results Watcher Controller. When set to true, the Results Watcher Controller is deployed as a StatefulSet instead of a Deployment, allowing for multiple replicas to be configured with a load-balancing mode. This ensures that the load is evenly distributed across replicas, and the number of buckets is enforced to match the number of replicas.
+Moreover, There are two mechanisms available for scaling Results Watcher Controller horizontally:
 - Using leader election, which allows for failover, but can result in hot-spotting.
 - Using StatefulSet ordinals, which doesn't allow for failover, but guarantees load is evenly spread across replicas.
 
 
 > #### Note:
-> * if you modify or remove any of the performance properties, `tekton-results-watcher` deployment and `tekton-results-config-leader-election` config-map (if `buckets` changed) will be updated, and `tekton-results-watcher` pods will be recreated
+> * If you modify or remove any of the performance properties, the `tekton-results-watcher` workload (Deployment or StatefulSet) and `tekton-results-config-leader-election` config-map (if `buckets` changed) will be updated, and `tekton-results-watcher` pods will be recreated
 
 ### Tekton Result Watcher Configuration
 

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
@@ -25,6 +25,7 @@ func (tp *TektonResult) SetDefaults(ctx context.Context) {
 	if tp.Spec.TLSHostnameOverride != "" {
 		tp.Spec.TLSHostnameOverride = ""
 	}
+	tp.Spec.Result.setPerformanceDefaults()
 }
 
 // Sets default values of Result
@@ -38,5 +39,18 @@ func (c *Result) setDefaults() {
 
 	if c.RouteTLSTermination == "" {
 		c.RouteTLSTermination = "edge"
+	}
+
+	c.setPerformanceDefaults()
+}
+
+func (c *Result) setPerformanceDefaults() {
+	// Statefulset Ordinals
+	// if StatefulSet Ordinals mode, buckets should be equal to replicas
+	if c.Performance.StatefulsetOrdinals != nil && *c.Performance.StatefulsetOrdinals {
+		if c.Performance.Replicas != nil && *c.Performance.Replicas > 1 {
+			replicas := uint(*c.Performance.Replicas)
+			c.Performance.Buckets = &replicas
+		}
 	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
@@ -60,6 +60,32 @@ func TestTektonResult_SetDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "SetDefaults auto-defaults buckets when statefulset ordinals enabled",
+			Spec: TektonResultSpec{
+				Result: Result{
+					Performance: PerformanceProperties{
+						PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+							StatefulsetOrdinals: ptr.Bool(true),
+						},
+						Replicas: func() *int32 { r := int32(3); return &r }(),
+					},
+				},
+			},
+			want: TektonResultSpec{
+				Result: Result{
+					Performance: PerformanceProperties{
+						PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+							StatefulsetOrdinals: ptr.Bool(true),
+						},
+						Replicas: func() *int32 { r := int32(3); return &r }(),
+						PerformanceLeaderElectionConfig: PerformanceLeaderElectionConfig{
+							Buckets: func() *uint { b := uint(3); return &b }(),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -98,5 +124,165 @@ func TestResult_SetDefaultsRoutes(t *testing.T) {
 
 	if d := cmp.Diff(want, r); d != "" {
 		t.Errorf("failed to set defaults %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
+	threeReplicas := int32(3)
+	threeBuckets := uint(3)
+
+	tests := []struct {
+		name string
+		in   Result
+		want Result
+	}{
+		{
+			name: "statefulset-ordinals true, replicas 3, no buckets → buckets defaults to 3",
+			in: Result{
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: &threeReplicas,
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: &threeReplicas,
+					PerformanceLeaderElectionConfig: PerformanceLeaderElectionConfig{
+						Buckets: &threeBuckets,
+					},
+				},
+			},
+		},
+		{
+			name: "statefulset-ordinals false → buckets not auto-set",
+			in: Result{
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(false),
+					},
+					Replicas: &threeReplicas,
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(false),
+					},
+					Replicas: &threeReplicas,
+				},
+			},
+		},
+		{
+			name: "statefulset-ordinals true, replicas 1 → buckets not auto-set",
+			in: Result{
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: func() *int32 { r := int32(1); return &r }(),
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: func() *int32 { r := int32(1); return &r }(),
+				},
+			},
+		},
+		{
+			name: "statefulset-ordinals nil → buckets not auto-set",
+			in: Result{
+				Performance: PerformanceProperties{
+					Replicas: &threeReplicas,
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					Replicas: &threeReplicas,
+				},
+			},
+		},
+		{
+			name: "statefulset-ordinals true, replicas nil → buckets not auto-set",
+			in: Result{
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "statefulset-ordinals true, replicas 3, buckets already 5 → buckets overridden to 3",
+			in: Result{
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: &threeReplicas,
+					PerformanceLeaderElectionConfig: PerformanceLeaderElectionConfig{
+						Buckets: func() *uint { b := uint(5); return &b }(),
+					},
+				},
+			},
+			want: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
+					RouteTLSTermination: "edge",
+				},
+				Performance: PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+					Replicas: &threeReplicas,
+					PerformanceLeaderElectionConfig: PerformanceLeaderElectionConfig{
+						Buckets: &threeBuckets,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.in.setDefaults()
+			if d := cmp.Diff(tt.want, tt.in); d != "" {
+				t.Errorf("Result.setDefaults() buckets auto-defaulting failed: %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }

--- a/pkg/reconciler/common/testdata/test-convert-result-deployment-to-statefulset.yaml
+++ b/pkg/reconciler/common/testdata/test-convert-result-deployment-to-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-watcher
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-watcher
+    app.kubernetes.io/part-of: tekton-results
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-watcher
+  template:
+    metadata:
+      labels:
+        app: tekton-results-watcher
+        app.kubernetes.io/name: tekton-results-watcher
+    spec:
+      serviceAccountName: tekton-results-watcher
+      containers:
+      - name: watcher
+        image: ghcr.io/tektoncd/results/watcher:latest
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: tekton-results-config-logging
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-results-config-leader-election
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: tekton-results-config-observability
+        - name: METRICS_DOMAIN
+          value: tekton.dev/results
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tekton-results-watcher
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-watcher
+    app.kubernetes.io/part-of: tekton-results
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+  - name: profiling
+    port: 8008
+  selector:
+    app.kubernetes.io/name: tekton-results-watcher

--- a/pkg/reconciler/kubernetes/tektonresult/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/transform_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tektonresult
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/ptr"
 )
 
 func Test_enablePVCLogging(t *testing.T) {
@@ -711,4 +713,98 @@ func containsArg(args []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestUpdateStatefulSetOrdinalsForResults(t *testing.T) {
+	fixtureReplicas := int32(3)
+	cr := &v1alpha1.TektonResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "result",
+			Namespace: "tekton-pipelines",
+		},
+		Spec: v1alpha1.TektonResultSpec{
+			CommonSpec: v1alpha1.CommonSpec{
+				TargetNamespace: "tekton-pipelines",
+			},
+			Result: v1alpha1.Result{
+				Performance: v1alpha1.PerformanceProperties{
+					PerformanceStatefulsetOrdinalsConfig: v1alpha1.PerformanceStatefulsetOrdinalsConfig{
+						StatefulsetOrdinals: ptr.Bool(true),
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	manifest, err := common.Fetch("../../common/testdata/test-convert-result-deployment-to-statefulset.yaml")
+	if err != nil {
+		t.Fatalf("Failed to fetch test data: %v", err)
+	}
+
+	r := &Reconciler{extension: common.NoExtension(ctx)}
+	err = r.transform(ctx, &manifest, cr)
+	if err != nil {
+		t.Fatalf("Error applying transformers: %v", err)
+	}
+
+	foundStatefulSet := false
+	for _, resource := range manifest.Resources() {
+		if resource.GetKind() == "StatefulSet" && resource.GetName() == tektonResultWatcherName {
+			foundStatefulSet = true
+
+			sts := &appsv1.StatefulSet{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(resource.Object, sts); err != nil {
+				t.Fatalf("Failed to convert resource to StatefulSet: %v", err)
+			}
+
+			if sts.Spec.Replicas == nil || *sts.Spec.Replicas != fixtureReplicas {
+				t.Errorf("Expected StatefulSet replicas to be %d, got %v", fixtureReplicas, sts.Spec.Replicas)
+			}
+
+			if sts.Spec.ServiceName != tektonResultWatcherServiceName {
+				t.Errorf("Expected StatefulSet serviceName to be %s, got %s", tektonResultWatcherServiceName, sts.Spec.ServiceName)
+			}
+
+			foundOrdinalEnv := false
+			foundServiceEnv := false
+			for _, container := range sts.Spec.Template.Spec.Containers {
+				for _, env := range container.Env {
+					if env.Name == tektonResultWatcherStatefulControllerOrdinal {
+						foundOrdinalEnv = true
+						if env.ValueFrom == nil || env.ValueFrom.FieldRef == nil || env.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+							t.Errorf("Expected %s to use fieldRef metadata.name", tektonResultWatcherStatefulControllerOrdinal)
+						}
+					}
+					if env.Name == tektonResultWatcherStatefulServiceName {
+						foundServiceEnv = true
+						if env.Value != tektonResultWatcherServiceName {
+							t.Errorf("Expected %s value to be %s, got %s", tektonResultWatcherStatefulServiceName, tektonResultWatcherServiceName, env.Value)
+						}
+					}
+				}
+			}
+
+			if !foundOrdinalEnv {
+				t.Errorf("Expected to find environment variable %s", tektonResultWatcherStatefulControllerOrdinal)
+			}
+
+			if !foundServiceEnv {
+				t.Errorf("Expected to find environment variable %s", tektonResultWatcherStatefulServiceName)
+			}
+
+			break
+		}
+	}
+
+	if !foundStatefulSet {
+		t.Error("Expected to find a StatefulSet in the transformed manifest, but none was found")
+	}
+
+	for _, resource := range manifest.Resources() {
+		if resource.GetKind() == "Deployment" && resource.GetName() == tektonResultWatcherName {
+			t.Error("Expected Deployment to be removed from manifest")
+			break
+		}
+	}
 }


### PR DESCRIPTION
## Summary
For Part 1 of SRVKP-13094 refer [this](https://docs.google.com/document/d/1-IZKGmRXNfjEzO0opaljyAt9_joHjar6tTrE09M0zrk/edit?usp=sharing) doc.
Hardens the existing Results watcher HA support (Part 2 of SRVKP-13094) by closing two gaps found during investigation:

- **Missing unit test for StatefulSet conversion (2.1):** The Chains reconciler has `TestUpdateStatefulSetOrdinalsForChains` that exercises the full transform pipeline, but Results had no equivalent - the only coverage was an e2e test requiring a live cluster. Added `TestUpdateStatefulSetOrdinalsForResults` that builds a `TektonResult` CR with `StatefulsetOrdinals=true`, runs it through `Reconciler.transform()` (the production code path), and asserts the watcher Deployment becomes a StatefulSet with the correct `serviceName`, `STATEFUL_CONTROLLER_ORDINAL` (via `fieldRef: metadata.name`), and `STATEFUL_SERVICE_NAME` env vars.

- **Missing buckets/replicas auto-defaulting (2.2):** Pipeline's `tektonpipeline_defaults.go` auto-sets `Buckets = Replicas` when `StatefulsetOrdinals` is enabled and `Replicas > 1`. Results had no equivalent, forcing users to manually set both fields to matching values or get a validation error. Added the same defaulting logic to `Result.setPerformanceDefaults()` and wired it into `TektonResult.SetDefaults()` for direct CR usage.

## Changes

| File | What |
|---|---|
| `pkg/reconciler/common/testdata/test-convert-result-deployment-to-statefulset.yaml` | New fixture YAML (mirrors Chain's equivalent) |
| `pkg/reconciler/kubernetes/tektonresult/transform_test.go` | `TestUpdateStatefulSetOrdinalsForResults` - exercises `Reconciler.transform()` with CR-gated `StatefulsetOrdinals` check |
| `pkg/apis/operator/v1alpha1/tektonresult_defaults.go` | `setPerformanceDefaults()` - auto-sets `Buckets = Replicas` when ordinals enabled; wired into `SetDefaults()` |
| `pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go` | 9 test cases: webhook-level defaulting + 6 sub-tests for buckets auto-defaulting coverage |
| `docs/TektonResult.md` | Documents the new auto-defaulting behavior for `buckets` |

## Design decisions

1. **`SetDefaults()` only wires performance defaults, not route defaults.** Previously `TektonResult.SetDefaults()` never called `Result.setDefaults()`. Calling the full `setDefaults()` would also trigger route defaults (`RouteEnabled=true` on OpenShift), which could change behavior for direct `TektonResult` CRs that previously left `RouteEnabled` unset. To avoid this out-of-scope side effect, only `setPerformanceDefaults()` is wired into `SetDefaults()`. Route defaults continue to fire through `TektonConfig.SetDefaults()` to `Result.setDefaults()`, which is the primary usage path.

2. **Chain has the same missing auto-defaulting.** `tektonchain_defaults.go` has no equivalent buckets auto-defaulting either. This is intentionally left for a separate ticket to keep this PR focused on Results parity.

## Known limitations

- `replicas=1` + `statefulset-ordinals=true` + no `buckets` set still results in a validation error. This matches Pipeline's behavior - auto-defaulting only fires for `replicas > 1`.
- When `buckets` is explicitly set to a value different from `replicas`, the defaulting silently overrides it to match `replicas`. This is intentional parity with Pipeline.

## Test plan

- [x] `TestUpdateStatefulSetOrdinalsForResults` - full `Reconciler.transform()` pipeline with `StatefulsetOrdinals=true`
- [x] `TestTektonResult_SetDefaults` - 3 sub-tests including buckets auto-defaulting on the webhook path
- [x] `TestResult_SetDefaultsBucketsAutoDefaulting` - 6 sub-tests:
  - `ordinals=true, replicas=3, no buckets` - buckets defaults to 3
  - `ordinals=false` - buckets not auto-set
  - `ordinals=true, replicas=1` - buckets not auto-set
  - `ordinals=nil` - buckets not auto-set
  - `ordinals=true, replicas=nil` - buckets not auto-set (nil safety)
  - `ordinals=true, replicas=3, buckets=5` - buckets overridden to 3 (parity with Pipeline)
- [x] All existing tests in both packages pass
- [x] `gofmt` and `go vet` clean

/kind feature

## Release Note
```
Add buckets auto-defaulting for Results watcher when StatefulSet ordinals are enabled.
```