### PR TITLE
feat(openshift): add ServiceMonitor for remote resolvers

### DIFF
--- a/cmd/openshift/operator/kodata/openshift-monitoring/04-pipeline-resolvers-monitoring.yaml
+++ b/cmd/openshift/operator/kodata/openshift-monitoring/04-pipeline-resolvers-monitoring.yaml
@@ -1,0 +1,35 @@
+---
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: resolvers
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: openshift-pipelines-resolvers-monitor
+  namespace: tekton-pipelines
+spec:
+  endpoints:
+    - interval: 10s
+      port: http-metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
+  selector:
+    matchLabels:
+      app: tekton-pipelines-remote-resolvers

--- a/pkg/reconciler/openshift/tektonpipeline/extension.go
+++ b/pkg/reconciler/openshift/tektonpipeline/extension.go
@@ -276,6 +276,10 @@ func filterAndTransformMonitoring(comp v1alpha1.TektonComponent, metricsMTLSRead
 					"openshift-pruner-monitor",
 					occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort,
 					"tekton-pruner-controller", targetNS),
+				occommon.UpdateServiceMonitorForMetricsMTLS(
+					"openshift-pipelines-resolvers-monitor",
+					occommon.MetricsHTTPPort, occommon.MetricsHTTPSPort,
+					tektonRemoteResolversControllerName, targetNS),
 				// TektonResult's watcher ServiceMonitor ships in this same shared
 				// openshift-monitoring manifest set (owned by the TektonPipeline
 				// PostSet), so it must be upgraded here too, in lockstep with the


### PR DESCRIPTION
# Changes

Adds a `ServiceMonitor` for the `tekton-pipelines-remote-resolvers` deployment on OpenShift, so its metrics (exposed on the `http-metrics` port) get scraped by the cluster's Prometheus, consistent with the existing monitors for the pipeline controller, webhook, triggers, chains, results, and pruner.

New file: `cmd/openshift/operator/kodata/openshift-monitoring/04-pipeline-resolvers-monitoring.yaml`

Verified on a live OpenShift (ROSA) cluster: the ServiceMonitor is created automatically alongside the others, with selector and port matching the live `tekton-pipelines-remote-resolvers` Service.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Add a ServiceMonitor for tekton-pipelines-remote-resolvers metrics on OpenShift.
```