### PR TITLE
[release-v0.79.x] Security: Update Go stdlib to 1.25.13 (net/url, html/template, crypto/tls, net/http, encoding/xml, encoding/asn1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/operator
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
# Changes

Update Go stdlib from 1.25.12 to 1.25.13 to remediate multiple reachable stdlib vulnerabilities on release-v0.79.x, confirmed present and reachable by govulncheck.

**Vulnerabilities fixed:**
| ID | Package | Severity |
|---|---|---|
| GO-2026-6218 | net/url | Important |
| GO-2026-6091 | html/template | Important |
| GO-2026-6090 | crypto/tls | Important |
| GO-2026-6089 | net/http | Important |
| GO-2026-6088 | encoding/xml | Important |
| GO-2026-5972 | encoding/asn1 | Important |
| GO-2026-5026 | net/http | Important |

govulncheck result after fix: no fixable stdlib CVEs remain.

Jira tickets: SRVKP-13173, SRVKP-13178, SRVKP-13179

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes tests (no test changes needed — stdlib bump only)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
Security: Update Go stdlib to 1.25.13 to address CVEs GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091, GO-2026-6218, GO-2026-5972, GO-2026-5026
```