### PR TITLE
fix(build): fetch golangci-lint install.sh from main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(BIN)/golangci-lint: | $(BIN) ; $(info $(M) getting golangci-lint $(GOLANGCI_VE
 	@if [ -f $(BIN)/golangci-lint ] && $(BIN)/golangci-lint --version 2>/dev/null | grep -qF "$(GOLANGCI_VERSION)"; then \
 		echo "golangci-lint $(GOLANGCI_VERSION) already installed"; \
 	else \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BIN) $(GOLANGCI_VERSION); \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(BIN) $(GOLANGCI_VERSION); \
 	fi
 
 ##@ Clean 


### PR DESCRIPTION
# Changes

`make lint-go` fails checksum verification when bootstrapping golangci-lint: the Makefile fetches `install.sh` from the deprecated `master` branch, whose checksum lookup uses an unanchored `grep "${BASENAME}"`. Releases now ship SBOM sidecars (`<tarball>.sbom.json`), so the lookup matches two checksum lines and the comparison always fails — even though the downloaded tarball hash is correct.

This switches the URL to the `main` branch, where the lookup is anchored (`grep "${BASENAME}$"`). Verified `make lint-go` end-to-end on darwin/arm64 with v2.12.2: downloads, verifies, lints clean.

Upstream issue (closed, fixed on main): golangci/golangci-lint#6572

# Submitter Checklist

These are criteria that every PR should meet, please check them off as you review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

Note: `make lint-go` passes end-to-end (this PR fixes its bootstrap). `make lint-yaml` couldn't run locally (yamllint not installed); this change doesn't touch YAML linting. No functionality or user-facing behavior changed, so no tests/docs included.

# Release Notes

```release-note
NONE
```