### PR TITLE
fix(chart): stamp CRD labels with chart appVersion instead of hardcoded devel

### DIFF
--- a/charts/tekton-operator/templates/kubernetes-crds.yaml
+++ b/charts/tekton-operator/templates/kubernetes-crds.yaml
@@ -7,8 +7,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -652,8 +652,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: openshiftpipelinesascodes.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -1375,8 +1375,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -2347,8 +2347,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -4449,8 +4449,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektondashboards.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -4664,8 +4664,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -4778,8 +4778,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -5649,8 +5649,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -6538,8 +6538,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -7241,8 +7241,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -8064,8 +8064,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -8739,8 +8739,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -9383,8 +9383,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:

--- a/charts/tekton-operator/templates/openshift-crds.yaml
+++ b/charts/tekton-operator/templates/openshift-crds.yaml
@@ -7,8 +7,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: manualapprovalgates.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -652,8 +652,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: openshiftpipelinesascodes.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -1375,8 +1375,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonaddons.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -1569,8 +1569,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonchains.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -2541,8 +2541,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonconfigs.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -4643,8 +4643,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektoninstallersets.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -4757,8 +4757,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpipelines.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -5628,8 +5628,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonresults.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -6517,8 +6517,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektontriggers.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -7220,8 +7220,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonpruners.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -8043,8 +8043,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonschedulers.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -8718,8 +8718,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: tektonmulticlusterproxyaaes.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:
@@ -9362,8 +9362,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: syncerservices.operator.tekton.dev
   labels:
-    version: "devel"
-    operator.tekton.dev/release: "devel"
+    version: {{ .Chart.AppVersion | quote }}
+    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}
 spec:
   group: operator.tekton.dev
   names:

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -42,8 +42,8 @@ inject_labels() {
     # After the "  name: ..." line under metadata, inject labels
     if echo "$line" | grep -qE '^  name: .*\.operator\.tekton\.dev$'; then
       echo '  labels:' >> "$tmpfile"
-      echo '    version: "devel"' >> "$tmpfile"
-      echo '    operator.tekton.dev/release: "devel"' >> "$tmpfile"
+      echo '    version: {{ .Chart.AppVersion | quote }}' >> "$tmpfile"
+      echo '    operator.tekton.dev/release: {{ .Chart.AppVersion | quote }}' >> "$tmpfile"
     fi
   done < "$input_file"
   cat "$tmpfile"


### PR DESCRIPTION
# Changes

The OCI-published chart (e.g. `ghcr.io/tektoncd/operator/charts/tekton-operator:0.81.0`) ships CRDs with labels `version: "devel"` and `operator.tekton.dev/release: "devel"` even though the chart itself is correctly stamped (`version: 0.81.0`, `appVersion: v0.81.0`) and all deployment images pin `:v0.81.0`. For GitOps users (ArgoCD), every CRD diff shows `release: devel` while everything else says the real version — misleading for auditing.

Root cause: `hack/sync-helm-crds.sh` (which generates `charts/tekton-operator/templates/{kubernetes,openshift}-crds.yaml`) injects hardcoded `"devel"` labels, and the release workflow (`.github/workflows/helm-release.yaml`) stamps only `Chart.yaml` — the CRD templates are never touched.

Fix: the label injection now emits `{{ .Chart.AppVersion | quote }}`. In-tree/dev renders keep `devel` (Chart.yaml `appVersion: "devel"`), released OCI charts stamp the real version. No workflow change needed.

These labels are inert metadata: the operator reads `operator.tekton.dev/release-version` (a different key) on InstallerSets; nothing selects on these CRD labels.

Render proof (13 CRDs per platform, both kubernetes and openshift sets):

| Chart.yaml appVersion | Rendered CRD label |
|---|---|
| `"devel"` (in-tree) | `operator.tekton.dev/release: "devel"` |
| `"v0.82.0"` (release-stamped) | `operator.tekton.dev/release: "v0.82.0"` |

Note: 0.81.0 is already published and stays as-is; this lands in the next release (maintainers may cherry-pick).

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR (chart-only change; `lint-go` 0 issues, `yamllint` clean on changed files. `helm lint` fails on main pre-existing — `version: "devel"` is not valid semver)
- [ ] Includes tests (chart templates — verified via `helm template` renders above)
- [ ] Includes docs (no user-facing behavior change beyond label values)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Helm chart: CRDs now carry the chart appVersion in their `version` / `operator.tekton.dev/release` labels instead of the hardcoded `devel`, so released charts show the actual release version.
```
