### PR TITLE
fix(pipeline): validate controller ordinal buckets

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform.go
@@ -18,7 +18,9 @@ package tektonpipeline
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
@@ -113,9 +115,54 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 		if err := common.ExecuteAdditionalOptionsTransformer(ctx, manifest, pipeline.Spec.GetTargetNamespace(), pipeline.Spec.Options); err != nil {
 			return &mf.Manifest{}, err
 		}
+		if pipeline.Spec.Performance.StatefulsetOrdinals != nil && *pipeline.Spec.Performance.StatefulsetOrdinals {
+			if err := validateStatefulSetOrdinals(manifest, leaderElectionPipelineConfig, tektonPipelinesControllerName); err != nil {
+				return &mf.Manifest{}, err
+			}
+			if err := validateStatefulSetOrdinals(manifest, leaderElectionResolversConfig, tektonRemoteResolversControllerName); err != nil {
+				return &mf.Manifest{}, err
+			}
+		}
 
 		return manifest, nil
 	}
+}
+
+func validateStatefulSetOrdinals(manifest *mf.Manifest, configMapName, statefulSetName string) error {
+	configMaps := manifest.Filter(mf.All(mf.ByKind(common.KindConfigMap), mf.ByName(configMapName))).Resources()
+	statefulSets := manifest.Filter(mf.All(mf.ByKind(common.KindStatefulSet), mf.ByName(statefulSetName))).Resources()
+	if len(configMaps) == 0 || len(statefulSets) == 0 {
+		return nil
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := apimachineryRuntime.DefaultUnstructuredConverter.FromUnstructured(configMaps[0].Object, configMap); err != nil {
+		return fmt.Errorf("convert %s ConfigMap: %w", configMapName, err)
+	}
+	statefulSet := &appsv1.StatefulSet{}
+	if err := apimachineryRuntime.DefaultUnstructuredConverter.FromUnstructured(statefulSets[0].Object, statefulSet); err != nil {
+		return fmt.Errorf("convert %s StatefulSet: %w", statefulSetName, err)
+	}
+
+	buckets := int64(1)
+	if configured, ok := configMap.Data["buckets"]; ok {
+		var err error
+		buckets, err = strconv.ParseInt(configured, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid %s data.buckets %q: %w", configMapName, configured, err)
+		}
+	}
+	if buckets < 1 || buckets > v1alpha1.MaxBuckets {
+		return fmt.Errorf("%s data.buckets must be between 1 and %d, got %d", configMapName, v1alpha1.MaxBuckets, buckets)
+	}
+	replicas := int64(1)
+	if statefulSet.Spec.Replicas != nil {
+		replicas = int64(*statefulSet.Spec.Replicas)
+	}
+	if buckets != replicas {
+		return fmt.Errorf("statefulset ordinal mode requires %s data.buckets (%d) to equal %s spec.replicas (%d)", configMapName, buckets, statefulSetName, replicas)
+	}
+	return nil
 }
 
 // updates resolver config environment variables

--- a/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/transform_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -262,6 +263,141 @@ func TestUpdateResolverConfigEnvironmentsInDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateStatefulSetOrdinalsAfterOptions(t *testing.T) {
+	controllers := []struct {
+		name, configMap, statefulSet string
+	}{
+		{"Pipelines controller", leaderElectionPipelineConfig, tektonPipelinesControllerName},
+		{"resolver controller", leaderElectionResolversConfig, tektonRemoteResolversControllerName},
+	}
+	tests := []struct {
+		name                string
+		statefulSetOrdinals bool
+		optionBuckets       string
+		optionReplicas      *int32
+		wantError           string
+		wantStatefulSet     bool
+	}{
+		{
+			name:                "reject mismatched bucket override",
+			statefulSetOrdinals: true,
+			optionBuckets:       "8",
+			wantError:           " data.buckets (8) to equal",
+			wantStatefulSet:     true,
+		},
+		{
+			name:                "reject mismatched replica override",
+			statefulSetOrdinals: true,
+			optionReplicas:      ptr.Int32(8),
+			wantError:           " data.buckets (4) to equal",
+			wantStatefulSet:     true,
+		},
+		{
+			name:                "allow matching overrides",
+			statefulSetOrdinals: true,
+			optionBuckets:       "8",
+			optionReplicas:      ptr.Int32(8),
+		},
+		{
+			name:                "reject out-of-range matching overrides",
+			statefulSetOrdinals: true,
+			optionBuckets:       "11",
+			optionReplicas:      ptr.Int32(11),
+			wantError:           " data.buckets must be between 1 and 10, got 11",
+		},
+		{
+			name:          "allow different bucket count with dynamic leader election",
+			optionBuckets: "8",
+		},
+	}
+
+	for _, controller := range controllers {
+		t.Run(controller.name, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					buckets := uint(4)
+					replicas := int32(4)
+					pipeline := &v1alpha1.TektonPipeline{
+						Spec: v1alpha1.TektonPipelineSpec{
+							Pipeline: v1alpha1.Pipeline{
+								PipelineProperties: v1alpha1.PipelineProperties{
+									Performance: v1alpha1.PerformanceProperties{
+										PerformanceLeaderElectionConfig:      v1alpha1.PerformanceLeaderElectionConfig{Buckets: &buckets},
+										PerformanceStatefulsetOrdinalsConfig: v1alpha1.PerformanceStatefulsetOrdinalsConfig{StatefulsetOrdinals: ptr.Bool(test.statefulSetOrdinals)},
+										Replicas:                             &replicas,
+									},
+								},
+							},
+						},
+					}
+					if test.optionBuckets != "" {
+						pipeline.Spec.Options.ConfigMaps = map[string]corev1.ConfigMap{
+							controller.configMap: {Data: map[string]string{"buckets": test.optionBuckets}},
+						}
+					}
+					if test.optionReplicas != nil {
+						pipeline.Spec.Options.StatefulSets = map[string]appsv1.StatefulSet{
+							controller.statefulSet: {Spec: appsv1.StatefulSetSpec{Replicas: test.optionReplicas}},
+						}
+					}
+
+					manifest := ordinalManifest(t)
+					_, err := filterAndTransform(common.NoExtension(t.Context()))(t.Context(), &manifest, pipeline)
+					if test.wantError == "" {
+						assert.NilError(t, err)
+					} else {
+						assert.ErrorContains(t, err, controller.configMap+test.wantError)
+						if test.wantStatefulSet {
+							assert.ErrorContains(t, err, controller.statefulSet)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func ordinalManifest(t *testing.T) mf.Manifest {
+	t.Helper()
+	objects := []interface{}{
+		&corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: common.KindConfigMap},
+			ObjectMeta: metav1.ObjectMeta{Name: leaderElectionPipelineConfig},
+			Data:       map[string]string{"buckets": "1"},
+		},
+		&appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: common.KindDeployment},
+			ObjectMeta: metav1.ObjectMeta{Name: tektonPipelinesControllerName},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.Int32(1),
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: pipelinesControllerContainer}}}},
+			},
+		},
+		&corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: common.KindConfigMap},
+			ObjectMeta: metav1.ObjectMeta{Name: leaderElectionResolversConfig},
+			Data:       map[string]string{"buckets": "1"},
+		},
+		&appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: common.KindDeployment},
+			ObjectMeta: metav1.ObjectMeta{Name: tektonRemoteResolversControllerName},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.Int32(1),
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: pipelinesRemoteResolverControllerContainer}}}},
+			},
+		},
+	}
+	resources := make([]unstructured.Unstructured, 0, len(objects))
+	for _, object := range objects {
+		content, err := apimachineryRuntime.DefaultUnstructuredConverter.ToUnstructured(object)
+		assert.NilError(t, err)
+		resources = append(resources, unstructured.Unstructured{Object: content})
+	}
+	manifest, err := mf.ManifestFrom(mf.Slice(resources))
+	assert.NilError(t, err)
+	return manifest
 }
 
 // not in use, see: https://github.com/tektoncd/pipeline/pull/7789


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

- Validate the effective leader-election bucket counts for both the main Pipelines controller and remote-resolver controller against their rendered StatefulSet replica counts after additional options are applied.
- Preserve matching overrides and dynamic leader-election configurations.
- Reject mismatched or out-of-range bucket overrides in StatefulSet ordinal mode.
- Cover both controllers with render-level tests for bucket overrides, replica overrides, matching values, and dynamic leader election.

The existing performance documentation already states that buckets must match replicas in ordinal mode.

Fixes #3957.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Validate that Pipelines and resolver leader-election buckets match their controller replicas when StatefulSet ordinal mode is enabled.
```

