### PR TITLE
fix(operatorhub): hide TektonDashboard from OpenShift Provided APIs

### DIFF
--- a/config/openshift/base/kustomization.yaml
+++ b/config/openshift/base/kustomization.yaml
@@ -14,6 +14,15 @@
 
 patches:
 - target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: tektondashboards.operator.tekton.dev
+  patch: |-
+    - op: add
+      path: /metadata/annotations/config.kubernetes.io~1local-config
+      value: "true"
+- target:
     kind: ClusterRoleBinding
     name: tekton-scheduler-rolebinding
   patch: |-

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev"]'
+    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev","tektondashboards.operator.tekton.dev"]'
     repository: https://github.com/tektoncd/operator
     support: Red Hat
   labels:

--- a/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
+++ b/operatorhub/openshift/manifests/bases/openshift-pipelines-operator-rh.clusterserviceversion.template.yaml.tmpl
@@ -19,7 +19,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev"]'
+    operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev", "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev", "tektonresults.operator.tekton.dev", "tektonchains.operator.tekton.dev", "openshiftpipelinesascodes.operator.tekton.dev", "manualapprovalgates.operator.tekton.dev","tektonpruners.operator.tekton.dev","tektonschedulers.operator.tekton.dev","tektonmulticlusterproxyaaes.operator.tekton.dev","syncerservices.operator.tekton.dev","tektondashboards.operator.tekton.dev"]'
     repository: https://github.com/tektoncd/operator
     support: Red Hat
   labels:

--- a/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/operatorhub/openshift/release-artifacts/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.21.0
     operators.operatorframework.io/internal-objects: '["tektoninstallersets.operator.tekton.dev",
       "tektonconfigs.operator.tekton.dev","tektonpipelines.operator.tekton.dev","tektontriggers.operator.tekton.dev","tektonaddons.operator.tekton.dev",
-      "tektonchains.operator.tekton.dev"]'
+      "tektonchains.operator.tekton.dev","tektondashboards.operator.tekton.dev"]'
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/openshift/tektoncd-operator
     support: Red Hat


### PR DESCRIPTION
# Changes

`TektonDashboard` is Kubernetes-only, but commit [e18041d](https://github.com/tektoncd/operator/commit/e18041d05e015fc424a9e42b57ebe124af7474b2) moved the `tektondashboards` CRD into the shared `config/base` to satisfy kustomize's path restrictions. This caused the OpenShift bundle to start shipping it, and OLM began advertising it as a Provided API in the OpenShift console.

This fix applies two complementary layers:

**1. Kustomize exclusion** (`config/openshift/base/kustomization.yaml`)  
Adds a patch that sets `config.kubernetes.io/local-config: "true"` on the `tektondashboards` CRD, causing kustomize to drop it from the OpenShift build output entirely. Verified:
- `kustomize build config/openshift/overlays/operatorhub` → 0 matches for `tektondashboards`
- `kustomize build config/kubernetes/overlays/operatorhub` → still includes it (3 matches)

**2. OLM internal-objects safety net** (OpenShift CSV templates)  
Adds `tektondashboards.operator.tekton.dev` to the `operators.operatorframework.io/internal-objects` annotation so OLM hides it from the console even if the CRD ends up in a bundle built via the `release-manifest` strategy, which uses a pre-built `release.yaml` and bypasses kustomize overlays.

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix TektonDashboard appearing as a Provided API in the OpenShift console. The CRD is now excluded from the OpenShift bundle via a kustomize patch and hidden by OLM's internal-objects annotation.
```

Made with [Cursor](https://cursor.com)