### PR TITLE
fix(operatorhub): exclude TektonAddon CRD from Kubernetes bundle

### DIFF
--- a/config/kubernetes/base/kustomization.yaml
+++ b/config/kubernetes/base/kustomization.yaml
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 patches:
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: tektonaddons.operator.tekton.dev
+  patch: |-
+    - op: add
+      path: /metadata/annotations/config.kubernetes.io~1local-config
+      value: "true"
 - path: operator.yaml
   target:
     kind: Deployment


### PR DESCRIPTION
# Changes

`TektonAddon` is OpenShift-only. Commit [e4f5c9d](https://github.com/tektoncd/operator/commit/e18041d05e015fc424a9e42b57ebe124af7474b2) moved the `tektonaddons` CRD into the shared `config/base` to satisfy kustomize's path restrictions, which caused the Kubernetes bundle to start shipping it. OLM would then advertise it as a Provided API in the Kubernetes OperatorHub console.

This is the **symmetric counterpart** to [#3978](https://github.com/tektoncd/operator/pull/3978), which excluded `tektondashboards` (Kubernetes-only) from the OpenShift bundle. Both issues were introduced by the same commit.

**Fix:** Add a kustomize patch in `config/kubernetes/base/kustomization.yaml` that sets `config.kubernetes.io/local-config: "true"` on the `tektonaddons` CRD, causing kustomize to drop it from the Kubernetes build output entirely.

**Verified:**
- `kustomize build config/kubernetes/overlays/operatorhub` → `tektonaddons` appears in RBAC rules only, no CRD object emitted
- `kustomize build config/openshift/overlays/operatorhub` → `tektonaddons` CRD still present (correct)

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Fix TektonAddon appearing as a Provided API in the Kubernetes OperatorHub console. The CRD is now excluded from the Kubernetes bundle via a kustomize patch (TektonAddon is OpenShift-only).
```

Made with [Cursor](https://cursor.com)