### PR TITLE
fix(release): bump Helm Chart.yaml version during release branch setup

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -55,6 +55,16 @@ function set_version_label() {
     -e "s/(app.kubernetes.io\/version: )\"?${old_version}\"?/\1${operator_version}/g" \
     -e "s/(version: )\"?${old_version}\"?/\1${operator_version}/g" \
     -e "s/(\"-version\"), \"?${old_version}\"?/\1, ${operator_version}/g" cmd/openshift/operator/kodata/cabundles/*.yaml
+
+  # Update the Helm chart. Chart.yaml's "version" (plain semver, no "v"
+  # prefix) and "appVersion" (matches the release tag) are the only fields
+  # that need updating: every templates/*.yaml label is already rendered
+  # from .Chart.AppVersion.
+  echo updating charts/tekton-operator/Chart.yaml from version: ${old_version} to version: ${operator_version}
+  sed -i -E \
+    -e "s/^version: \"?${old_version#v}\"?/version: ${operator_version#v}/" \
+    -e "s/^appVersion: \"?${old_version}\"?/appVersion: ${operator_version}/" \
+    charts/tekton-operator/Chart.yaml
 }
 
 
@@ -64,6 +74,7 @@ function commit_changes() {
 
   git add -u cmd/
   git add -u config/
+  git add -u charts/
   git commit -m "Freezing Component versions and updating version labels"
 }
 

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -51,20 +51,6 @@ on the shared Tekton infrastructure cluster.
    curl -s https://infra.tekton.dev/tekton-releases/operator/previous/${TEKTON_RELEASE_VERSION}/openshift-release.yaml | head
    ```
 
-1. Update Helm charts with the new version:
-
-   ```bash
-   # Update labels in YAML files under templates directory
-   find charts/tekton-operator/templates -type f -name '*.yaml' -exec sed -i \
-     "s/operator\.tekton\.dev\/release: \"devel\"/operator.tekton.dev\/release: ${TEKTON_RELEASE_VERSION}/g" {} +
-   find charts/tekton-operator/templates -type f -name '*.yaml' -exec sed -i \
-     "s/version: \"devel\"/version: ${TEKTON_RELEASE_VERSION}/g" {} +
-
-   # Update Chart.yaml
-   sed -i "s/^version: \"devel\"/version: ${TEKTON_RELEASE_VERSION#v}/" charts/tekton-operator/Chart.yaml
-   sed -i "s/^appVersion: \"devel\"/appVersion: ${TEKTON_RELEASE_VERSION}/" charts/tekton-operator/Chart.yaml
-   ```
-
 ### Patch Release (bugfix)
 
 Patch releases can be triggered manually or automatically.


### PR DESCRIPTION
# Changes

`charts/tekton-operator/Chart.yaml` has shipped with `version: "devel"` /
`appVersion: "devel"` committed in the git tree for every release since
v0.80.0 (confirmed by fetching the raw `Chart.yaml` at the `v0.80.0`,
`v0.81.0` and `v0.81.1` tags), and with a stale `v0.79.1` for `v0.79.2`.
Helm rejects `"devel"` as an invalid chart version, so consumers that read
the chart straight from a git tag/branch (e.g. ArgoCD via the `helm-git`
plugin, or a plain git clone) fail to deploy.

Root cause: the actual release-branch preparation script,
`hack/release-setup-branch.sh` (invoked per `tekton/release-cheat-sheet.md`
for every minor and patch release), never touched `charts/tekton-operator/Chart.yaml`.
The only place this file got bumped was:
- a manual, easy-to-forget sed step documented in the cheat sheet (only ever
  run once, for `v0.79.1`), and
- `.github/workflows/helm-release.yaml`, which seds the file in the CI
  runner's ephemeral checkout to build the packaged chart, but never commits
  that change back to git - so the git tag itself keeps `"devel"` forever.

This PR extends `set_version_label()` in `hack/release.sh` (called by
`hack/release-setup-branch.sh`) to also bump `Chart.yaml`'s `version`/`appVersion`
fields using the same `old_version`/`operator_version` variables it already
computes for every other manifest, and includes `charts/` in the release
commit. `charts/tekton-operator/templates/*.yaml` already renders every
version label from `.Chart.AppVersion` (added in 683e44704), so `Chart.yaml`
is the only file that needed updating. The now-redundant manual step is
removed from `tekton/release-cheat-sheet.md`.

Note: `.github/workflows/helm-release.yaml`'s own "Update Chart version with
release tag" sed step becomes a silent no-op once `Chart.yaml` no longer
contains the literal string `"devel"` at tag time - harmless, since the
values it packages are derived from the git ref rather than from the sed
match, but worth a follow-up cleanup.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR (n/a: only `hack/release.sh` (bash) and a `.md` doc changed - no `.go`/`.yaml` files touched; ran `shellcheck` on the shell script instead, see Validation disclosure below)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

**Validation disclosure:** `hack/release.sh` is a manual maintainer script
with no unit tests, no shellcheck CI, and no GitHub Actions coverage;
`hack/release-setup-branch.sh` requires a real `upstream` git remote to push
branches, so I could not run it end to end. This sandbox only has BSD `sed`
(no `-i`-compatible GNU sed) - a pre-existing limitation shared by every
other `sed -i -E` call already in this file, not something introduced here.
I instead extracted the new sed expressions and ran them (via `sed -E`,
writing to stdout instead of `-i`) against a copy of the real `Chart.yaml`:
`old_version=devel, operator_version=v0.80.0` correctly produced
`version: 0.80.0` / `appVersion: v0.80.0` (matching the format already
committed for `v0.79.1`), and chaining `old_version=v0.80.0,
operator_version=v0.80.1` against that output correctly produced
`version: 0.80.1` / `appVersion: v0.80.1`, proving the transform works for
ordinary patch-to-patch transitions too, not just the initial `devel` case.
Also ran `shellcheck` on both scripts: only pre-existing info-level SC2086
findings in the same style as surrounding code.

# Release Notes

```release-note
Fix Helm chart `Chart.yaml` shipping `version: "devel"` / `appVersion: "devel"` in release tags, which made `helm-git`/git-based chart consumers (e.g. ArgoCD) fail to deploy.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #4002