### PR TITLE
fix(installerset): return requeue sentinel when not ready

### DIFF
--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set.go
@@ -18,8 +18,6 @@ package client
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	mf "github.com/manifestival/manifestival"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -112,9 +110,8 @@ func (i *InstallerSetClient) statusCheck(logger *zap.SugaredLogger, setType stri
 			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 		if !ready.IsTrue() {
-			msg := fmt.Sprintf("%v/%v: installer set not ready, will retry: %v", i.resourceKind, setType, ready.Message)
-			logger.Debugf(msg)
-			return errors.New(msg)
+			logger.Debugf("%v/%v: installer set not ready, will retry: %v", i.resourceKind, setType, ready.Message)
+			return v1alpha1.REQUEUE_EVENT_AFTER
 		}
 	}
 	return nil

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/main_set_test.go
@@ -65,8 +65,14 @@ func TestInstallerSetClient_MainSet_NewInstallation(t *testing.T) {
 		assert.NilError(t, err)
 	}
 
+	// Regression test for a reconcile hot-loop bug: when an installer set is known
+	// to be NotReady (e.g. its deployment isn't ready yet), MainSet must return the
+	// v1alpha1.REQUEUE_EVENT_AFTER sentinel so callers requeue with backoff instead
+	// of falling through to their "mark status NotReady and return nil" branch,
+	// which causes an immediate, un-throttled re-reconcile via the status-update
+	// informer event (see SRVKP-12674).
 	err = client.MainSet(ctx, comp, &manifest, filterAndTransform(nil))
-	assert.Assert(t, err != nil)
+	assert.Equal(t, err, v1alpha1.REQUEUE_EVENT_AFTER)
 
 	// set installer sets as false
 	createdSets, err = fakeClient.List(ctx, metav1.ListOptions{})

--- a/pkg/reconciler/kubernetes/tektoninstallerset/client/pre_post_custom_set_test.go
+++ b/pkg/reconciler/kubernetes/tektoninstallerset/client/pre_post_custom_set_test.go
@@ -54,8 +54,11 @@ func TestInstallerSetClient_PreSet_NewInstallation(t *testing.T) {
 		assert.NilError(t, err)
 	}
 
+	// Regression test for a reconcile hot-loop bug: a known NotReady installer set
+	// must yield v1alpha1.REQUEUE_EVENT_AFTER (proper backoff), not a plain error
+	// that callers swallow into a status update + nil return (see SRVKP-12674).
 	err = client.PreSet(ctx, comp, &manifest, filterAndTransform(nil))
-	assert.Assert(t, err != nil)
+	assert.Equal(t, err, v1alpha1.REQUEUE_EVENT_AFTER)
 
 	// set installer sets as false
 	createdSets, err = fakeClient.List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
# Changes

`statusCheck()` returned a plain error instead of the `REQUEUE_EVENT_AFTER`
sentinel when an installer set's `Ready` condition was `False`. Every caller
checks for that sentinel to requeue with backoff; otherwise it marks status
and returns `nil`, which triggers an immediate, un-throttled re-reconcile
instead of the intended 10s delayed requeue. A transiently-NotReady
deployment (e.g. HPA scaling) could turn into a prolonged reconcile
hot-loop, repeatedly disrupting pods across Tekton components sharing this
code path (`MainSet`, `PreSet`, `PostSet`, `CustomSet`).

Fix: return the same sentinel already used for the `Unknown` case.

Fixes SRVKP-12674

# Submitter Checklist

- [x] Run `make test lint` before submitting a PR
- [x] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
Fix a reconciler hot-loop where a transiently not-ready InstallerSet caused immediate re-reconciles instead of backing off, which could repeatedly restart component pods.
```