### PR TITLE
fix(tektonresult): default route TLS termination to reencrypt

### DIFF
--- a/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
+++ b/cmd/openshift/operator/kodata/static/tekton-results/route-rbac/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   verbs:
   - get
   resourceNames:
-  - tekton-results-api-service
+  - tekton-results-api
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,5 +58,5 @@ spec:
   port:
     targetPort: 8080
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect

--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -330,6 +330,8 @@ manualApproval:
 
 Result section allows user to customize the Tekton Result component, Refer to [Result Spec](https://github.com/tektoncd/operator/blob/main/docs/TektonResult.md#spec) section in TektonResult for available options.
 
+On OpenShift, `route_tls_termination` controls TLS termination on the Results route. Only `reencrypt` is supported (and is the default). `edge` breaks the route outright (no client flag can fix it). `passthrough` also works, but the client connects to the backend's service-serving certificate, so it must trust the cluster's service CA (or pass `--insecure`). `reencrypt` instead presents the ingress router certificate; note that by default this is cluster-signed rather than publicly trusted, so clients may still need the cluster's ingress CA (or `--insecure`) unless the router uses a publicly trusted certificate. See [route_tls_termination](https://github.com/tektoncd/operator/blob/main/docs/TektonResult.md#property-route_tls_termination-openshift-only) for details.
+
 Default Result configuration in TektonConfig looks like following if user doesn't specified any configuration options
 
 Example:
@@ -370,6 +372,7 @@ result:
   loki_stack_namespace: #optional
   prometheus_port: 9090
   prometheus_histogram: false
+  route_tls_termination: reencrypt # OpenShift only; only reencrypt is supported (default: reencrypt)
   watcher:
     completed_run_grace_period: 24h
     check_owner: true

--- a/docs/TektonResult.md
+++ b/docs/TektonResult.md
@@ -78,6 +78,45 @@ These properties are analogous to the one in configmap of tekton results api `te
 [result]:https://github.com/tektoncd/results
 
 
+### Property "route_tls_termination" (OpenShift only)
+
+On OpenShift, the operator exposes the Results API through an OpenShift `Route`. The
+`route_tls_termination` property controls how TLS is terminated on that route:
+
+```yaml
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonResult
+metadata:
+  name: result
+spec:
+  route_tls_termination: reencrypt
+```
+
+If the property is left empty, the operator defaults it to `reencrypt`.
+
+> **Only `reencrypt` is supported.** The Results API pod serves HTTPS only. `reencrypt`
+> terminates TLS at the router and re-encrypts traffic to the HTTPS backend, giving
+> correct end-to-end TLS. It is the default and the recommended value.
+>
+> Other values are not recommended. `edge` terminates TLS at the router and forwards plain
+> HTTP to the HTTPS-only backend; this breaks the route outright and no client flag can
+> fix it (`--insecure` only disables the client's verification of the router certificate,
+> it cannot repair the router-to-backend connection). `passthrough` also produces a working
+> route, but the client connects directly to the backend, which presents the OpenShift
+> service-serving certificate; clients must therefore trust the cluster's service CA (or
+> pass `--insecure`).
+>
+> With `reencrypt` the client sees the ingress router certificate instead. Note this is
+> not necessarily publicly trusted either — by default the ingress certificate is
+> cluster-signed, so clients may still need the cluster's ingress CA (or `--insecure`)
+> unless the router is configured with a publicly trusted certificate. The advantage of
+> `reencrypt` is that it works out of the box and keeps end-to-end TLS; do not change this
+> property away from `reencrypt`.
+
+> **Note:** On upgrade, existing installs that still carry the previous `edge` default are
+> automatically migrated to `reencrypt`.
+
+
 ### Property "secret_name":
 `secret_name` - name of your custom secret or leave it as empty. It an optional property. The secret should be created by the user on the `targetNamespace`. The secret can contain `S3_` prefixed keys from the [result API properties](https://github.com/tektoncd/results/blob/fded140081468e418aeb860d16aca3306c675d8b/cmd/api/README.md). Please note: the key of the secret should be in UPPER_CASE and values should be in `string` format.
 The following keys are supported by this secret.

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation.go
@@ -156,6 +156,7 @@ func (tc *TektonConfig) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(tc.Spec.Trigger.Options.validate("spec.trigger.options"))
 	errs = errs.Also(tc.Spec.Result.Options.validate("spec.result.options"))
 	errs = errs.Also(tc.Spec.Result.Watcher.Validate("spec.result.watcher"))
+	errs = errs.Also(tc.Spec.Result.ResultsAPIProperties.validateRouteTLSTermination("spec.result"))
 	errs = errs.Also(tc.Spec.MulticlusterProxyAAE.Options.validate("spec.multiclusterProxyAAE.options"))
 	errs = errs.Also(tc.Spec.ManualApproval.Options.validate("spec.manualApproval.options"))
 

--- a/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonconfig_validation_test.go
@@ -584,3 +584,28 @@ func containsFieldError(err *apis.FieldError, pathFragment string) bool {
 	}
 	return strings.Contains(err.Error(), pathFragment)
 }
+
+func Test_ValidateTektonConfig_InvalidResultRouteTLSTermination(t *testing.T) {
+	tc := &TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "namespace",
+		},
+		Spec: TektonConfigSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "namespace",
+			},
+			Profile: "all",
+			Pruner:  Prune{Disabled: true},
+			Result: Result{
+				ResultsAPIProperties: ResultsAPIProperties{
+					RouteTLSTermination: "invalid",
+				},
+			},
+		},
+	}
+
+	err := tc.Validate(context.TODO())
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, "spec.result.route_tls_termination")
+}

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults.go
@@ -38,7 +38,7 @@ func (c *Result) setDefaults() {
 	}
 
 	if c.RouteTLSTermination == "" {
-		c.RouteTLSTermination = "edge"
+		c.RouteTLSTermination = "reencrypt"
 	}
 
 	c.setPerformanceDefaults()

--- a/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_defaults_test.go
@@ -116,7 +116,7 @@ func TestResult_SetDefaultsRoutes(t *testing.T) {
 	want := &Result{
 		ResultsAPIProperties: ResultsAPIProperties{
 			RouteEnabled:        ptr.Bool(true),
-			RouteTLSTermination: "edge",
+			RouteTLSTermination: "reencrypt",
 		},
 	}
 
@@ -149,7 +149,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
@@ -175,7 +175,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
@@ -198,7 +198,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
@@ -218,7 +218,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					Replicas: &threeReplicas,
@@ -237,7 +237,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{
@@ -262,7 +262,7 @@ func TestResult_SetDefaultsBucketsAutoDefaulting(t *testing.T) {
 			want: Result{
 				ResultsAPIProperties: ResultsAPIProperties{
 					RouteEnabled:        ptr.Bool(IsOpenShiftPlatform()),
-					RouteTLSTermination: "edge",
+					RouteTLSTermination: "reencrypt",
 				},
 				Performance: PerformanceProperties{
 					PerformanceStatefulsetOrdinalsConfig: PerformanceStatefulsetOrdinalsConfig{

--- a/pkg/apis/operator/v1alpha1/tektonresult_validation.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_validation.go
@@ -59,6 +59,9 @@ func (trs *TektonResultSpec) validate(path string) (errs *apis.FieldError) {
 		}
 	}
 
+	// validate route TLS termination
+	errs = errs.Also(trs.ResultsAPIProperties.validateRouteTLSTermination(path))
+
 	// validate performance properties
 	errs = errs.Also(trs.Performance.Validate(fmt.Sprintf("%s.performance", path)))
 
@@ -68,4 +71,20 @@ func (trs *TektonResultSpec) validate(path string) (errs *apis.FieldError) {
 	errs = errs.Also(trs.NetworkPolicy.validate(fmt.Sprintf("%s.networkPolicy", path)))
 
 	return errs
+}
+
+// validateRouteTLSTermination validates that the route TLS termination type is one of the
+// supported values. It is called from both TektonResult and TektonConfig validators so that
+// unsupported values are rejected at the parent (TektonConfig) level as well.
+func (props ResultsAPIProperties) validateRouteTLSTermination(path string) *apis.FieldError {
+	if props.RouteTLSTermination == "" {
+		return nil
+	}
+	switch props.RouteTLSTermination {
+	case "edge", "reencrypt", "passthrough":
+		return nil
+	default:
+		errMsg := fmt.Sprintf("unsupported route TLS termination type %q, must be one of: edge, reencrypt, passthrough", props.RouteTLSTermination)
+		return apis.ErrInvalidValue(props.RouteTLSTermination, fmt.Sprintf("%s.route_tls_termination", path), errMsg)
+	}
 }

--- a/pkg/apis/operator/v1alpha1/tektonresult_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonresult_validation_test.go
@@ -54,6 +54,46 @@ func TestTektonResult_ValidateTargetNamespaceDenylist(t *testing.T) {
 	assert.Equal(t, "invalid value: kube-system: spec.targetNamespace\n'kube-system' is a reserved system namespace and is not allowed", errs.Error())
 }
 
+func TestTektonResult_ValidateRouteTLSTermination(t *testing.T) {
+	tests := []struct {
+		name        string
+		termination string
+		expectError bool
+	}{
+		{name: "valid edge", termination: "edge", expectError: false},
+		{name: "valid reencrypt", termination: "reencrypt", expectError: false},
+		{name: "valid passthrough", termination: "passthrough", expectError: false},
+		{name: "empty is valid", termination: "", expectError: false},
+		{name: "invalid value", termination: "invalid", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &TektonResult{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "result",
+				},
+				Spec: TektonResultSpec{
+					CommonSpec: CommonSpec{
+						TargetNamespace: "foo",
+					},
+					Result: Result{
+						ResultsAPIProperties: ResultsAPIProperties{
+							RouteTLSTermination: tt.termination,
+						},
+					},
+				},
+			}
+			errs := tr.Validate(context.TODO())
+			if tt.expectError {
+				assert.Assert(t, errs != nil, "expected validation error for termination %q", tt.termination)
+			} else {
+				assert.Assert(t, errs == nil, "unexpected validation error for termination %q: %v", tt.termination, errs)
+			}
+		})
+	}
+}
+
 func TestTektonResultWatcherPerformancePropertiesValidate(t *testing.T) {
 	tr := &TektonResult{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/openshift/tektonresult/extension_test.go
+++ b/pkg/reconciler/openshift/tektonresult/extension_test.go
@@ -199,6 +199,28 @@ func Test_ResultsAPIInjectRout(t *testing.T) {
 	assert.Equal(t, route.Spec.Path, "/api")
 }
 
+func Test_ResultsAPIInjectRouteReencrypt(t *testing.T) {
+	testData := path.Join("testdata", "static/tekton-results", "route-rbac", "rbac.yaml")
+	manifest, err := mf.ManifestFrom(mf.Recursive(testData))
+	assert.NilError(t, err)
+	filteredManifest := manifest.Filter(mf.ByKind("Route"))
+
+	route := &routev1.Route{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(filteredManifest.Resources()[0].Object, route)
+	assertNoError(t, err)
+
+	props := v1alpha1.ResultsAPIProperties{RouteEnabled: ptr.Bool(true), RouteTLSTermination: "reencrypt", RouteHost: "results.example.com"}
+	manifest, err = filteredManifest.Transform(injectResultsAPIRoute(props))
+	assert.NilError(t, err)
+
+	route = &routev1.Route{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(manifest.Resources()[0].Object, route)
+	assert.NilError(t, err)
+
+	assert.Equal(t, route.Spec.TLS.Termination, routev1.TLSTerminationType("reencrypt"))
+	assert.Equal(t, route.Spec.Host, "results.example.com")
+}
+
 func Test_isEnableRoute(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
+++ b/pkg/reconciler/openshift/tektonresult/testdata/static/tekton-results/route-rbac/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   verbs:
   - get
   resourceNames:
-  - tekton-results-api-service
+  - tekton-results-api
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,5 +58,5 @@ spec:
   port:
     targetPort: 8080
   tls:
-    termination: edge
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect

--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade.go
@@ -570,6 +570,51 @@ func migrateLegacyNamespaceSyncParams(ctx context.Context, logger *zap.SugaredLo
 	return err
 }
 
+// migrateResultsRouteTLSToReencrypt updates the Results route TLS termination from the
+// previous default "edge" to "reencrypt". With "edge" the router terminates TLS and
+// forwards plain HTTP to the Results API, which serves HTTPS only. That mismatch breaks
+// the route outright: there is no client flag that fixes it, since --insecure only
+// disables the client's verification of the router certificate and cannot repair the
+// router's plaintext connection to a TLS-only backend. "reencrypt" restores correct
+// end-to-end TLS.
+//
+// Only "edge" is migrated: it was the previous SetDefaults value and is persisted on
+// essentially every existing install, and it is broken against the HTTPS-only backend.
+// Other values ("reencrypt", "passthrough", empty) are left untouched -- "passthrough"
+// was never auto-persisted and is a valid choice when set manually (it works, but the
+// client connects to the service-serving certificate and must trust the cluster's service
+// CA, or pass --insecure). The change is made on TektonConfig (the source of truth) which
+// then syncs to the TektonResult CR.
+func migrateResultsRouteTLSToReencrypt(ctx context.Context, logger *zap.SugaredLogger, k8sClient kubernetes.Interface, operatorClient versioned.Interface, restConfig *rest.Config) error {
+	// Route TLS termination is only relevant on OpenShift.
+	if !v1alpha1.IsOpenShiftPlatform() {
+		return nil
+	}
+
+	tcCR, err := operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Only migrate the previous default. Any other value (reencrypt, passthrough, empty)
+	// is left untouched.
+	if tcCR.Spec.Result.RouteTLSTermination != "edge" {
+		return nil
+	}
+
+	tcCR.Spec.Result.RouteTLSTermination = "reencrypt"
+	if _, err := operatorClient.OperatorV1alpha1().TektonConfigs().Update(ctx, tcCR, metav1.UpdateOptions{}); err != nil {
+		logger.Errorw("error migrating Results route TLS termination from edge to reencrypt", "error", err)
+		return err
+	}
+
+	logger.Info("Migrated Results route TLS termination from edge to reencrypt")
+	return nil
+}
+
 // removeHubFromTektonConfig removes the deprecated hub field from the TektonConfig spec.
 // TODO: Remove this function in the release-v0.80.x
 func removeHubFromTektonConfig(ctx context.Context, logger *zap.SugaredLogger, k8sClient kubernetes.Interface, operatorClient versioned.Interface, restConfig *rest.Config) error {

--- a/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/pre_upgrade_test.go
@@ -270,6 +270,101 @@ func TestUpgradePipelineProperties(t *testing.T) {
 	}
 }
 
+func TestMigrateResultsRouteTLSToReencrypt(t *testing.T) {
+	tests := []struct {
+		name        string
+		termination string
+		expected    string
+	}{
+		{
+			name:        "edge is migrated to reencrypt",
+			termination: "edge",
+			expected:    "reencrypt",
+		},
+		{
+			name:        "reencrypt is left untouched",
+			termination: "reencrypt",
+			expected:    "reencrypt",
+		},
+		{
+			name:        "passthrough is left untouched",
+			termination: "passthrough",
+			expected:    "passthrough",
+		},
+		{
+			name:        "empty is left untouched",
+			termination: "",
+			expected:    "",
+		},
+	}
+
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PLATFORM", "openshift")
+			operatorClient := operatorFake.NewSimpleClientset()
+
+			// no TektonConfig CR -> no error
+			err := migrateResultsRouteTLSToReencrypt(ctx, logger, nil, operatorClient, nil)
+			assert.NoError(t, err)
+
+			tc := &v1alpha1.TektonConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1alpha1.ConfigResourceName,
+				},
+				Spec: v1alpha1.TektonConfigSpec{
+					Result: v1alpha1.Result{
+						ResultsAPIProperties: v1alpha1.ResultsAPIProperties{
+							RouteTLSTermination: tt.termination,
+						},
+					},
+				},
+			}
+			_, err = operatorClient.OperatorV1alpha1().TektonConfigs().Create(ctx, tc, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			err = migrateResultsRouteTLSToReencrypt(ctx, logger, nil, operatorClient, nil)
+			assert.NoError(t, err)
+
+			tcData, err := operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, tcData.Spec.Result.RouteTLSTermination)
+		})
+	}
+}
+
+func TestMigrateResultsRouteTLSToReencrypt_NonOpenShift(t *testing.T) {
+	t.Setenv("PLATFORM", "kubernetes")
+	ctx := context.TODO()
+	logger := logging.FromContext(ctx).Named("unit-test")
+	operatorClient := operatorFake.NewSimpleClientset()
+
+	tc := &v1alpha1.TektonConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v1alpha1.ConfigResourceName,
+		},
+		Spec: v1alpha1.TektonConfigSpec{
+			Result: v1alpha1.Result{
+				ResultsAPIProperties: v1alpha1.ResultsAPIProperties{
+					RouteTLSTermination: "edge",
+				},
+			},
+		},
+	}
+	_, err := operatorClient.OperatorV1alpha1().TektonConfigs().Create(ctx, tc, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// On non-OpenShift platforms the migration is a no-op and leaves edge untouched.
+	err = migrateResultsRouteTLSToReencrypt(ctx, logger, nil, operatorClient, nil)
+	assert.NoError(t, err)
+
+	tcData, err := operatorClient.OperatorV1alpha1().TektonConfigs().Get(ctx, v1alpha1.ConfigResourceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "edge", tcData.Spec.Result.RouteTLSTermination)
+}
+
 func TestPreUpgradeTektonPruner(t *testing.T) {
 	ctx := context.TODO()
 	operatorClient := operatorFake.NewSimpleClientset()

--- a/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
+++ b/pkg/reconciler/shared/tektonconfig/upgrade/upgrade.go
@@ -44,6 +44,7 @@ var (
 		removeHubFromTektonConfig,                // upgrade #7: clear deprecated hub field
 		preUpgradeManualApprovalGate,             // upgrade #8: adopt standalone MAG config into TektonConfig
 		migrateLegacyNamespaceSyncParams,         // upgrade #9: persist createRbacResource/createCABundleConfigMaps/legacyPipelineRbac migration to namespaceSync
+		migrateResultsRouteTLSToReencrypt,        // upgrade #10: migrate Results route TLS termination from edge to reencrypt
 	}
 
 	// post upgrade functions


### PR DESCRIPTION
# Changes

The Results API route on OpenShift was defaulting to `edge` TLS termination,
which causes TLS handshake failures when clients try to connect. The router
terminates TLS at the edge and forwards **unencrypted** traffic to the gRPC
backend — but the backend only speaks TLS.

Additionally, when `passthrough` was used as a workaround, clients had to
pass `--insecure-skip-tls-verify` because the OpenShift service-serving
certificate was not trusted by external clients.

**`reencrypt`** is the correct termination type:
- The router presents a **trusted** certificate to external clients (no `--insecure` needed)
- The router **re-encrypts** to the backend using the OpenShift service-serving cert
- End-to-end encryption is maintained

### Upgrade migration

Changing the default only affects **new** installs — existing installs persist
the previous `edge` value in their `TektonConfig`/`TektonResult` CR, so they
would stay broken after upgrading. A version-gated pre-upgrade migration
(`migrateResultsRouteTLSToReencrypt`) updates the Results route TLS termination
from `edge` → `reencrypt` on `TektonConfig` (the source of truth), which then
syncs to the `TektonResult` CR. It runs on OpenShift only and migrates **only**
`edge`; values set manually to `reencrypt` or `passthrough` are left untouched.

### Changes made

| File | Change |
|---|---|
| `tektonresult_defaults.go` | Default `route_tls_termination` changed from `edge` → `reencrypt` |
| `route-rbac/rbac.yaml` (kodata) | Route TLS termination updated from `passthrough` → `reencrypt` |
| `route-rbac/rbac.yaml` (testdata) | RBAC `resourceNames` fixed: `tekton-results-api-service` → `tekton-results-api` (matches actual Route name) |
| `tektonresult_validation.go` | Extracted `validateRouteTLSTermination`; only `edge`, `reencrypt`, `passthrough` accepted |
| `tektonconfig_validation.go` | Reject invalid `spec.result.route_tls_termination` at the parent CR level too |
| `upgrade.go` / `pre_upgrade.go` | Added version-gated pre-upgrade migration `edge` → `reencrypt` |
| `docs/TektonResult.md`, `docs/TektonConfig.md` | Document that only `reencrypt` is supported on OpenShift; note the upgrade migration |
| `*_test.go` | Tests for defaults, `TektonResult`/`TektonConfig` validation, route injection, and the migration |

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
fix(tektonresult): change default OpenShift Results API route TLS
termination from `edge` to `reencrypt`, and add a pre-upgrade
migration that flips existing installs from `edge` to `reencrypt`.
This fixes TLS handshake failures and eliminates the need for
`--insecure-skip-tls-verify` when accessing the Results API via the
OpenShift route. Also adds validation to reject unsupported
`route_tls_termination` values.
```
