### PR TITLE
fix(results): allow retention-policy-agent egress to the API server

### DIFF
--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies.go
@@ -114,9 +114,13 @@ func resultsDefaultPolicies(params networkpolicy.PlatformParams, props v1alpha1.
 					networkingv1.PolicyTypeIngress,
 					networkingv1.PolicyTypeEgress,
 				},
+				// The agent watches its ConfigMap (schedule, retention policy) via the
+				// API server, so it needs the same API-server egress as results-api/
+				// results-watcher, in addition to DNS and DB access.
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					networkpolicy.DNSEgressRule(params),
 					dbEgress,
+					networkpolicy.APIServerEgressRule(),
 				},
 			},
 		},

--- a/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
+++ b/pkg/reconciler/kubernetes/tektonresult/networkpolicies_test.go
@@ -60,8 +60,12 @@ func TestResultsDefaultPolicies(t *testing.T) {
 	assertIngressHasPort(t, "results-watcher", watcher.Spec.Ingress, 9090)
 
 	retention := byName["results-retention-policy-agent"]
+	if got := len(retention.Spec.Egress); got != 3 {
+		t.Fatalf("results-retention-policy-agent: expected 3 egress rules (DNS + DB + allow-all), got %d", got)
+	}
 	assertEgressHasDNS(t, "results-retention-policy-agent", retention.Spec.Egress, 5353)
 	assertEgressHasDBPort(t, "results-retention-policy-agent", retention.Spec.Egress, 5432)
+	assertEgressHasAllowAll(t, "results-retention-policy-agent", retention.Spec.Egress)
 
 	postgres := byName["results-postgres"]
 	assertIngressHasPort(t, "results-postgres", postgres.Spec.Ingress, 5432)


### PR DESCRIPTION
The results-retention-policy-agent NetworkPolicy allowed egress to DNS and the database, but not to the Kubernetes API server. The agent uses a ConfigMap watcher (informer) to load its schedule and retention settings from tekton-results-config-results-retention-policy, which requires talking to the API server, not just Postgres/DNS.


Assisted-by: Claude <noreply@anthropic.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
NONE
```
