### PR TITLE
fix(tektonaddon): use zip format for Windows CLI downloads

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
+++ b/pkg/reconciler/openshift/tektonaddon/testdata/test-console-cli-expected.yaml
@@ -18,7 +18,7 @@ spec:
       text: Download tkn and tkn-pac for Mac x86_64
     - href: https://testserver.com/tkn/tkn-macos-arm64.tar.gz
       text: Download tkn and tkn-pac for Mac ARM 64
-    - href: https://testserver.com/tkn/tkn-windows-amd64.tar.gz
+    - href: https://testserver.com/tkn/tkn-windows-amd64.zip
       text: Download tkn and tkn-pac for Windows x86_64
-    - href: https://testserver.com/tkn/tkn-windows-arm64.tar.gz
+    - href: https://testserver.com/tkn/tkn-windows-arm64.zip
       text: Download tkn and tkn-pac for Windows ARM 64

--- a/pkg/reconciler/openshift/tektonaddon/transformer.go
+++ b/pkg/reconciler/openshift/tektonaddon/transformer.go
@@ -77,8 +77,8 @@ func getlinks(baseURL string) []console.CLIDownloadLink {
 		{"IBM Z", "tkn/tkn-linux-s390x.tar.gz"},
 		{"Mac x86_64", "tkn/tkn-macos-amd64.tar.gz"},
 		{"Mac ARM 64", "tkn/tkn-macos-arm64.tar.gz"},
-		{"Windows x86_64", "tkn/tkn-windows-amd64.tar.gz"},
-		{"Windows ARM 64", "tkn/tkn-windows-arm64.tar.gz"},
+		{"Windows x86_64", "tkn/tkn-windows-amd64.zip"},
+		{"Windows ARM 64", "tkn/tkn-windows-arm64.zip"},
 	}
 	links := []console.CLIDownloadLink{}
 	for _, platformURL := range platformURLs {


### PR DESCRIPTION
Change Windows tkn binary download links from .tar.gz to .zip format. CLI publishes Windows binaries as .zip archives and Windows users expect .zip archives for CLI tools.

Updating the download links will ensure consistency with the published CLI artifacts.

CLI Windows binaries release format: https://github.com/tektoncd/cli/blob/16e95eb4c447deee42c8c1b715a182d0ac531830/.goreleaser.yml#L31

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Update the Windows tkn binary download links from .tar.gz to .zip format, the Tekton CLI publishes Windows binaries as .zip archives, which is the standard and expected format for Windows users.
```
