### PR TITLE
fix(pipelinesascode): guard nil Settings in validate

### DIFF
--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation.go
@@ -54,6 +54,12 @@ func (pac *OpenShiftPipelinesAsCode) Validate(ctx context.Context) *apis.FieldEr
 func (ps *PACSettings) validate(logger *zap.SugaredLogger, path string) *apis.FieldError {
 	var errs *apis.FieldError
 
+	// Settings may be nil when PAC is disabled (SetDefaults nils it out), but
+	// SyncConfig writes into it unconditionally, so guard against a nil map here.
+	if ps.Settings == nil {
+		ps.Settings = map[string]string{}
+	}
+
 	defaultPacSettings := pacSettings.Settings{}
 	if err := pacSettings.SyncConfig(logger, &defaultPacSettings, ps.Settings, pacSettings.DefaultValidators(), http.DefaultClient); err != nil {
 		errs = errs.Also(apis.ErrInvalidValue(err, fmt.Sprintf("%s.settings", path)))

--- a/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
+++ b/pkg/apis/operator/v1alpha1/openshiftpipelinesascode_validation_test.go
@@ -194,3 +194,26 @@ func TestValidateAddtionalPACControllerInvalidSetting(t *testing.T) {
 	err := opacCR.Validate(context.TODO())
 	assert.Equal(t, "invalid value: invalid value: invalid value for URL, error: parse \"test/path\": invalid URI for request: validation failed for field custom-console-url: spec.additionalPACControllers.settings", err.Error())
 }
+
+// TestValidateNilSettings guards against a regression where a nil
+// PACSettings.Settings map (as left behind when PAC is disabled via
+// SetDefaults) reaches SyncConfig and panics with "assignment to entry in
+// nil map".
+func TestValidateNilSettings(t *testing.T) {
+	opacCR := &OpenShiftPipelinesAsCode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: OpenShiftPipelinesAsCodeSpec{
+			CommonSpec: CommonSpec{
+				TargetNamespace: "openshift-pipelines",
+			},
+			PACSettings: PACSettings{
+				Settings: nil,
+			},
+		},
+	}
+	err := opacCR.Validate(context.TODO())
+	assert.Assert(t, err == nil, "unexpected validation error: %v", err)
+}


### PR DESCRIPTION
# Changes

Fix a validating-webhook panic ("assignment to entry in nil map") that is
triggered whenever `TektonConfig.Spec.Platforms.{Kubernetes,OpenShift}.PipelinesAsCode`
is disabled, via either `pipelinesAsCode.enable: false` or the deprecated
`spec.addon.enablePipelinesAsCode: false`.

`SetDefaults` sets `PACSettings.Settings` to `nil` on the disable path (both
platform branches), but `(*PACSettings).validate` unconditionally passes
`ps.Settings` into the vendored `pipelines-as-code` `SyncConfig`, which
writes into that map unconditionally (`getHubCatalogs`, `default.go:21`).
A nil map panics on write.

The fix guards `ps.Settings` to an empty map before calling `SyncConfig`,
in `(*PACSettings).validate` — the single method used by both the
`OpenShiftPipelinesAsCode.Validate` and `TektonConfig.Validate` (Kubernetes
and OpenShift branches) entry points, so one guard covers all three call
sites.

A regression test reproduces the exact panic reported in the issue
(`PACSettings{Settings: nil}` through `OpenShiftPipelinesAsCode.Validate`)
and asserts it now returns cleanly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
Fix a validating webhook panic when disabling PipelinesAsCode in
TektonConfig (via `pipelinesAsCode.enable: false` or the deprecated
`addon.enablePipelinesAsCode: false`), which previously rejected the
update and blocked unrelated TektonConfig field changes as well.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #4057