### PR TITLE
feat(pruner): add default resource limits to controller and webhook

### DIFF
--- a/docs/TektonConfig.md
+++ b/docs/TektonConfig.md
@@ -835,7 +835,44 @@ spec:
 - The event-based pruner responds to resource events in real-time, providing more efficient cleanup
 - When `enforcedConfigLevel` is set to `namespace`, individual namespaces can override these settings using ConfigMaps
 
+#### Resource Limits
 
+The operator applies default resource limits to pruner deployments based on benchmark data:
+
+**Controller:** `requests: 100m CPU, 256Mi memory` | `limits: 2Gi memory`  
+**Webhook:** `requests: 50m CPU, 64Mi memory` | `limits: 512Mi memory`
+
+CPU limits are omitted to avoid CFS throttling during reconciliation bursts. Memory limits are based on linear growth (~13.6 MB per 1k resident PipelineRuns). The 2Gi controller limit supports up to ~50k runs with some safety margin.
+
+**Benchmark data:**
+
+| Scale | Resident PRs | Heap (MB) | Container (MB) |
+|-------|--------------|-----------|----------------|
+| Baseline | 0 | 23 | - |
+| Low | 1,000 | 65 | 58 |
+| Medium | 6,000 | 148 | 69 |
+| High | 16,000 | 301 | 104 |
+| Production | 41,000 | 579 | 170 |
+
+
+**Override via options:**
+```yaml
+  tektonpruner:
+    options:
+      deployments:
+        tekton-pruner-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: controller
+                  resources:
+                    limits:
+                      memory: 4Gi
+                      cpu: 1000m
+```
+
+For >50k resident runs, calculate required memory: `memory_mb = 23 + (13.6 × runs_in_thousands)` and apply 1.5x safety factor.
 
 ### Additional fields as `options`
 

--- a/pkg/reconciler/kubernetes/tektonpruner/transform.go
+++ b/pkg/reconciler/kubernetes/tektonpruner/transform.go
@@ -23,7 +23,104 @@ import (
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/common"
 	"github.com/tektoncd/operator/pkg/reconciler/kubernetes/tektoninstallerset/client"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
 )
+
+// addDefaultResourceLimits injects pruner-specific resource limits based on benchmark data
+// Overridable via TektonPruner.Spec.Options (options transformer runs last).
+func addDefaultResourceLimits() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		kind := u.GetKind()
+		if kind != "Deployment" && kind != "StatefulSet" {
+			return nil
+		}
+
+		deploymentName := u.GetName()
+
+		// Only apply to pruner controller and webhook
+		if deploymentName != "tekton-pruner-controller" && deploymentName != "tekton-pruner-webhook" {
+			return nil
+		}
+
+		// Define default resources based on benchmark results
+		var defaultResources corev1.ResourceRequirements
+
+		if deploymentName == "tekton-pruner-controller" {
+			// Controller: handles PipelineRun/TaskRun informer cache
+			// Benchmark: 846-1126 MB for 26k-38k runs
+			// 2Gi limit provides safety margin for production scale
+			defaultResources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			}
+		} else if deploymentName == "tekton-pruner-webhook" {
+			// Webhook: stateless, minimal memory footprint
+			defaultResources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			}
+		}
+
+		// Both Deployment and StatefulSet have containers at spec.template.spec.containers
+		// Use unstructured path access to avoid duplication
+		containers, found, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers")
+		if !found || err != nil {
+			return err
+		}
+
+		modified := false
+		for i := range containers {
+			containerMap := containers[i].(map[string]interface{})
+
+			// Check if resources field exists
+			resources, hasResources := containerMap["resources"]
+			if !hasResources {
+				// No resources field, add defaults
+				resourcesMap, err := apimachineryRuntime.DefaultUnstructuredConverter.ToUnstructured(&defaultResources)
+				if err != nil {
+					return err
+				}
+				containerMap["resources"] = resourcesMap
+				modified = true
+			} else {
+				// Has resources field, check if both requests and limits are empty
+				resourcesMap := resources.(map[string]interface{})
+				_, hasRequests := resourcesMap["requests"]
+				_, hasLimits := resourcesMap["limits"]
+				if !hasRequests && !hasLimits {
+					// Both nil, replace with defaults
+					resourcesMap, err := apimachineryRuntime.DefaultUnstructuredConverter.ToUnstructured(&defaultResources)
+					if err != nil {
+						return err
+					}
+					containerMap["resources"] = resourcesMap
+					modified = true
+				}
+			}
+		}
+
+		if modified {
+			if err := unstructured.SetNestedSlice(u.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
 
 func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 	return func(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.TektonComponent) (*mf.Manifest, error) {
@@ -36,6 +133,7 @@ func filterAndTransform(extension common.Extension) client.FilterAndTransform {
 			common.DeploymentImages(prunerImages),
 			common.AddDeploymentRestrictedPSA(),
 			common.AddConfigMapValues(PrunerConfigMapName, prunerCR.Spec.TektonPrunerConfig),
+			addDefaultResourceLimits(), // Add default resource limits (can be overridden via Options)
 		}
 		extra = append(extra, extension.Transformers(prunerCR)...)
 		err := common.Transform(ctx, manifest, prunerCR, extra...)


### PR DESCRIPTION
  ## Summary

  Adds default resource requests and limits for `tekton-pruner-controller` and `tekton-pruner-webhook` deployments in the operator. 

  ## Changes

  Modified `pkg/reconciler/kubernetes/tektonpruner/transform.go` to include a new `addDefaultResourceLimits()` transformer that injects default
  resource specifications:

  ### tekton-pruner-controller
  ```yaml
  resources:
    requests:
      cpu: 100m
      memory: 256Mi
    limits:
      cpu: 500m
      memory: 2Gi
```
  tekton-pruner-webhook
```yaml
  resources:
    requests:
      cpu: 50m
      memory: 64Mi
    limits:
      cpu: 250m
      memory: 128Mi
```
  #### Rationale

  Benchmark data: Testing showed the pruner controller uses 846-1126 MB heap memory when tracking 26k-38k resident PipelineRuns in its informer cache. 

  ### Override Mechanism

  These defaults can be overridden via TektonConfig or TektonPruner CR:
```yaml
  apiVersion: operator.tekton.dev/v1alpha1
  kind: TektonConfig
  spec:
    pruner:
      options:
        deployments:
        - name: tekton-pruner-controller
          spec:
            template:
              spec:
                containers:
                - name: controller
                  resources:
                    limits:
                      memory: 4Gi  # Override default
```
  The transformer runs before the options transformer, so user-specified values take precedence.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Operator now applies default resource limits to tekton-pruner-controller (2Gi memory) and tekton-pruner-webhook (512Mi memory) based on benchmark data. CPU limits omitted to avoid throttling. Override via TektonConfig.spec.tektonpruner.options.deployments if needed.
```
