### PR TITLE
fix(openshift): handle missing TektonConfig during TLS resolution

### DIFF
--- a/pkg/reconciler/openshift/common/tlsprofile.go
+++ b/pkg/reconciler/openshift/common/tlsprofile.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -212,11 +213,18 @@ type TektonConfigLister interface {
 
 // ResolveCentralTLSToEnvVars checks whether central TLS config is enabled in TektonConfig,
 // fetches the raw profile from the shared APIServer lister, and converts it to env vars.
-// Returns (nil, nil) if central TLS is disabled or no TLS config is available.
+// Returns (nil, nil) if the TektonConfig is absent, central TLS is disabled, or no TLS
+// config is available. Other lister and profile errors are returned to the caller.
 func ResolveCentralTLSToEnvVars(ctx context.Context, lister TektonConfigLister) (*TLSEnvVars, error) {
 	tc, err := lister.Get(v1alpha1.ConfigResourceName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
+	}
+	if tc == nil {
+		return nil, nil
 	}
 
 	// nil means the field was not set → treat as true (default-on after SetDefaults).

--- a/pkg/reconciler/openshift/common/tlsprofile_test.go
+++ b/pkg/reconciler/openshift/common/tlsprofile_test.go
@@ -18,10 +18,12 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestConvertTLSVersionToEnvFormat(t *testing.T) {
@@ -136,10 +138,36 @@ func (f *fakeTektonConfigLister) Get(_ string) (*v1alpha1.TektonConfig, error) {
 }
 
 func TestResolveCentralTLSToEnvVars_TektonConfigNotFound(t *testing.T) {
-	lister := &fakeTektonConfigLister{err: fmt.Errorf("tektonconfigs.operator.tekton.dev \"config\" not found")}
+	lister := &fakeTektonConfigLister{err: apierrors.NewNotFound(
+		schema.GroupResource{Group: "operator.tekton.dev", Resource: "tektonconfigs"},
+		v1alpha1.ConfigResourceName,
+	)}
 	result, err := ResolveCentralTLSToEnvVars(context.Background(), lister)
-	if err == nil {
-		t.Error("Expected error when TektonConfig not found, got nil")
+	if err != nil {
+		t.Errorf("Unexpected error when TektonConfig is absent: %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil result, got %v", result)
+	}
+}
+
+func TestResolveCentralTLSToEnvVars_NilTektonConfig(t *testing.T) {
+	lister := &fakeTektonConfigLister{}
+	result, err := ResolveCentralTLSToEnvVars(context.Background(), lister)
+	if err != nil {
+		t.Errorf("Unexpected error when TektonConfig is nil: %v", err)
+	}
+	if result != nil {
+		t.Errorf("Expected nil result, got %v", result)
+	}
+}
+
+func TestResolveCentralTLSToEnvVars_ListerError(t *testing.T) {
+	wantErr := errors.New("lister unavailable")
+	lister := &fakeTektonConfigLister{err: wantErr}
+	result, err := ResolveCentralTLSToEnvVars(context.Background(), lister)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Expected lister error %v, got %v", wantErr, err)
 	}
 	if result != nil {
 		t.Errorf("Expected nil result, got %v", result)


### PR DESCRIPTION
# Changes

Make OpenShift component TLS configuration resolution safe when the optional TektonConfig object is absent. A Kubernetes API NotFound result or a nil lister object now produces no TLS environment variables and no retry-triggering error; other lister errors continue to propagate.

# Submitter Checklist

- [x] Includes focused regression tests
- [x] Updated nearby behavior documentation
- [x] No API or dependency changes

# Validation

- `gofmt -d pkg/reconciler/openshift/common/tlsprofile.go pkg/reconciler/openshift/common/tlsprofile_test.go && git diff --check`
- `go test ./pkg/reconciler/openshift/common`
- `go test -race ./pkg/reconciler/openshift/common`

```release-note
NONE
```

Validation observed for this change:
- `gofmt -d pkg/reconciler/openshift/common/tlsprofile.go pkg/reconciler/openshift/common/tlsprofile_test.go && git diff --check`
- `go test ./pkg/reconciler/openshift/common`
- `go test -race ./pkg/reconciler/openshift/common`

<!-- repo-agent-case:0a318cdc-4d09-4158-8497-e9d870fd0a0b -->