### PR TITLE
Enable results completely in case of Hub mode

### DIFF
--- a/pkg/reconciler/shared/tektonconfig/result/result.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result.go
@@ -24,12 +24,9 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/logging"
 )
 
 // This Ensure TektonResult CR is exist or not
@@ -191,15 +188,6 @@ func UpdateResult(ctx context.Context, old *v1alpha1.TektonResult, new *v1alpha1
 func GetTektonResultCR(config *v1alpha1.TektonConfig, operatorVersion string) *v1alpha1.TektonResult {
 	ownerRef := *metav1.NewControllerRef(config, config.GroupVersionKind())
 
-	result := config.Spec.Result
-
-	// For Hub clusters (multicluster enabled AND role is Hub), set replicas to 0
-	// for watcher and retention-policy-agent deployments
-	if !config.Spec.Kueue.MultiClusterDisabled &&
-		strings.EqualFold(string(config.Spec.Kueue.MultiClusterRole), string(v1alpha1.MultiClusterRoleHub)) {
-		result = disableWatcherAndRetentionAgentOnHubCluster(result)
-	}
-
 	return &v1alpha1.TektonResult{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            v1alpha1.ResultResourceName,
@@ -212,42 +200,9 @@ func GetTektonResultCR(config *v1alpha1.TektonConfig, operatorVersion string) *v
 			CommonSpec: v1alpha1.CommonSpec{
 				TargetNamespace: config.Spec.TargetNamespace,
 			},
-			Result:        result,
+			Result:        config.Spec.Result,
 			Config:        config.Spec.Config,
 			NetworkPolicy: config.Spec.NetworkPolicy,
 		},
 	}
-}
-
-// disableWatcherAndRetentionAgentOnHubCluster modifies the Result options to set replicas to 0
-// for watcher and retention-policy-agent deployments on Hub clusters.
-//
-// This function injects deployment overrides into Options.Deployments. These overrides are applied
-// during reconciliation and will force the specified deployments to use 0 replicas, regardless of
-// the default values from the release manifests.
-//
-// Note: Even if the Deployments map is empty or nil, we create new entries with zero-value Deployment
-// structs that only have Spec.Replicas set. This is intentional - accessing a non-existent map key
-// returns a zero-value struct, which we then modify and insert as an override.
-func disableWatcherAndRetentionAgentOnHubCluster(result v1alpha1.Result) v1alpha1.Result {
-	logging.FromContext(context.Background()).Debug("Disabling watcher and retention-policy-agent for Hub cluster")
-
-	// Initialize the Deployments map if nil
-	if result.Options.Deployments == nil {
-		result.Options.Deployments = make(map[string]appsv1.Deployment)
-	}
-
-	zeroReplicas := ptr.To(int32(0))
-
-	// Set watcher replicas to 0
-	watcherDeployment := result.Options.Deployments["tekton-results-watcher"]
-	watcherDeployment.Spec.Replicas = zeroReplicas
-	result.Options.Deployments["tekton-results-watcher"] = watcherDeployment
-
-	// Set retention-policy-agent replicas to 0
-	retentionDeployment := result.Options.Deployments["tekton-results-retention-policy-agent"]
-	retentionDeployment.Spec.Replicas = zeroReplicas
-	result.Options.Deployments["tekton-results-retention-policy-agent"] = retentionDeployment
-
-	return result
 }

--- a/pkg/reconciler/shared/tektonconfig/result/result_test.go
+++ b/pkg/reconciler/shared/tektonconfig/result/result_test.go
@@ -24,7 +24,6 @@ import (
 	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
@@ -142,48 +141,26 @@ func getTektonConfig() *v1alpha1.TektonConfig {
 	}
 }
 
-func TestGetTektonResultCR_HubClusterConfig(t *testing.T) {
+func TestGetTektonResultCR_CompleteInstallBothRoles(t *testing.T) {
 	tests := []struct {
-		name                       string
-		multiClusterDisabled       bool
-		multiClusterRole           v1alpha1.MultiClusterRole
-		expectZeroReplicaWatcher   bool
-		expectZeroReplicaRetention bool
+		name                 string
+		multiClusterDisabled bool
+		multiClusterRole     v1alpha1.MultiClusterRole
 	}{
 		{
-			name:                       "multicluster enabled with Hub role - should set zero replicas",
-			multiClusterDisabled:       false,
-			multiClusterRole:           v1alpha1.MultiClusterRoleHub,
-			expectZeroReplicaWatcher:   true,
-			expectZeroReplicaRetention: true,
+			name:                 "multicluster enabled with Hub role - complete install",
+			multiClusterDisabled: false,
+			multiClusterRole:     v1alpha1.MultiClusterRoleHub,
 		},
 		{
-			name:                       "multicluster enabled with Spoke role - should NOT set zero replicas",
-			multiClusterDisabled:       false,
-			multiClusterRole:           v1alpha1.MultiClusterRoleSpoke,
-			expectZeroReplicaWatcher:   false,
-			expectZeroReplicaRetention: false,
+			name:                 "multicluster enabled with Spoke role - complete install",
+			multiClusterDisabled: false,
+			multiClusterRole:     v1alpha1.MultiClusterRoleSpoke,
 		},
 		{
-			name:                       "multicluster disabled with Hub role - should NOT set zero replicas",
-			multiClusterDisabled:       true,
-			multiClusterRole:           v1alpha1.MultiClusterRoleHub,
-			expectZeroReplicaWatcher:   false,
-			expectZeroReplicaRetention: false,
-		},
-		{
-			name:                       "multicluster disabled with Spoke role - should NOT set zero replicas",
-			multiClusterDisabled:       true,
-			multiClusterRole:           v1alpha1.MultiClusterRoleSpoke,
-			expectZeroReplicaWatcher:   false,
-			expectZeroReplicaRetention: false,
-		},
-		{
-			name:                       "multicluster disabled with empty role - should NOT set zero replicas",
-			multiClusterDisabled:       true,
-			multiClusterRole:           "",
-			expectZeroReplicaWatcher:   false,
-			expectZeroReplicaRetention: false,
+			name:                 "multicluster disabled - complete install",
+			multiClusterDisabled: true,
+			multiClusterRole:     "",
 		},
 	}
 
@@ -209,31 +186,15 @@ func TestGetTektonResultCR_HubClusterConfig(t *testing.T) {
 
 			result := GetTektonResultCR(config, "v0.70.0")
 
-			// Check watcher deployment replicas
-			watcherDeployment, watcherExists := result.Spec.Options.Deployments["tekton-results-watcher"]
-			if tt.expectZeroReplicaWatcher {
-				if !watcherExists {
-					t.Error("expected watcher deployment to exist in Options.Deployments")
-				} else if watcherDeployment.Spec.Replicas == nil || *watcherDeployment.Spec.Replicas != 0 {
-					t.Errorf("expected watcher replicas to be 0, got %v", watcherDeployment.Spec.Replicas)
-				}
-			} else {
-				if watcherExists && watcherDeployment.Spec.Replicas != nil && *watcherDeployment.Spec.Replicas == 0 {
-					t.Error("did not expect watcher replicas to be set to 0")
+			// Complete install: no forced zero replicas for watcher or retention-policy-agent
+			if watcherDeployment, exists := result.Spec.Options.Deployments["tekton-results-watcher"]; exists {
+				if watcherDeployment.Spec.Replicas != nil && *watcherDeployment.Spec.Replicas == 0 {
+					t.Error("did not expect watcher replicas to be forced to 0")
 				}
 			}
-
-			// Check retention-policy-agent deployment replicas
-			retentionDeployment, retentionExists := result.Spec.Options.Deployments["tekton-results-retention-policy-agent"]
-			if tt.expectZeroReplicaRetention {
-				if !retentionExists {
-					t.Error("expected retention-policy-agent deployment to exist in Options.Deployments")
-				} else if retentionDeployment.Spec.Replicas == nil || *retentionDeployment.Spec.Replicas != 0 {
-					t.Errorf("expected retention-policy-agent replicas to be 0, got %v", retentionDeployment.Spec.Replicas)
-				}
-			} else {
-				if retentionExists && retentionDeployment.Spec.Replicas != nil && *retentionDeployment.Spec.Replicas == 0 {
-					t.Error("did not expect retention-policy-agent replicas to be set to 0")
+			if retentionDeployment, exists := result.Spec.Options.Deployments["tekton-results-retention-policy-agent"]; exists {
+				if retentionDeployment.Spec.Replicas != nil && *retentionDeployment.Spec.Replicas == 0 {
+					t.Error("did not expect retention-policy-agent replicas to be forced to 0")
 				}
 			}
 		})
@@ -331,69 +292,4 @@ func TestGetTektonResultCR_ConfigPropagation(t *testing.T) {
 	if result.Spec.Config.PriorityClassName != "system-cluster-critical" {
 		t.Errorf("expected priorityClassName to be propagated from TektonConfig, got %q", result.Spec.Config.PriorityClassName)
 	}
-}
-
-func TestDisableWatcherAndRetentionAgentOnHubCluster(t *testing.T) {
-	t.Run("injects zero replicas for watcher and retention-policy-agent", func(t *testing.T) {
-		result := v1alpha1.Result{}
-		modifiedResult := disableWatcherAndRetentionAgentOnHubCluster(result)
-
-		// Verify Deployments map is initialized
-		if modifiedResult.Options.Deployments == nil {
-			t.Fatal("expected Deployments map to be initialized")
-		}
-
-		// Verify watcher deployment
-		watcherDeployment, exists := modifiedResult.Options.Deployments["tekton-results-watcher"]
-		if !exists {
-			t.Error("expected tekton-results-watcher deployment to exist")
-		}
-		if watcherDeployment.Spec.Replicas == nil || *watcherDeployment.Spec.Replicas != 0 {
-			t.Errorf("expected watcher replicas to be 0, got %v", watcherDeployment.Spec.Replicas)
-		}
-
-		// Verify retention-policy-agent deployment
-		retentionDeployment, exists := modifiedResult.Options.Deployments["tekton-results-retention-policy-agent"]
-		if !exists {
-			t.Error("expected tekton-results-retention-policy-agent deployment to exist")
-		}
-		if retentionDeployment.Spec.Replicas == nil || *retentionDeployment.Spec.Replicas != 0 {
-			t.Errorf("expected retention-policy-agent replicas to be 0, got %v", retentionDeployment.Spec.Replicas)
-		}
-	})
-
-	t.Run("preserves existing deployment configurations", func(t *testing.T) {
-		// Create a result with existing deployment config
-		existingReplicas := int32(3)
-		result := v1alpha1.Result{
-			Options: v1alpha1.AdditionalOptions{
-				Deployments: map[string]appsv1.Deployment{
-					"tekton-results-watcher": {
-						Spec: appsv1.DeploymentSpec{
-							Replicas: &existingReplicas,
-						},
-					},
-					"tekton-results-api": {
-						Spec: appsv1.DeploymentSpec{
-							Replicas: &existingReplicas,
-						},
-					},
-				},
-			},
-		}
-
-		modifiedResult := disableWatcherAndRetentionAgentOnHubCluster(result)
-
-		// Verify watcher replicas is now 0 (overwritten)
-		watcherDeployment := modifiedResult.Options.Deployments["tekton-results-watcher"]
-		if watcherDeployment.Spec.Replicas == nil || *watcherDeployment.Spec.Replicas != 0 {
-			t.Errorf("expected watcher replicas to be 0, got %v", watcherDeployment.Spec.Replicas)
-		}
-
-		// Verify api deployment is unchanged
-		apiDeployment := modifiedResult.Options.Deployments["tekton-results-api"]
-		if apiDeployment.Spec.Replicas == nil || *apiDeployment.Spec.Replicas != existingReplicas {
-			t.Errorf("expected api replicas to remain %d, got %v", existingReplicas, apiDeployment.Spec.Replicas)
-		}
-	})
 }

--- a/test/e2e/common/10_hubcluster_result_config_test.go
+++ b/test/e2e/common/10_hubcluster_result_config_test.go
@@ -32,12 +32,10 @@ import (
 	"github.com/tektoncd/operator/test/utils"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// HubClusterResultConfigTestSuite tests the hub cluster result configuration
-// When multicluster is enabled and role is Hub, the TektonResult CR should have
-// zero replicas for watcher and retention-policy-agent deployments
+// HubClusterResultConfigTestSuite tests that TektonResult is completely installed
+// on both Hub and Spoke clusters (watcher and retention-policy-agent running).
 type HubClusterResultConfigTestSuite struct {
 	resourceNames utils.ResourceNames
 	suite.Suite
@@ -88,7 +86,7 @@ func (s *HubClusterResultConfigTestSuite) TearDownTest() {
 }
 
 // Test01_HubClusterResultConfig tests that when multicluster is enabled with Hub role,
-// the TektonResult CR has zero replicas for watcher and retention-policy-agent
+// TektonResult is completely installed (watcher and retention-policy-agent running).
 func (s *HubClusterResultConfigTestSuite) Test01_HubClusterResultConfig() {
 	t := s.T()
 
@@ -121,14 +119,18 @@ func (s *HubClusterResultConfigTestSuite) Test01_HubClusterResultConfig() {
 	err = resources.WaitForTektonConfigReady(s.clients.TektonConfig(), s.resourceNames.TektonConfig, s.interval, s.timeout)
 	require.NoError(t, err, "TektonConfig failed to become ready")
 
-	// Verify TektonResult CR has zero replicas for watcher and retention-policy-agent
-	s.logger.Debug("verifying TektonResult CR has zero replicas for watcher and retention-policy-agent")
-	s.verifyResultDeploymentReplicas("tekton-results-watcher", 0)
-	s.verifyResultDeploymentReplicas("tekton-results-retention-policy-agent", 0)
+	// Verify TektonResult CR does NOT force zero replicas (complete install)
+	s.logger.Debug("verifying TektonResult CR has complete install on Hub role")
+	s.verifyResultDeploymentReplicasNotZero("tekton-results-watcher")
+	s.verifyResultDeploymentReplicasNotZero("tekton-results-retention-policy-agent")
+
+	// Verify watcher and retention-policy-agent deployments are actually running
+	s.logger.Debug("verifying watcher and retention-policy-agent deployments are available on Hub")
+	s.verifyDeploymentsAvailable()
 }
 
 // Test02_SpokeClusterResultConfig tests that when multicluster is enabled with Spoke role,
-// the TektonResult CR does NOT have zero replicas forced for watcher and retention-policy-agent
+// the TektonResult CR is completely installed.
 func (s *HubClusterResultConfigTestSuite) Test02_SpokeClusterResultConfig() {
 	t := s.T()
 
@@ -161,15 +163,18 @@ func (s *HubClusterResultConfigTestSuite) Test02_SpokeClusterResultConfig() {
 	err = resources.WaitForTektonConfigReady(s.clients.TektonConfig(), s.resourceNames.TektonConfig, s.interval, s.timeout)
 	require.NoError(t, err, "TektonConfig failed to become ready")
 
-	// Verify TektonResult CR does NOT have zero replicas forced
-	// (replicas should be default or user-specified, not 0)
-	s.logger.Debug("verifying TektonResult CR does not have forced zero replicas for Spoke role")
+	// Verify TektonResult CR is completely installed
+	s.logger.Debug("verifying TektonResult CR has complete install on Spoke role")
 	s.verifyResultDeploymentReplicasNotZero("tekton-results-watcher")
 	s.verifyResultDeploymentReplicasNotZero("tekton-results-retention-policy-agent")
+
+	// Verify watcher and retention-policy-agent deployments are actually running
+	s.logger.Debug("verifying watcher and retention-policy-agent deployments are available on Spoke")
+	s.verifyDeploymentsAvailable()
 }
 
 // Test03_MultiClusterDisabled tests that when multicluster is disabled,
-// the TektonResult CR does NOT have zero replicas forced
+// the TektonResult CR is completely installed.
 func (s *HubClusterResultConfigTestSuite) Test03_MultiClusterDisabled() {
 	t := s.T()
 
@@ -202,8 +207,8 @@ func (s *HubClusterResultConfigTestSuite) Test03_MultiClusterDisabled() {
 	err = resources.WaitForTektonConfigReady(s.clients.TektonConfig(), s.resourceNames.TektonConfig, s.interval, s.timeout)
 	require.NoError(t, err, "TektonConfig failed to become ready")
 
-	// Verify TektonResult CR does NOT have zero replicas forced
-	s.logger.Debug("verifying TektonResult CR does not have forced zero replicas when multicluster is disabled")
+	// Verify TektonResult CR is completely installed
+	s.logger.Debug("verifying TektonResult CR has complete install when multicluster is disabled")
 	s.verifyResultDeploymentReplicasNotZero("tekton-results-watcher")
 	s.verifyResultDeploymentReplicasNotZero("tekton-results-retention-policy-agent")
 }
@@ -234,41 +239,6 @@ func (s *HubClusterResultConfigTestSuite) resetMultiClusterConfig() {
 	}
 }
 
-func (s *HubClusterResultConfigTestSuite) verifyResultDeploymentReplicas(deploymentName string, expectedReplicas int32) {
-	t := s.T()
-
-	// Wait for TektonResult CR to be updated with the expected replicas
-	err := wait.PollUntilContextTimeout(context.TODO(), s.interval, s.timeout, true, func(ctx context.Context) (bool, error) {
-		result, err := s.clients.TektonResult().Get(context.TODO(), v1alpha1.ResultResourceName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-
-		deployment, exists := result.Spec.Options.Deployments[deploymentName]
-		if !exists {
-			s.logger.Debugw("deployment not found in TektonResult CR", "deployment", deploymentName)
-			return false, nil
-		}
-
-		if deployment.Spec.Replicas == nil {
-			s.logger.Debugw("deployment replicas not set", "deployment", deploymentName)
-			return false, nil
-		}
-
-		if *deployment.Spec.Replicas == expectedReplicas {
-			return true, nil
-		}
-
-		s.logger.Debugw("waiting for deployment replicas to be updated",
-			"deployment", deploymentName,
-			"expected", expectedReplicas,
-			"actual", *deployment.Spec.Replicas)
-		return false, nil
-	})
-
-	require.NoError(t, err, "TektonResult CR %s deployment replicas did not reach expected value %d", deploymentName, expectedReplicas)
-}
-
 func (s *HubClusterResultConfigTestSuite) verifyResultDeploymentReplicasNotZero(deploymentName string) {
 	t := s.T()
 
@@ -285,5 +255,14 @@ func (s *HubClusterResultConfigTestSuite) verifyResultDeploymentReplicasNotZero(
 
 	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
 		t.Errorf("expected %s deployment replicas to NOT be forced to 0, but it was", deploymentName)
+	}
+}
+
+func (s *HubClusterResultConfigTestSuite) verifyDeploymentsAvailable() {
+	t := s.T()
+
+	for _, deploymentName := range []string{"tekton-results-watcher", "tekton-results-retention-policy-agent"} {
+		err := resources.WaitForDeploymentAvailable(s.clients.KubeClient, deploymentName, s.resourceNames.TargetNamespace, s.interval, s.timeout)
+		require.NoError(t, err, "deployment %s did not become available (complete install expected)", deploymentName)
 	}
 }


### PR DESCRIPTION
This enables the results completely in case of Hub Mode by deploying watcher and retention policy agent.

Assisted by AI

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

-->

```release-note
Tekton results watcher and retention policy agent is now deployed in multicluster hub - mode. 
```
