### PR TITLE
fix(release): apply project-specific OCI labels to images for Operator

### DIFF
--- a/tekton/build-publish-images-manifests.yaml
+++ b/tekton/build-publish-images-manifests.yaml
@@ -169,6 +169,9 @@ spec:
       kustomize build ${PROJECT_ROOT}/config/${KUBE_DISTRO}/overlays/default | \
         ko resolve \
           --image-label=org.opencontainers.image.source=https://$(params.package) \
+            --image-label=org.opencontainers.image.url=https://$(params.package) \
+            --image-label=org.opencontainers.image.title=operator \
+            --image-label=org.opencontainers.image.description=Tekton\ Operator \
           --platform=$(params.platforms) ${KO_EXTRA_ARGS} \
           -t $(params.versionTag) \
           -f - > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.yaml
@@ -179,6 +182,9 @@ spec:
       kustomize build ${PROJECT_ROOT}/config/${KUBE_DISTRO}/overlays/default | \
         ko resolve \
           --image-label=org.opencontainers.image.source=https://$(params.package) \
+            --image-label=org.opencontainers.image.url=https://$(params.package) \
+            --image-label=org.opencontainers.image.title=operator \
+            --image-label=org.opencontainers.image.description=Tekton\ Operator \
           --platform=$(params.platforms) ${KO_EXTRA_ARGS} \
           -f - > $OUTPUT_RELEASE_DIR/${FILENAME_PREFIX}release.notags.yaml
 


### PR DESCRIPTION
# Changes

Fixes tektoncd/plumbing#3435

This updates the `tekton/build-publish-images-manifests.yaml` task to explicitly pass project-specific OCI image labels (`url`, `title`, and `description`) to the `ko resolve` commands. This prevents the published Operator images from incorrectly inheriting OCI metadata from their base images.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
NONE
```
